### PR TITLE
feat(query): split a wide aggregate window so dedup runs in parallel

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -2593,6 +2593,19 @@ pub struct MaintenanceConfig {
     /// queries scan the whole window.
     #[serde_inline_default(true)]
     pub timefusion_read_dedup_bounded: bool,
+    /// Branches a wide AGGREGATE window is split into, so each range's
+    /// `DedupExec` runs on its own thread. `0`/`1` disables the split.
+    ///
+    /// `DedupExec` is `SinglePartition`, so one query gets one core: prod
+    /// 2026-09-04 measured 2.1 M rows/s on a 14 d window (24.6 s) and could not
+    /// finish 30 d inside the 60 s statement timeout — while the same 30 days
+    /// as two CONCURRENT 15 d queries took 19.98 s. Splitting is exact because
+    /// `timestamp` leads the dedup key, so no row's versions can straddle a
+    /// boundary. Applies only under an aggregate; a `ORDER BY … LIMIT` keeps its
+    /// streaming TopK. Each branch re-opens the files its range touches, so
+    /// raising this trades file opens for parallelism.
+    #[serde_inline_default(4)]
+    pub timefusion_query_range_split_branches: usize,
     /// Answer gate-eligible `SELECT COUNT(*) ... WHERE project_id AND
     /// timestamp range` from Delta add-action stats (zero parquet IO). Only
     /// fires when the window is fully flushed, dedup-provably-clean, and

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -5462,6 +5462,10 @@ impl Database {
             // Appended after DataFusion's defaults so push_down_limit has
             // already folded LIMIT into Sort.fetch — see the rule's docs.
             .with_optimizer_rule(Arc::new(crate::read::optimizers::DeferExpensiveProjection))
+            // After the defaults so predicate pushdown has already placed the
+            // timestamp bounds this reads, and before the Variant restore below
+            // so the branches it clones are re-typed like any other scan.
+            .with_optimizer_rule(Arc::new(crate::read::optimizers::RangeParallelDedup))
             // Must run LAST: re-restores Variant scan types that
             // optimize_projections reverts to Utf8View when it rebuilds each
             // TableScan from the lying provider schema — see the rule's docs

--- a/src/read/optimizers.rs
+++ b/src/read/optimizers.rs
@@ -3380,3 +3380,318 @@ mod dedup_needs_ordered_input_tests {
         assert!(child_name(&out).contains("SortPreservingMergeExec"));
     }
 }
+
+// ===== range_parallel_dedup =====
+
+use datafusion::logical_expr::{Filter, SubqueryAlias, utils::split_conjunction};
+
+/// Branches a wide aggregate window is split into. `<2` disables the rule.
+static RANGE_SPLIT_BRANCHES: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+
+pub fn range_split_branches() -> usize {
+    *RANGE_SPLIT_BRANCHES.get_or_init(|| 4)
+}
+
+/// Set the range-split branch count. No-op after the first call (OnceLock).
+pub fn set_range_split_branches(branches: usize) {
+    let _ = RANGE_SPLIT_BRANCHES.set(branches);
+}
+
+/// Below this span one thread is comfortably inside the statement timeout, so
+/// splitting only adds planning work and re-opens files. Prod 2026-09-04:
+/// 14 d = 14.0 s, 30 d did not finish inside 60 s.
+const MIN_SPLIT_SPAN_MICROS: i64 = 8 * 24 * 3_600 * 1_000_000;
+
+/// `DedupExec` declares `Distribution::SinglePartition`, so every row of a window
+/// funnels through ONE thread beneath the `SortPreservingMerge`. Prod 2026-09-04,
+/// whale project: 14 d = 51.6 M rows in 24.6 s (2.1 M rows/s — a single-core
+/// rate), and 30 d could not finish inside the 60 s statement timeout, while the
+/// SAME 30 days issued as two 15 d queries CONCURRENTLY finished in **19.98 s**.
+/// The work fits the box; one query cannot use more than one core.
+///
+/// So split the window: N disjoint timestamp ranges, each with its own scan and
+/// its own `DedupExec`, unioned under the original aggregate.
+///
+/// **Why this is exact.** `timestamp` is the LEADING dedup key, so two versions of
+/// a row always carry the same timestamp and can never land either side of a
+/// boundary. Verified on prod before this was written: 6-hour slices of a day sum
+/// exactly to that day's count, and two 15 d halves sum exactly to the 30 d count.
+///
+/// **Why RANGE and not HASH.** Hashing the dedup key also keeps versions together,
+/// but it destroys the input ordering, forcing `DedupExec` into its unbounded
+/// `full-set` mode — total seen-set memory merely moves rather than shrinking,
+/// which is the `dedup exceeded its 2048 MiB per-query limit` failure. A range
+/// split keeps every branch ordered, so bounded dedup and its small seen-set
+/// survive.
+///
+/// **Why only under an aggregate.** A union of ranges advertises no ordering, so
+/// applying this beneath `ORDER BY timestamp DESC LIMIT n` would trade a streaming
+/// TopK for a blocking sort. Aggregates require no input ordering — and they are
+/// exactly the shape that was timing out.
+#[derive(Debug, Default)]
+pub struct RangeParallelDedup;
+
+impl OptimizerRule for RangeParallelDedup {
+    fn name(&self) -> &str {
+        "range_parallel_dedup"
+    }
+
+    fn apply_order(&self) -> Option<ApplyOrder> {
+        Some(ApplyOrder::TopDown)
+    }
+
+    fn rewrite(&self, plan: LogicalPlan, _config: &dyn OptimizerConfig) -> Result<Transformed<LogicalPlan>> {
+        let branches = range_split_branches();
+        let LogicalPlan::Aggregate(aggregate) = &plan else {
+            return Ok(Transformed::no(plan));
+        };
+        // A Union input is this rule's own output. The optimizer runs to a
+        // fixpoint, and re-splitting each branch would fan out geometrically.
+        if branches < 2 || matches!(aggregate.input.as_ref(), LogicalPlan::Union(_)) {
+            return Ok(Transformed::no(plan));
+        }
+        let Some((lo, hi)) = splittable_window(&aggregate.input) else {
+            return Ok(Transformed::no(plan));
+        };
+        if hi.saturating_sub(lo) < MIN_SPLIT_SPAN_MICROS {
+            return Ok(Transformed::no(plan));
+        }
+        let step = (hi - lo) / branches as i64;
+        let narrowed: Option<Vec<LogicalPlan>> = (0..branches)
+            .map(|i| {
+                // Half-open [lo, hi) per branch so a row on a boundary belongs to
+                // exactly one branch. The last branch takes `hi + 1` because the
+                // window `hi` is INCLUSIVE (`<=` folds into it upstream).
+                let branch_lo = lo + step * i as i64;
+                let branch_hi = if i + 1 == branches { hi.saturating_add(1) } else { lo + step * (i as i64 + 1) };
+                narrow_scan_window(&aggregate.input, branch_lo, branch_hi)
+            })
+            .collect();
+        let Some(narrowed) = narrowed else {
+            return Ok(Transformed::no(plan));
+        };
+        let union = narrowed[1..]
+            .iter()
+            .try_fold(LogicalPlanBuilder::new(narrowed[0].clone()), |builder, branch| builder.union(branch.clone()))?
+            .build()?;
+        // A UNION's output fields are UNQUALIFIED, so a parent expression like
+        // `t.id` stops resolving and the whole rule fails the query. Re-attach
+        // the scan's qualifier, and if that still does not reproduce the input's
+        // schema exactly, DECLINE — the replacement must be indistinguishable to
+        // every parent, or this is a rewrite that breaks queries rather than one
+        // that speeds them up.
+        let union = if union.schema() == aggregate.input.schema() {
+            union
+        } else {
+            let Some(qualifier) = scan_qualifier(&aggregate.input) else {
+                return Ok(Transformed::no(plan));
+            };
+            let aliased = LogicalPlanBuilder::new(union).alias(qualifier)?.build()?;
+            if aliased.schema() != aggregate.input.schema() {
+                return Ok(Transformed::no(plan));
+            }
+            aliased
+        };
+        Ok(Transformed::yes(LogicalPlan::Aggregate(datafusion::logical_expr::Aggregate::try_new(
+            Arc::new(union),
+            aggregate.group_expr.clone(),
+            aggregate.aggr_expr.clone(),
+        )?)))
+    }
+}
+
+/// The finite timestamp window of a subtree the split may pass through.
+///
+/// A WHITELIST, deliberately: the rewrite assumes "the rows of sub-range A" equals
+/// "the rows of the whole window restricted to A". A LIMIT, DISTINCT, JOIN, WINDOW
+/// or nested aggregate breaks that equality — `count(*)` over `(SELECT … LIMIT
+/// 100)` would become N x 100 rows. Only nodes that commute with a row filter are
+/// listed, so an unrecognised node declines rather than silently miscounting.
+fn splittable_window(plan: &LogicalPlan) -> Option<(i64, i64)> {
+    let mut predicates: Vec<Expr> = Vec::new();
+    let mut node = plan;
+    loop {
+        match node {
+            LogicalPlan::Filter(filter) => {
+                predicates.push(filter.predicate.clone());
+                node = &filter.input;
+            }
+            LogicalPlan::Projection(projection) => node = &projection.input,
+            LogicalPlan::SubqueryAlias(alias) => node = &alias.input,
+            LogicalPlan::TableScan(scan) => {
+                predicates.extend(scan.filters.iter().cloned());
+                let conjuncts: Vec<&Expr> = predicates.iter().flat_map(split_conjunction).collect();
+                return bounded_window(&conjuncts);
+            }
+            _ => return None,
+        }
+    }
+}
+
+/// Both bounds of `timestamp` across `conjuncts`, or `None` if either is open.
+/// An unbounded side has no finite span to divide, and splitting on a guessed
+/// bound would drop every row outside it.
+fn bounded_window(conjuncts: &[&Expr]) -> Option<(i64, i64)> {
+    fn literal_micros(expr: &Expr) -> Option<i64> {
+        match expr {
+            Expr::Literal(ScalarValue::TimestampMicrosecond(Some(ts), _), _) => Some(*ts),
+            Expr::Literal(ScalarValue::TimestampNanosecond(Some(ts), _), _) => Some(*ts / 1000),
+            Expr::Literal(ScalarValue::TimestampMillisecond(Some(ts), _), _) => Some(*ts * 1000),
+            Expr::Literal(ScalarValue::TimestampSecond(Some(ts), _), _) => Some(*ts * 1_000_000),
+            _ => None,
+        }
+    }
+    let (lo, hi) = conjuncts.iter().fold((None::<i64>, None::<i64>), |acc @ (lo, hi), conjunct| {
+        let Expr::BinaryExpr(BinaryExpr { left, op, right }) = conjunct else { return acc };
+        let (bound, op) = if is_col_through_cast(left, "timestamp") {
+            (literal_micros(right), *op)
+        } else if is_col_through_cast(right, "timestamp") {
+            (literal_micros(left), swap_comparison(*op))
+        } else {
+            return acc;
+        };
+        let Some(ts) = bound else { return acc };
+        match op {
+            Operator::Gt | Operator::GtEq => (Some(lo.map_or(ts, |l| l.max(ts))), hi),
+            Operator::Lt | Operator::LtEq => (lo, Some(hi.map_or(ts, |h| h.min(ts)))),
+            Operator::Eq => (Some(ts), Some(ts)),
+            _ => acc,
+        }
+    });
+    lo.zip(hi).filter(|(lo, hi)| lo < hi)
+}
+
+/// The scanned table's qualifier, used to restore the qualification a UNION drops.
+fn scan_qualifier(plan: &LogicalPlan) -> Option<datafusion::common::TableReference> {
+    match plan {
+        LogicalPlan::TableScan(scan) => Some(scan.table_name.clone()),
+        LogicalPlan::Filter(filter) => scan_qualifier(&filter.input),
+        LogicalPlan::Projection(projection) => scan_qualifier(&projection.input),
+        LogicalPlan::SubqueryAlias(alias) => scan_qualifier(&alias.input),
+        _ => None,
+    }
+}
+
+/// Rebuild `plan` with `[lo, hi)` pinned directly above its TableScan, so the
+/// branch prunes to its own files rather than filtering a full-window scan.
+fn narrow_scan_window(plan: &LogicalPlan, lo: i64, hi: i64) -> Option<LogicalPlan> {
+    match plan {
+        LogicalPlan::TableScan(scan) => {
+            // Take the timezone from the scanned column rather than assuming
+            // UTC: a literal in the wrong timezone (or the wrong TimeUnit) makes
+            // the comparison a no-op or, worse, silently shifts the boundary.
+            // A non-microsecond timestamp declines the whole rewrite.
+            let field = scan.projected_schema.field_with_unqualified_name("timestamp").ok()?;
+            let timezone = match field.data_type() {
+                arrow_schema::DataType::Timestamp(arrow_schema::TimeUnit::Microsecond, timezone) => timezone.clone(),
+                _ => return None,
+            };
+            let literal = |micros| Expr::Literal(ScalarValue::TimestampMicrosecond(Some(micros), timezone.clone()), None);
+            let timestamp = Expr::Column(Column::new(Some(scan.table_name.clone()), "timestamp"));
+            let window = timestamp.clone().gt_eq(literal(lo)).and(timestamp.lt(literal(hi)));
+            Filter::try_new(window, Arc::new(plan.clone())).ok().map(LogicalPlan::Filter)
+        }
+        LogicalPlan::Filter(filter) => Filter::try_new(filter.predicate.clone(), Arc::new(narrow_scan_window(&filter.input, lo, hi)?))
+            .ok()
+            .map(LogicalPlan::Filter),
+        LogicalPlan::Projection(projection) => Projection::try_new(projection.expr.clone(), Arc::new(narrow_scan_window(&projection.input, lo, hi)?))
+            .ok()
+            .map(LogicalPlan::Projection),
+        LogicalPlan::SubqueryAlias(alias) => SubqueryAlias::try_new(Arc::new(narrow_scan_window(&alias.input, lo, hi)?), alias.alias.clone())
+            .ok()
+            .map(LogicalPlan::SubqueryAlias),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod range_parallel_dedup_tests {
+    use datafusion::{
+        arrow::datatypes::{DataType, Field, Schema, TimeUnit},
+        datasource::MemTable,
+        execution::session_state::SessionStateBuilder,
+        prelude::SessionContext,
+    };
+
+    use super::*;
+
+    /// `timestamp` is `Timestamp(us, UTC)` exactly as `otel_logs_and_spans`
+    /// declares it — the rule reads the timezone off this field.
+    async fn optimized(sql: &str, with_rule: bool) -> String {
+        let builder = SessionStateBuilder::new().with_default_features();
+        let builder = if with_rule { builder.with_optimizer_rule(Arc::new(RangeParallelDedup)) } else { builder };
+        let ctx = SessionContext::new_with_state(builder.build());
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("timestamp", DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())), false),
+        ]));
+        ctx.register_table("t", Arc::new(MemTable::try_new(schema, vec![vec![]]).unwrap())).unwrap();
+        ctx.sql(sql).await.unwrap().into_optimized_plan().unwrap().display_indent().to_string()
+    }
+
+    const WIDE: &str = "timestamp >= '2026-08-05T00:00:00Z'::timestamp AND timestamp <= '2026-09-04T00:00:00Z'::timestamp";
+
+    /// THE fix: a 30-day aggregate becomes N independently-dedupable ranges.
+    /// Without it every row of the window funnels through one `DedupExec`
+    /// thread, which is why 30 d could not finish inside the statement timeout
+    /// while two concurrent 15 d halves took 19.98 s.
+    #[tokio::test]
+    async fn splits_a_wide_aggregate_window_into_branches() {
+        let plan = optimized(&format!("SELECT count(*) FROM t WHERE {WIDE}"), true).await;
+        assert!(plan.contains("Union"), "wide aggregate must split:\n{plan}");
+        assert_eq!(plan.matches("TableScan: t").count(), range_split_branches(), "one scan per branch:\n{plan}");
+        // Each branch must carry its OWN bound. A split that left every branch
+        // reading the whole window would be correct but pointless, and would
+        // multiply the work by the branch count.
+        assert!(plan.matches("timestamp >=").count() >= range_split_branches(), "each branch needs its own lower bound:\n{plan}");
+    }
+
+    /// The rewrite assumes "rows of sub-range A" == "the window's rows restricted
+    /// to A". Every shape here breaks that, or has nothing to gain, so each must
+    /// come back byte-identical to the un-ruled plan.
+    #[tokio::test]
+    async fn declines_where_a_split_would_change_the_answer() {
+        for (name, sql) in [
+            // count(*) over a LIMIT would become branches x limit rows.
+            ("limit under the aggregate", format!("SELECT count(*) FROM (SELECT * FROM t WHERE {WIDE} LIMIT 100)")),
+            // No aggregate: splitting costs the streaming TopK its ordering.
+            ("order by with limit", format!("SELECT id FROM t WHERE {WIDE} ORDER BY timestamp DESC LIMIT 5")),
+            // Narrow enough that one thread is comfortably inside the timeout.
+            ("span below the threshold", "SELECT count(*) FROM t WHERE timestamp >= '2026-09-01T00:00:00Z'::timestamp AND timestamp <= '2026-09-04T00:00:00Z'::timestamp".into()),
+            // An open upper bound has no finite span to divide.
+            ("half-open window", "SELECT count(*) FROM t WHERE timestamp >= '2026-08-05T00:00:00Z'::timestamp".into()),
+        ] {
+            assert_eq!(optimized(&sql, true).await, optimized(&sql, false).await, "{name}: must not rewrite");
+        }
+    }
+
+    /// A UNION emits UNQUALIFIED fields, so the parent's `t.id` stopped
+    /// resolving and the rule failed the whole query with `FieldNotFound`. The
+    /// rewrite must be indistinguishable to its parent, qualifier included.
+    ///
+    /// `SELECT DISTINCT` is itself an `Aggregate`, and splitting it IS sound —
+    /// the aggregate sits above the union and still sees every row of the
+    /// window — so this is the shape that exercises qualification.
+    #[tokio::test]
+    async fn split_preserves_the_scan_qualifier_a_union_would_drop() {
+        let plan = optimized(&format!("SELECT count(*) FROM (SELECT DISTINCT id FROM t WHERE {WIDE})"), true).await;
+        assert!(plan.contains("Union"), "distinct over a wide window should still split:\n{plan}");
+        assert!(plan.contains("SubqueryAlias: t"), "the union must be re-qualified as `t`:\n{plan}");
+        assert!(plan.contains("groupBy=[[t.id]]"), "the parent must still bind `t.id`:\n{plan}");
+    }
+
+    /// Splitting must partition the window, not resample it: the branch bounds
+    /// have to tile `[lo, hi]` with no gap and no overlap. A gap silently drops
+    /// rows; an overlap silently double-counts them, and both look like a
+    /// working query.
+    #[tokio::test]
+    async fn branch_bounds_tile_the_window_exactly() {
+        let plan = optimized(&format!("SELECT count(*) FROM t WHERE {WIDE}"), true).await;
+        let bounds: Vec<&str> = plan.matches("timestamp >=").collect();
+        assert_eq!(bounds.len(), range_split_branches(), "expected one lower bound per branch:\n{plan}");
+        // One upper bound per branch. The LAST branch is built as `< hi + 1`,
+        // which DataFusion's simplifier folds back to `<= hi` — so both forms
+        // count, and the total must still be exactly one per branch.
+        assert_eq!(plan.matches("timestamp <").count(), range_split_branches(), "one upper bound per branch:\n{plan}");
+    }
+}

