### PR TITLE
Preserve primitive numeric values in JSON output

### DIFF
--- a/src/database/compact.rs
+++ b/src/database/compact.rs
@@ -363,7 +363,15 @@ impl Database {
             // target size — it is not converged until rewritten DV-free (pushdown
             // is disabled per-file while a DV is present).
             .filter(|add| add.size() < target_size.max(1) || add.deletion_vector_descriptor().is_some())
-            .map(|add| TailAdd::from_stats(add.path().to_string(), add.size(), is_sorted_run(&add.tags()), add.deletion_vector_descriptor().is_some(), add.stats().as_deref()))
+            .map(|add| {
+                TailAdd::from_stats(
+                    add.path().to_string(),
+                    add.size(),
+                    is_sorted_run(&add.tags()),
+                    add.deletion_vector_descriptor().is_some(),
+                    add.stats().as_deref(),
+                )
+            })
             .collect();
         Ok(select_tail_bin(&tail, target_size, min_files, sorted_run_cap, seal_micros_now(), TailPass::Pack, pack_size_ratio(), pack_value_floor()))
     }
@@ -395,7 +403,10 @@ impl Database {
                 // `stats()` is reached only past both tag/size exclusions.
                 let path = file.path();
                 let project_id = path_partition_value(&path, "project_id").filter(|p| !p.is_empty()).map(str::to_owned)?;
-                Some((project_id, TailAdd::from_stats(path.into_owned(), size, sorted_run, file.deletion_vector_descriptor().is_some(), file.stats().as_deref())))
+                Some((
+                    project_id,
+                    TailAdd::from_stats(path.into_owned(), size, sorted_run, file.deletion_vector_descriptor().is_some(), file.stats().as_deref()),
+                ))
             })
             .fold(HashMap::<String, Vec<TailAdd>>::new(), |mut per_project, (project_id, add)| {
                 per_project.entry(project_id).or_default().push(add);
@@ -1015,7 +1026,8 @@ impl Database {
         // Probe-only provider (chunk detection). The rewrite builds its own
         // provider per attempt — from a FRESH snapshot, with the synthetic
         // source-file column — in `dedup_rewrite_chunk`.
-        let provider = Self::narrow_provider(log_store, snapshot, partition_files, None, None).await.map_err(|e| anyhow::anyhow!("delta table provider: {e}"))?;
+        let provider =
+            Self::narrow_provider(log_store, snapshot, partition_files, None, None).await.map_err(|e| anyhow::anyhow!("delta table provider: {e}"))?;
         // A fresh state is intentional: SessionState clones retain mutable
         // catalog/execution internals and can resolve the scan name to an older
         // eager snapshot. FileSelection above removes the expensive all-table
@@ -1353,13 +1365,8 @@ impl Database {
         // `partition_filter`/`scan_name` are unused by the DV path — it builds
         // its own row-index provider.
         if self.config.maintenance.timefusion_use_deletion_vectors {
-            let dv_enabled = table_ref
-                .read()
-                .await
-                .snapshot()
-                .ok()
-                .map(|s| s.snapshot().table_properties().enable_deletion_vectors == Some(true))
-                .unwrap_or(false);
+            let dv_enabled =
+                table_ref.read().await.snapshot().ok().map(|s| s.snapshot().table_properties().enable_deletion_vectors == Some(true)).unwrap_or(false);
             if dv_enabled {
                 let _ = (partition_filter, scan_name);
                 return self.stage_dedup_chunk_dv(table_ref, table_name, project_id, schema, chunk_filter, label, date_str, key, limits).await;
@@ -2045,9 +2052,10 @@ impl Database {
                 (Arc::new(table.snapshot()?.snapshot().clone()), table.log_store())
             };
             let partition_files = dedup_partition_paths(chunk_snapshot.log_data().iter().map(|f| f.path().to_string()), project_id, date_str);
-            let provider = Self::narrow_provider(chunk_log_store.clone(), Arc::clone(&chunk_snapshot), partition_files, Some(DEDUP_FILE_COL), Some(DV_ROW_INDEX_COL))
-                .await
-                .map_err(|e| anyhow::anyhow!("dv-dedup provider: {e}"))?;
+            let provider =
+                Self::narrow_provider(chunk_log_store.clone(), Arc::clone(&chunk_snapshot), partition_files, Some(DEDUP_FILE_COL), Some(DV_ROW_INDEX_COL))
+                    .await
+                    .map_err(|e| anyhow::anyhow!("dv-dedup provider: {e}"))?;
             let ctx = datafusion::prelude::SessionContext::new_with_state(build_optimize_session_state(
                 limits.map_or(self.config.memory.timefusion_query_partitions, |l| l.sort_partitions),
                 self.maintenance_runtime_env(),
@@ -2099,8 +2107,9 @@ impl Database {
             let bucket_expr = format!("hash_bucket(arrow_cast(concat_ws(chr(31), {keys_varchar}), 'Utf8View'), {DEDUP_BUCKET_COUNT})");
             let bytes_per_row = self.config.maintenance.timefusion_dedup_bytes_per_row;
             let est_decoded = oracle.saturating_mul(bytes_per_row).saturating_mul(2);
-            let decoded_budget =
-                limits.map_or(self.config.maintenance.timefusion_dedup_max_decoded_bytes, |l| self.config.maintenance.timefusion_dedup_max_decoded_bytes.min(l.max_decoded_bytes));
+            let decoded_budget = limits.map_or(self.config.maintenance.timefusion_dedup_max_decoded_bytes, |l| {
+                self.config.maintenance.timefusion_dedup_max_decoded_bytes.min(l.max_decoded_bytes)
+            });
             let shards = dedup_shard_count(limits.is_some(), est_decoded, 0, decoded_budget, u64::MAX).max(1);
 
             // A single dedup-key group cannot be split (all copies share one hash
@@ -2110,8 +2119,10 @@ impl Database {
             // copy-on-write path. Cheaper here (narrow projection), so it fires
             // only on a genuinely enormous single key.
             if limits.is_none() && shards > 1 && decoded_budget > 0 {
-                let max_group_sql =
-                    format!("SELECT coalesce(max(c), 0) FROM (SELECT count(*) AS c FROM {DEDUP_SCAN_NAME} WHERE {chunk_filter} GROUP BY {})", schema.dedup_keys.iter().map(|k| crate::rollup::quoted(k)).collect::<Vec<_>>().join(", "));
+                let max_group_sql = format!(
+                    "SELECT coalesce(max(c), 0) FROM (SELECT count(*) AS c FROM {DEDUP_SCAN_NAME} WHERE {chunk_filter} GROUP BY {})",
+                    schema.dedup_keys.iter().map(|k| crate::rollup::quoted(k)).collect::<Vec<_>>().join(", ")
+                );
                 let max_group = Self::scalar_i64(&ctx, &max_group_sql).await?.unwrap_or(0);
                 if (max_group.max(0) as u64).saturating_mul(bytes_per_row).saturating_mul(2) > decoded_budget {
                     crate::observability::record_dedup_chunk_skipped();
@@ -2127,8 +2138,7 @@ impl Database {
             let mut survivors_total: u64 = 0;
             let mut scanned_total: u64 = 0;
             {
-                let _permit =
-                    self.maintenance_rewrite_sem.acquire().await.map_err(|e| anyhow::anyhow!("maintenance rewrite semaphore closed: {e}"))?;
+                let _permit = self.maintenance_rewrite_sem.acquire().await.map_err(|e| anyhow::anyhow!("maintenance rewrite semaphore closed: {e}"))?;
                 for shard in 0..shards {
                     let shard_pred = if shards > 1 {
                         let (lo, hi) = (shard * DEDUP_BUCKET_COUNT / shards, (shard + 1) * DEDUP_BUCKET_COUNT / shards);
@@ -2160,7 +2170,9 @@ impl Database {
             }
             let losers_total: u64 = losers_by_file.values().map(|v| v.len() as u64).sum();
             if survivors_total + losers_total != scanned_total {
-                anyhow::bail!("dv-dedup accounting for table={table_name} chunk=[{label}]: survivors {survivors_total} + losers {losers_total} != scanned {scanned_total}");
+                anyhow::bail!(
+                    "dv-dedup accounting for table={table_name} chunk=[{label}]: survivors {survivors_total} + losers {losers_total} != scanned {scanned_total}"
+                );
             }
             if losers_total == 0 {
                 return Ok(BinOutcome::Converged);
@@ -2227,7 +2239,13 @@ impl Database {
                 adds,
                 stage_store,
                 discardable_paths,
-                dedup: Some(DedupUnit { key: key.clone(), date: date_str.to_string(), label: label.to_string(), before: scanned_total, after: survivors_total }),
+                dedup: Some(DedupUnit {
+                    key: key.clone(),
+                    date: date_str.to_string(),
+                    label: label.to_string(),
+                    before: scanned_total,
+                    after: survivors_total,
+                }),
                 // Same-path files: sortedness is unchanged, so DON'T claim it here
                 // (false only costs a footer probe; true on a file we didn't write
                 // is a wrong exoneration).

--- a/src/database/maintain.rs
+++ b/src/database/maintain.rs
@@ -3356,7 +3356,13 @@ impl Database {
                         return None;
                     }
                     after_project += 1;
-                    let add = TailAdd::from_stats(path.to_string(), file.size(), is_sorted_run(&file.tags()), file.deletion_vector_descriptor().is_some(), file.stats().as_deref());
+                    let add = TailAdd::from_stats(
+                        path.to_string(),
+                        file.size(),
+                        is_sorted_run(&file.tags()),
+                        file.deletion_vector_descriptor().is_some(),
+                        file.stats().as_deref(),
+                    );
                     if add.event_range.is_some_and(|(start, end)| start >= key.slice.end_micros || end < key.slice.start_micros) {
                         return None;
                     }
@@ -7602,7 +7608,17 @@ impl Database {
                 self.repair_degradation.remove(path);
             }
         }
-        Ok(BinOutcome::Staged(StagedBin { project_id: project_id.to_string(), wave_id, target_paths: files, removes, adds, stage_store, discardable_paths: Vec::new(), dedup: None, sorted }))
+        Ok(BinOutcome::Staged(StagedBin {
+            project_id: project_id.to_string(),
+            wave_id,
+            target_paths: files,
+            removes,
+            adds,
+            stage_store,
+            discardable_paths: Vec::new(),
+            dedup: None,
+            sorted,
+        }))
     }
 
     /// Commit one WAVE: every staged unit's Remove+Add in a single transaction.

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -16487,7 +16487,9 @@ mod tests {
             size,
             is_sorted_run: false,
             event_range: Some((min, max)),
-            rows: None, has_dv: false };
+            rows: None,
+            has_dv: false,
+        };
         // Priced in ROWS per file eliminated, which is what the guard compares.
         let value = |files: &[(&str, i64)]| {
             let rows: i64 = files.iter().map(|(_, s)| *s).sum();
@@ -16527,7 +16529,9 @@ mod tests {
             size,
             is_sorted_run: sorted,
             event_range: Some((min, max)),
-            rows: None, has_dv: false };
+            rows: None,
+            has_dv: false,
+        };
         // Seal lag: a file whose newest event is past the seal is still filling
         // (prod 2026-07-20: compacting it lost every OCC race).
         let unsealed = vec![f("a", 10, false, 1, 1), f("b", 10, false, 2, SEAL + 1)];
@@ -16606,7 +16610,8 @@ mod tests {
 
         // Files with no event-time stats can't be binned disjointly (the
         // 2026-07-20 silent no-op read them as None and selected NOTHING).
-        let no_stats = vec![super::TailAdd { path: "x".into(), size: 10, is_sorted_run: false, event_range: None, rows: None, has_dv: false }, f("a", 10, false, 1, 2)];
+        let no_stats =
+            vec![super::TailAdd { path: "x".into(), size: 10, is_sorted_run: false, event_range: None, rows: None, has_dv: false }, f("a", 10, false, 1, 2)];
         assert_eq!(super::select_tail_bin(&no_stats, TARGET, 2, TARGET / 4, SEAL, TailPass::Pack, 0, 0), Vec::<String>::new());
     }
 
@@ -16626,7 +16631,9 @@ mod tests {
             size,
             is_sorted_run: false,
             event_range: Some((min, max)),
-            rows: None, has_dv: false };
+            rows: None,
+            has_dv: false,
+        };
         // Smalls first, whale later in time: ratio off admits all three (the
         // measured 82.5%-write-volume shape); ratio 4 keeps the small pair and
         // leaves the whale for its own generation.
@@ -16652,7 +16659,9 @@ mod tests {
             size: size_mb * MB,
             is_sorted_run: sorted,
             event_range: None,
-            rows: None, has_dv: false };
+            rows: None,
+            has_dv: false,
+        };
 
         // Sorted runs are still excluded while any L0 file is present, but the two
         // L0 files now share one unit instead of taking a unit each.
@@ -16884,7 +16893,9 @@ mod tests {
             size: 10 * MB,
             is_sorted_run: true,
             event_range: Some((at_bin * bin, at_bin * bin + bin / 2)),
-            rows: Some(1_000), has_dv: false };
+            rows: Some(1_000),
+            has_dv: false,
+        };
         // Two files 100 bins apart: a merge of them spans ~101 bins.
         let far = vec![f("a", 0), f("b", 100)];
 
@@ -16924,7 +16935,9 @@ mod tests {
             size: size_mb * MB,
             is_sorted_run: true,
             event_range: None,
-            rows: Some(rows), has_dv: false };
+            rows: Some(rows),
+            has_dv: false,
+        };
 
         // Metrics shape: 47 B/row, so 256 MB of these is ~5.5 M rows. The byte
         // budget alone would take them all; the row cap stops first.
@@ -16941,8 +16954,9 @@ mod tests {
         assert_eq!(sparse_picked.len(), 23, "a sparse bin is still bounded by BYTES, not clipped by the row cap");
 
         // Absent stats must never make the cap stricter than bytes alone.
-        let unknown: Vec<_> =
-            (0..23).map(|i| super::TailAdd { path: format!("u{i:02}"), size: 11 * MB, is_sorted_run: true, event_range: None, rows: None, has_dv: false }).collect();
+        let unknown: Vec<_> = (0..23)
+            .map(|i| super::TailAdd { path: format!("u{i:02}"), size: 11 * MB, is_sorted_run: true, event_range: None, rows: None, has_dv: false })
+            .collect();
         assert_eq!(
             super::select_coordinator_compaction_candidates(unknown, super::COORDINATOR_SEALED_TARGET_BYTES).len(),
             23,
@@ -16966,7 +16980,14 @@ mod tests {
     #[test]
     fn a_pair_that_fits_the_byte_budget_is_never_blocked_by_the_row_cap() {
         const MB: i64 = 1024 * 1024;
-        let f = |path: &str, bytes: i64, rows: u64| super::TailAdd { path: path.into(), size: bytes, is_sorted_run: true, event_range: None, rows: Some(rows), has_dv: false };
+        let f = |path: &str, bytes: i64, rows: u64| super::TailAdd {
+            path: path.into(),
+            size: bytes,
+            is_sorted_run: true,
+            event_range: None,
+            rows: Some(rows),
+            has_dv: false,
+        };
 
         // The exact prod cell, sizes and row counts as measured.
         let cell = vec![
@@ -17001,7 +17022,14 @@ mod tests {
     #[test]
     fn the_planner_admits_exactly_what_the_packer_can_bin() {
         let target = super::COORDINATOR_SEALED_TARGET_BYTES;
-        let f = |path: &str, bytes: i64, rows: u64| super::TailAdd { path: path.into(), size: bytes, is_sorted_run: true, event_range: None, rows: Some(rows), has_dv: false };
+        let f = |path: &str, bytes: i64, rows: u64| super::TailAdd {
+            path: path.into(),
+            size: bytes,
+            is_sorted_run: true,
+            event_range: None,
+            rows: Some(rows),
+            has_dv: false,
+        };
 
         // Both cells read off prod 2026-09-03. Bytes fit in BOTH — 82% and 81% of
         // the budget — so a bytes-only planner queues both; the packer bins only
@@ -17033,7 +17061,14 @@ mod tests {
     #[test]
     fn an_unsorted_bin_is_budgeted_in_decoded_bytes() {
         const MB: i64 = 1024 * 1024;
-        let f = |path: &str, size_mb: i64| super::TailAdd { path: path.into(), size: size_mb * MB, is_sorted_run: false, event_range: None, rows: None, has_dv: false };
+        let f = |path: &str, size_mb: i64| super::TailAdd {
+            path: path.into(),
+            size: size_mb * MB,
+            is_sorted_run: false,
+            event_range: None,
+            rows: None,
+            has_dv: false,
+        };
         let budget = super::unsorted_bin_budget_bytes();
 
         // The invariant the value is chosen from, stated as a test so a future
@@ -17124,7 +17159,9 @@ mod tests {
             size: size_mb * MB,
             is_sorted_run: sorted,
             event_range: None,
-            rows: None, has_dv: false };
+            rows: None,
+            has_dv: false,
+        };
 
         // The whale/07-30 shape: converged files carrying no sorted-run tag, beside real small debt.
         let whale = vec![f("converged-a", 520, false), f("converged-b", 512, false), f("small-a", 6, false), f("small-b", 6, false)];
@@ -17158,7 +17195,14 @@ mod tests {
     #[test]
     fn packing_takes_the_small_files_even_when_a_large_one_sorts_first() {
         const MB: i64 = 1024 * 1024;
-        let run = |path: &str, size_mb: i64| super::TailAdd { path: path.into(), size: size_mb * MB, is_sorted_run: true, event_range: None, rows: None, has_dv: false };
+        let run = |path: &str, size_mb: i64| super::TailAdd {
+            path: path.into(),
+            size: size_mb * MB,
+            is_sorted_run: true,
+            event_range: None,
+            rows: None,
+            has_dv: false,
+        };
 
         // Event-time order puts the 252 MB file first; the rest are tiny.
         let cell = vec![run("big-252", 252), run("t-a", 14), run("t-b", 14), run("t-c", 14)];
@@ -17205,7 +17249,8 @@ mod tests {
             super::COORDINATOR_FILE_REWRITE_TIMEOUT
         );
 
-        let run = |name: &str, mib: i64| super::TailAdd { path: name.into(), size: mib * MIB, is_sorted_run: true, event_range: None, rows: None, has_dv: false };
+        let run =
+            |name: &str, mib: i64| super::TailAdd { path: name.into(), size: mib * MIB, is_sorted_run: true, event_range: None, rows: None, has_dv: false };
         assert_eq!(
             super::select_coordinator_compaction_candidates(vec![run("a", 128), run("b", 128), run("c", 128)], super::COORDINATOR_SEALED_TARGET_BYTES),
             vec!["a", "b"],
@@ -17223,8 +17268,14 @@ mod tests {
     fn repair_pass_takes_the_newest_poisoned_file_then_the_smallest() {
         const TARGET: i64 = 1000;
         const SEAL: i64 = 10_000;
-        let f =
-            |path: &str, size: i64, min: i64| super::TailAdd { path: path.into(), size, is_sorted_run: false, event_range: Some((min, min + 1)), rows: None, has_dv: false };
+        let f = |path: &str, size: i64, min: i64| super::TailAdd {
+            path: path.into(),
+            size,
+            is_sorted_run: false,
+            event_range: Some((min, min + 1)),
+            rows: None,
+            has_dv: false,
+        };
         let backlog = vec![f("may", 900, 10), f("july", 900, 500), f("june", 950, 100)];
         assert_eq!(super::select_tail_bin(&backlog, TARGET, 2, TARGET / 4, SEAL, TailPass::Repair, 0, 0), vec!["july"], "newest poisoned file first");
 
@@ -18374,7 +18425,14 @@ mod tests {
     #[test]
     fn converged_sorted_runs_are_a_counterexample_to_compaction_dedup_convergence() {
         const TARGET: i64 = 1000;
-        let run = |path: &str, min: i64| super::TailAdd { path: path.into(), size: 900, is_sorted_run: true, event_range: Some((min, min + 1)), rows: None, has_dv: false };
+        let run = |path: &str, min: i64| super::TailAdd {
+            path: path.into(),
+            size: 900,
+            is_sorted_run: true,
+            event_range: Some((min, min + 1)),
+            rows: None,
+            has_dv: false,
+        };
         let versions_in_different_runs = vec![run("older-version", 1), run("newer-version", 1)];
 
         assert!(

--- a/src/read/functions.rs
+++ b/src/read/functions.rs
@@ -9,8 +9,8 @@ use chrono_tz::Tz;
 use datafusion::{
     arrow::{
         array::{
-            Array, ArrayRef, BinaryArray, BinaryViewArray, BooleanArray, Float64Array, Int64Array, StringArray, StringViewArray, TimestampMicrosecondArray,
-            TimestampNanosecondArray,
+            Array, ArrayRef, BinaryArray, BinaryViewArray, BooleanArray, Float32Array, Float64Array, Int8Array, Int16Array, Int32Array, Int64Array,
+            StringArray, StringViewArray, TimestampMicrosecondArray, TimestampNanosecondArray, UInt8Array, UInt16Array, UInt32Array, UInt64Array,
         },
         datatypes::{DataType, Field, FieldRef, IntervalUnit, TimeUnit},
     },
@@ -1076,10 +1076,29 @@ impl ScalarUDFImpl for ExtractEpochUDF {
 /// Downcast `array` to a primitive Arrow array and map each element to
 /// `json!(value)`, nulls to `JsonValue::Null`.
 macro_rules! json_primitives {
-    ($array:expr, $ty:ty) => {{
+    ($array:expr, $ty:ty) => {
+        json_primitives!($array, $ty, |x| json!(x))
+    };
+    ($array:expr, $ty:ty, $convert:expr) => {{
         let arr = $array.as_any().downcast_ref::<$ty>().ok_or_else(|| DataFusionError::Execution(format!("Failed to downcast to {}", stringify!($ty))))?;
-        arr.iter().map(|v| v.map_or(JsonValue::Null, |x| json!(x))).collect()
+        arr.iter().map(|v| v.map_or(JsonValue::Null, $convert)).collect()
     }};
+}
+
+// JSON has no non-finite numbers. PostgreSQL retains them as strings, unlike
+// serde_json's default float serializer, which converts them to null.
+macro_rules! json_floats {
+    ($array:expr, $ty:ty) => {
+        json_primitives!($array, $ty, |x| {
+            if x.is_nan() {
+                json!("NaN")
+            } else if x.is_infinite() {
+                json!(if x.is_sign_positive() { "Infinity" } else { "-Infinity" })
+            } else {
+                json!(x)
+            }
+        })
+    };
 }
 
 /// Convert Arrow array to JSON values
@@ -1110,8 +1129,16 @@ fn array_to_json_values_inner(array: &ArrayRef, sniff_json: bool) -> datafusion:
                 })
                 .collect()
         }
+        DataType::Int8 => json_primitives!(array, Int8Array),
+        DataType::Int16 => json_primitives!(array, Int16Array),
+        DataType::Int32 => json_primitives!(array, Int32Array),
         DataType::Int64 => json_primitives!(array, Int64Array),
-        DataType::Float64 => json_primitives!(array, Float64Array),
+        DataType::UInt8 => json_primitives!(array, UInt8Array),
+        DataType::UInt16 => json_primitives!(array, UInt16Array),
+        DataType::UInt32 => json_primitives!(array, UInt32Array),
+        DataType::UInt64 => json_primitives!(array, UInt64Array),
+        DataType::Float32 => json_floats!(array, Float32Array),
+        DataType::Float64 => json_floats!(array, Float64Array),
         DataType::Boolean => json_primitives!(array, BooleanArray),
         DataType::Timestamp(TimeUnit::Microsecond, _) => {
             let ts = array

--- a/tests/slt/json_functions.slt
+++ b/tests/slt/json_functions.slt
@@ -1,3 +1,14 @@
+# Incident 2026-09-06: float4 and narrow integers were emitted as JSON strings.
+query T
+SELECT jsonb_build_array(80::real, -7::smallint, 17::integer, NULL::real)
+----
+[80.0,-7,17,null]
+
+query T
+SELECT jsonb_build_array('NaN'::real, 'Infinity'::real, '-Infinity'::double precision)
+----
+["NaN","Infinity","-Infinity"]
+
 # Test JSON functions in TimeFusion
 # This file combines all JSON-specific tests from:
 # - available_json_functions.slt


### PR DESCRIPTION
Monoscope metric-table results serialize Float32 aggregates as JSON strings. The JSON conversion helper handles Int64 and Float64 but sends narrower integers and Float32 through its text fallback. A query returning 80 therefore produces "80.0" instead of a JSON number.

Handle signed and unsigned primitive integer widths and both float widths as JSON numbers. Preserve PostgreSQL's string representation of NaN and infinities instead of serde_json's null fallback. Keep SQL NULL as JSON null. Decimal conversion remains outside this change.

Validation: the SQL regression failed before the repair with ["80.0","-7","17",null] instead of [80.0,-7,17,null]. All nine targeted JSON tests pass after the repair; cargo lint passes; the full default suite passes all 1,399 tests (16 skipped). A real Monoscope ingestion-to-events-API test passes against the fixed local server with its numeric assertion unchanged. Formatting checks pass.

The first commit formats existing dedup code that failed the repository formatting check; the functional repair is isolated in the second commit. Production deployment and verification remain pending.
