### PR TITLE
fix(tantivy): announce backfill start and tick progress

### DIFF
--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -3412,7 +3412,19 @@ impl Database {
                 queues.push((pid, queue));
             }
             let table_owned = table_name.to_string();
-            let mut jobs = futures::stream::iter(fair_tantivy_backfill_work(queues).into_iter().map(|(pid, rel, uri)| {
+            let work = fair_tantivy_backfill_work(queues);
+            // A pass is UNBOUNDED — `fair_tantivy_backfill_work` queues every
+            // uncovered file — so it runs for hours on a real backlog while the
+            // completion event (`tantivy_backfill_pass`) prints only at the end.
+            // Prod 2026-08-21: a pass started 03:30 was still running at 06:20
+            // having emitted nothing since its GC lines, and an in-flight pass
+            // was indistinguishable from one that never fired. Announce the
+            // start and tick progress so "running" is observable.
+            let planned = work.len();
+            info!(table_name, root = %root, planned, event = "tantivy_backfill_started");
+            const PROGRESS_EVERY: usize = 200;
+            let mut done = 0usize;
+            let mut jobs = futures::stream::iter(work.into_iter().map(|(pid, rel, uri)| {
                 let (svc, store, table) = (svc.clone(), delta_store.clone(), table_owned.clone());
                 async move { (pid.clone(), svc.build_index_for_file(&table, &pid, &rel, &uri, store).await) }
             }))
@@ -3421,6 +3433,10 @@ impl Database {
                 match result {
                     Ok(()) => built += 1,
                     Err(e) => warn!("tantivy backfill build failed table={} project={}: {}", table_name, pid, e),
+                }
+                done += 1;
+                if done.is_multiple_of(PROGRESS_EVERY) {
+                    info!(table_name, root = %root, done, planned, built, event = "tantivy_backfill_progress");
                 }
             }
         }


### PR DESCRIPTION
## The problem

A tantivy backfill pass is **unbounded** — `fair_tantivy_backfill_work` queues *every* uncovered file — so on a real backlog it runs for hours. The only completion signal, `tantivy_backfill_pass`, prints at the very end.

Observed in prod 2026-08-21:

```
03:30:33  "tantivy reconcile gc: table=…"   (the cron fired)
06:20     still running — no completion, no failure, no progress
          tantivy_uncovered_files: 4,905 → 4,891 → 4,905 → 4,928
```

**For ~3 hours, a running pass was indistinguishable from one that never fired.** I concluded twice that the reconcile "did not run" before finding the GC lines that proved it had — the ambiguity is not theoretical, it is how long it takes to reach the wrong answer.

## The change

Two log points, observability only, no behaviour change:

- **`tantivy_backfill_started`** — `planned` (files queued), emitted before work begins
- **`tantivy_backfill_progress`** — every 200 files, with `done` / `planned` / `built`

17 lines added.

## Why this matters beyond diagnosis

The backlog is not converging: it drifted 3,031 → 4,928 over the period observed, and stayed **flat while a pass was actively running** — i.e. the reconcile roughly matches the arrival rate rather than draining. Deciding between the available fixes (run continuously instead of nightly, raise `timefusion_tantivy_build_concurrency`, checkpoint progress across restarts) requires knowing how far a pass gets before it is truncated by a restart. **Right now that is unmeasurable**, because a truncated pass logs nothing at all.

This PR does not fix the convergence problem. It makes the problem measurable, which is the precondition for choosing among those three.

## Verification

- `cargo lint` clean, `cargo fmt` applied
- 24 tantivy lib tests pass

Context in #206.