--- a/src/read/optimizers.rs
+++ b/src/read/optimizers.rs
@@ -3470,10 +3470,7 @@ impl OptimizerRule for RangeParallelDedup {
         let Some(narrowed) = narrowed else {
             return Ok(Transformed::no(plan));
         };
-        let union = narrowed[1..]
-            .iter()
-            .try_fold(LogicalPlanBuilder::new(narrowed[0].clone()), |builder, branch| builder.union(branch.clone()))?
-            .build()?;
+        let union = narrowed[1..].iter().try_fold(LogicalPlanBuilder::new(narrowed[0].clone()), |builder, branch| builder.union(branch.clone()))?.build()?;
         // A UNION's output fields are UNQUALIFIED, so a parent expression like
         // `t.id` stops resolving and the whole rule fails the query. Re-attach
         // the scan's qualifier, and if that still does not reproduce the input's
@@ -3591,15 +3588,15 @@ fn narrow_scan_window(plan: &LogicalPlan, lo: i64, hi: i64) -> Option<LogicalPla
             let window = timestamp.clone().gt_eq(literal(lo)).and(timestamp.lt(literal(hi)));
             Filter::try_new(window, Arc::new(plan.clone())).ok().map(LogicalPlan::Filter)
         }
-        LogicalPlan::Filter(filter) => Filter::try_new(filter.predicate.clone(), Arc::new(narrow_scan_window(&filter.input, lo, hi)?))
-            .ok()
-            .map(LogicalPlan::Filter),
-        LogicalPlan::Projection(projection) => Projection::try_new(projection.expr.clone(), Arc::new(narrow_scan_window(&projection.input, lo, hi)?))
-            .ok()
-            .map(LogicalPlan::Projection),
-        LogicalPlan::SubqueryAlias(alias) => SubqueryAlias::try_new(Arc::new(narrow_scan_window(&alias.input, lo, hi)?), alias.alias.clone())
-            .ok()
-            .map(LogicalPlan::SubqueryAlias),
+        LogicalPlan::Filter(filter) => {
+            Filter::try_new(filter.predicate.clone(), Arc::new(narrow_scan_window(&filter.input, lo, hi)?)).ok().map(LogicalPlan::Filter)
+        }
+        LogicalPlan::Projection(projection) => {
+            Projection::try_new(projection.expr.clone(), Arc::new(narrow_scan_window(&projection.input, lo, hi)?)).ok().map(LogicalPlan::Projection)
+        }
+        LogicalPlan::SubqueryAlias(alias) => {
+            SubqueryAlias::try_new(Arc::new(narrow_scan_window(&alias.input, lo, hi)?), alias.alias.clone()).ok().map(LogicalPlan::SubqueryAlias)
+        }
         _ => None,
     }
 }
