### PR TITLE
fix(observability): sample rollup misses per reason per interval, not 1-in-512

### DIFF
--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -3680,7 +3680,7 @@ impl Database {
         // Sampled on the same limiter as `rollup_miss_sampled`, so a
         // multiple-per-second miss rate cannot flood the log.
         if let Some(project) = &first_uncovered
-            && crate::observability::sample_rollup_miss()
+            && crate::observability::sample_rollup_miss(crate::rollup::MissReason::IncompleteCoverage)
         {
             warn!(
                 project_id = %project,
@@ -3704,7 +3704,7 @@ impl Database {
             // it away, or that what survives is narrower than one grain. Those
             // want opposite fixes — build more coverage vs flush sooner vs widen
             // the window — and nothing outside the process can tell them apart.
-            if crate::observability::sample_rollup_miss() {
+            if crate::observability::sample_rollup_miss(crate::rollup::MissReason::TinyInterior) {
                 warn!(
                     lo = route.lo,
                     hi = route.hi,

--- a/src/dml.rs
+++ b/src/dml.rs
@@ -265,7 +265,7 @@ impl QueryPlanner for DmlQueryPlanner {
                 // queries — the two need opposite fixes. Sampled so a
                 // multiple-per-second rate cannot flood the log, and the plan is
                 // only rendered when a sample is actually taken.
-                if crate::observability::sample_rollup_miss() {
+                if crate::observability::sample_rollup_miss(reason) {
                     warn!(
                         reason = reason.label(),
                         plan = %fmt_capped(&logical_plan.display_indent().to_string(), 1200),

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -659,13 +659,29 @@ pub fn record_rollup_hit(mode: &'static str, grain: &str) {
 /// arm, so `missing_project`, `unbounded_time`, `non_decomposable` and
 /// `rewrite_schema_mismatch` were indistinguishable in prod — 29 misses that
 /// could not be diagnosed without a deploy.
-/// True once every `ROLLUP_MISS_SAMPLE` misses, for logging one refused plan
-/// with context. Misses run at several per second on a busy node, so the
-/// counter is what you alert on and this is what you diagnose with.
-pub fn sample_rollup_miss() -> bool {
-    const ROLLUP_MISS_SAMPLE: u64 = 512;
-    static SEEN: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
-    SEEN.fetch_add(1, std::sync::atomic::Ordering::Relaxed).is_multiple_of(ROLLUP_MISS_SAMPLE)
+/// True at most once per REASON per `SAMPLE_INTERVAL_SECS`, for logging one
+/// refused plan with context. The counter is what you alert on; this is what you
+/// diagnose with.
+///
+/// Was a fixed 1-in-512 ratio. That was right for the regime it was written in —
+/// the call site records ~2.7 misses/second, where 1:512 yields ~19 samples/hour
+/// — but a FIXED RATIO GOES SILENT EXACTLY WHEN THE DIAGNOSTIC BECOMES USEFUL.
+/// Prod 2026-08-21 ran ~170 misses/hour, so 1:512 fired about once every three
+/// hours and a 30-minute window contained nothing at all. The surviving misses
+/// at a low rate are the interesting ones, and the sampler was hiding them.
+///
+/// Per-reason, because the actionable reason is usually not the common one: that
+/// window was 27% `unknown_filter` (a gap in the matcher) against 37%
+/// `filter_not_eligible` (a correct refusal), and a global sampler spends its
+/// budget on whichever is loudest.
+pub fn sample_rollup_miss(reason: crate::rollup::MissReason) -> bool {
+    use std::sync::atomic::{AtomicI64, Ordering};
+    const SAMPLE_INTERVAL_SECS: i64 = 60;
+    static LAST: [AtomicI64; crate::rollup::MissReason::COUNT] = [const { AtomicI64::new(i64::MIN) }; crate::rollup::MissReason::COUNT];
+    let now = crate::support::now_micros() / 1_000_000;
+    let slot = &LAST[reason as usize];
+    let last = slot.load(Ordering::Relaxed);
+    now.saturating_sub(last) >= SAMPLE_INTERVAL_SECS && slot.compare_exchange(last, now, Ordering::Relaxed, Ordering::Relaxed).is_ok()
 }
 
 pub fn record_rollup_miss(reason: crate::rollup::MissReason) {
@@ -1219,6 +1235,23 @@ pub fn capped_preview_fn(batch: &arrow::record_batch::RecordBatch) -> Result<Str
         out.push('\n');
     }
     Ok(out)
+}
+
+#[cfg(test)]
+mod sampler_tests {
+    use crate::rollup::MissReason;
+
+    /// A fixed 1-in-512 ratio went silent at low miss rates: prod 2026-08-21 ran
+    /// ~170 misses/hour, so it fired once per ~3h and a 30-minute diagnostic
+    /// window contained nothing. Every reason must yield a sample promptly, and
+    /// a loud reason must not consume another reason's budget.
+    #[test]
+    fn every_reason_samples_once_then_rate_limits_independently() {
+        for reason in MissReason::ALL {
+            assert!(super::sample_rollup_miss(reason), "{} never sampled", reason.label());
+            assert!(!super::sample_rollup_miss(reason), "{} sampled twice inside the interval", reason.label());
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/rollup.rs
+++ b/src/rollup.rs
@@ -39,6 +39,32 @@ pub enum MissReason {
 }
 
 impl MissReason {
+    /// Number of variants, for fixed-size per-reason arrays (see
+    /// `sample_rollup_miss`). `ALL` is declared `[Self; Self::COUNT]`, so adding
+    /// a variant without updating this fails the BUILD rather than silently
+    /// indexing out of range.
+    pub const COUNT: usize = 15;
+
+    /// Every variant. Exists so `COUNT` cannot drift, and so tests can sweep
+    /// reasons exhaustively.
+    pub const ALL: [Self; Self::COUNT] = [
+        Self::UnsupportedShape,
+        Self::MissingProject,
+        Self::UnboundedTime,
+        Self::UnknownGroupBy,
+        Self::UnknownFilter,
+        Self::FilterNotEligible,
+        Self::MissingMeasure,
+        Self::NonDecomposableAggregate,
+        Self::PartialBucket,
+        Self::NotBuilt,
+        Self::StaleCoverage,
+        Self::IncompleteCoverage,
+        Self::TinyInterior,
+        Self::TooManyBranches,
+        Self::RewriteSchemaMismatch,
+    ];
+
     pub const fn label(self) -> &'static str {
         match self {
             Self::UnsupportedShape => "unsupported_shape",


### PR DESCRIPTION
## The problem

`rollup_miss_sampled` renders the refused plan and is the tool that previously turned a "97% missing_project" mystery into a one-line fix. **It currently logs nothing.**

```rust
const ROLLUP_MISS_SAMPLE: u64 = 512;   // 1 in 512 misses
```

That constant was right for the regime it was written in — the call site records **~2.7 misses/second** (~9,700/hour), where 1:512 yields ~19 samples/hour. Prod on 2026-08-21 ran **~170 misses/hour**, so it fires about **once every three hours**, and a 30-minute diagnostic window contained zero events.

**A fixed sampling ratio goes silent exactly when the diagnostic becomes most useful.** While misses are a flood, 1:512 is right. Once they are a trickle, the survivors are the interesting ones — and the sampler hides them.

## Why per-reason and not just a smaller constant

The actionable reason is usually not the loudest one. The window that prompted this:

```
filter_not_eligible  38   (37%)  ← a correct refusal
unknown_filter       28   (27%)  ← a GAP IN THE MATCHER, the addressable category
not_built            24   (23%)
tiny_interior        12   (12%)  ← a correct refusal
```

A global sampler spends its budget on whichever reason dominates. Lowering the constant fixes today's rate and breaks again at the next traffic level.

## The change

- `sample_rollup_miss(reason)` — at most one sample **per `MissReason` per 60s**. Rate-based, so it cannot go quiet as traffic falls; per-reason, so a loud refusal cannot crowd out a rare actionable one.
- `MissReason::ALL` is declared `[Self; Self::COUNT]`, so adding a variant **fails the build** rather than silently indexing out of range — a compile-time guarantee rather than a test that can rot.
- Three call sites updated. The two diagnostic sites in `database/mod.rs` that borrow this limiter now pass the semantically closest reason (`IncompleteCoverage`, `TinyInterior`).

## Verification

- new test sweeps `MissReason::ALL`: every reason samples once, then rate-limits
- **verified the test FAILS against the old ratio sampler** — it is load-bearing, not decorative
- 82 rollup lib tests pass; `cargo lint` clean (only pre-existing vendored `walrus-rust` warnings); `cargo fmt` applied

## Note on scope

Deliberately small and observability-only — it changes no query or maintenance behaviour. Context for why this matters now is in #206: routing hit rate reads ~7% at some hours versus 91.5% at others, and **this sampler is the blocker on diagnosing which**, because it is the only thing that renders the plan that was refused.