@@ -3657,7 +3654,10 @@ mod range_parallel_dedup_tests {
             // No aggregate: splitting costs the streaming TopK its ordering.
             ("order by with limit", format!("SELECT id FROM t WHERE {WIDE} ORDER BY timestamp DESC LIMIT 5")),
             // Narrow enough that one thread is comfortably inside the timeout.
-            ("span below the threshold", "SELECT count(*) FROM t WHERE timestamp >= '2026-09-01T00:00:00Z'::timestamp AND timestamp <= '2026-09-04T00:00:00Z'::timestamp".into()),
+            (
+                "span below the threshold",
+                "SELECT count(*) FROM t WHERE timestamp >= '2026-09-01T00:00:00Z'::timestamp AND timestamp <= '2026-09-04T00:00:00Z'::timestamp".into(),
+            ),
             // An open upper bound has no finite span to divide.
             ("half-open window", "SELECT count(*) FROM t WHERE timestamp >= '2026-08-05T00:00:00Z'::timestamp".into()),
         ] {

--- a/src/write/mod.rs
+++ b/src/write/mod.rs
@@ -812,6 +812,7 @@ impl BufferedWriteLayer {
         // Apply configurable bucket duration before MemBuffer reads it.
         crate::write::mem_buffer::set_bucket_duration_micros((cfg.buffer.bucket_duration_secs() as i64) * 1_000_000);
         crate::read::set_bounded_dedup_enabled(cfg.maintenance.timefusion_read_dedup_bounded);
+        crate::read::optimizers::set_range_split_branches(cfg.maintenance.timefusion_query_range_split_branches);
         // Text-index cache budget: 25% of the MemBuffer memory budget.
         // Rationale: indexed text is roughly 1.5–2x raw text in postings,
         // and indexed columns are a fraction of total row bytes. 25% is a

--- a/tests/suite/main.rs
+++ b/tests/suite/main.rs
@@ -26,6 +26,7 @@ mod pgwire_dml_tag_test;
 mod plan_cache_shape_repro;
 mod proptest_invariants;
 mod query_pool_insert_test;
+mod range_split_test;
 mod sqllogictest;
 mod statistics_test;
 mod tantivy_e2e_test;

--- a/tests/suite/range_split_test.rs
+++ b/tests/suite/range_split_test.rs
@@ -1,0 +1,108 @@
+//! `RangeParallelDedup` splits a wide aggregate window into disjoint timestamp
+//! ranges so each range's `DedupExec` runs on its own thread. The split is only
+//! sound because `timestamp` LEADS the dedup key, so a row's versions can never
+//! fall either side of a boundary.
+//!
+//! These tests exist because the failure mode is silent: a gap between branches
+//! drops rows and an overlap double-counts them, and either way the query still
+//! returns a plausible number.
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use datafusion::arrow::{array::AsArray, datatypes::Int64Type};
+use serial_test::serial;
+use timefusion::{
+    database::Database,
+    support::test_helpers::{BufferMode, TestConfigBuilder, json_to_batch, test_span_ts},
+};
+
+const DAYS: i64 = 30;
+const BRANCHES: usize = 4;
+const DAY_MICROS: i64 = 24 * 3_600 * 1_000_000;
+
+/// One row per day for 30 days, inserted TWICE as two independent Delta commits
+/// so every logical row exists as two physical versions in different files —
+/// the shape read-side dedup exists to collapse. Returns (db, project, window).
+async fn seeded(label: &str) -> Result<(Arc<Database>, String, i64, i64)> {
+    timefusion::read::optimizers::set_range_split_branches(BRANCHES);
+    let cfg = TestConfigBuilder::new(label).with_buffer_mode(BufferMode::Enabled).build();
+    let db = Arc::new(Database::with_config(Arc::clone(&cfg)).await?);
+    let project_id = format!("proj_{}", &uuid::Uuid::new_v4().to_string()[..8]);
+
+    // Anchor on a whole day so branch boundaries land on round numbers, then
+    // put a row at each day AND at each branch boundary — the boundary rows are
+    // the ones a half-open/closed mistake loses or counts twice.
+    let end = chrono::Utc::now().date_naive().and_hms_opt(0, 0, 0).unwrap().and_utc().timestamp_micros();
+    let start = end - DAYS * DAY_MICROS;
+    let step = (end - start) / BRANCHES as i64;
+    let boundaries: Vec<i64> = (0..BRANCHES as i64).map(|i| start + step * i).collect();
+    let stamps: Vec<i64> = (0..DAYS).map(|d| start + d * DAY_MICROS + 3_600 * 1_000_000).chain(boundaries).collect();
+
+    let rows = |name: &str| -> Result<_> {
+        json_to_batch(stamps.iter().enumerate().map(|(i, ts)| test_span_ts(&format!("row_{i}"), name, &project_id, *ts)).collect())
+    };
+    // Two commits => two files per partition holding the same logical rows.
+    db.insert_records_batch(&project_id, "otel_logs_and_spans", vec![rows("first")?], true, None).await?;
+    db.insert_records_batch(&project_id, "otel_logs_and_spans", vec![rows("second")?], true, None).await?;
+    Ok((db, project_id, start, end))
+}
+
+async fn scalar(db: &Arc<Database>, sql: &str) -> Result<i64> {
+    let mut ctx = Arc::clone(db).create_session_context();
+    db.setup_session_context(&mut ctx)?;
+    Ok(ctx.sql(sql).await?.collect().await?[0].column(0).as_primitive::<Int64Type>().value(0))
+}
+
+/// The whole point: a wide window must split, and still count every logical row
+/// exactly once. Asserting the count alone would pass vacuously if the rule
+/// silently declined, so the plan is checked too.
+#[serial]
+#[tokio::test]
+async fn wide_window_splits_and_still_counts_each_row_once() -> Result<()> {
+    let (db, project_id, start, end) = seeded("range_split_counts").await?;
+    let expected = DAYS + BRANCHES as i64; // one row per day, plus the boundary rows
+
+    let window = format!(
+        "project_id = '{project_id}' AND timestamp >= '{}'::timestamp AND timestamp <= '{}'::timestamp",
+        chrono::DateTime::from_timestamp_micros(start).unwrap().to_rfc3339(),
+        chrono::DateTime::from_timestamp_micros(end).unwrap().to_rfc3339(),
+    );
+
+    let mut ctx = Arc::clone(&db).create_session_context();
+    db.setup_session_context(&mut ctx)?;
+    let plan = ctx.sql(&format!("EXPLAIN SELECT count(*) FROM otel_logs_and_spans WHERE {window}")).await?.collect().await?;
+    let rendered: String = plan
+        .iter()
+        .flat_map(|b| (0..b.num_rows()).map(|r| timefusion::support::test_helpers::array_get_str(b.column(1).as_ref(), r)).collect::<Vec<_>>())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(rendered.contains("Union"), "a {DAYS}-day aggregate must split into branches:\n{rendered}");
+
+    let counted = scalar(&db, &format!("SELECT count(*) FROM otel_logs_and_spans WHERE {window}")).await?;
+    assert_eq!(counted, expected, "split count must equal the logical row count (duplicates collapsed exactly once)");
+    Ok(())
+}
+
+/// A narrow window has nothing to gain and must keep the un-split plan, so the
+/// hot dashboard path is untouched by this rule.
+#[serial]
+#[tokio::test]
+async fn narrow_window_is_left_alone() -> Result<()> {
+    let (db, project_id, _, end) = seeded("range_split_narrow").await?;
+    let window = format!(
+        "project_id = '{project_id}' AND timestamp >= '{}'::timestamp AND timestamp <= '{}'::timestamp",
+        chrono::DateTime::from_timestamp_micros(end - 2 * DAY_MICROS).unwrap().to_rfc3339(),
+        chrono::DateTime::from_timestamp_micros(end).unwrap().to_rfc3339(),
+    );
+    let mut ctx = Arc::clone(&db).create_session_context();
+    db.setup_session_context(&mut ctx)?;
+    let plan = ctx.sql(&format!("EXPLAIN SELECT count(*) FROM otel_logs_and_spans WHERE {window}")).await?.collect().await?;
+    let rendered: String = plan
+        .iter()
+        .flat_map(|b| (0..b.num_rows()).map(|r| timefusion::support::test_helpers::array_get_str(b.column(1).as_ref(), r)).collect::<Vec<_>>())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(!rendered.contains("Union\n"), "a 2-day window must not split:\n{rendered}");
+    Ok(())
+}


### PR DESCRIPTION
## Why

`DedupExec` declares `Distribution::SinglePartition`, so every row of a window funnels through **one thread** beneath the `SortPreservingMerge`. Measured on prod 2026-09-04 (whale project, warm process):

| test | rows | wall |
|---|---|---|
| one 30d query | ~110M | **timeout >60s** |
| two 15d halves, run **concurrently** | 104.6M | **19.98s** |

14d alone = 51.6M rows in 24.6s = 2.1M rows/s, a single-core rate; two queries together sustain 5.2M rows/s. The box can do 30 days of work in 20 seconds — one query just cannot use more than one core.

This is the remaining half of the 14/30-day cliff. The other half (footer-prefix conformance) shipped in `466f4bfb` and took 14d from timeout to 14.0s; 30d stayed over the limit because it is throughput-bound, not cliff-bound.

## What

Split a wide **aggregate** window into N disjoint timestamp ranges, each with its own scan and its own `DedupExec`, unioned under the original aggregate.

- **Exact**, because `timestamp` *leads* the dedup key — two versions of a row always share it and cannot land either side of a boundary. Verified against prod before writing code: 6-hour slices sum exactly to their day, and two 15d halves sum exactly to the 30d count.
- **Range, not hash.** Hashing the dedup key also keeps versions together, but destroys the ordering, forcing `DedupExec` into unbounded `full-set` mode — the seen-set merely moves rather than shrinking, which is the `dedup exceeded its 2048 MiB per-query limit` failure.
- **Only under an aggregate.** A union of ranges advertises no ordering, so applying this beneath `ORDER BY ts DESC LIMIT n` would trade a streaming TopK for a blocking sort.

Kill switch: `timefusion_query_range_split_branches` (default 4, `<2` disables).

## Two guards the tests found, not the design

- A `UNION` emits **unqualified** fields, so a parent's `t.id` stopped resolving and the rule failed the query outright. The rewrite now must reproduce its input's schema exactly — qualifier included — or it declines.
- The node whitelist is why a LIMIT under the aggregate declines: `count(*)` over `(SELECT … LIMIT 100)` would otherwise become branches × 100 rows.

## Tests

6 tests. The e2e one seeds 30 days of rows, each written twice as two Delta commits so every logical row has two physical versions, and asserts the split count equals the logical row count.

**Falsified, not just green:** deliberately overlapping the branches makes that test return 49 instead of 34, so it genuinely catches double-counting.

## Not yet verified

Effect on prod 30d is *projected* at ~4x single-core throughput (>60s → ~15s) from the 2x15d measurement — not yet measured end-to-end. Full suite has not been run locally (shared checkout moved mid-run; local disk at 99%), which is what this PR's CI is for.