### PR TITLE
Implement DEALLOCATE ALL across SQL and protocol statement stores

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2199,9 +2199,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion"
-version = "54.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "997a31e15872606a49478e670c58302094c97cb96abb0a7d60720f8e92170040"
+version = "54.1.0"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -2252,9 +2251,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-catalog"
-version = "54.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7dd61161508f8f5fa1107774ea687bd753c22d83a32eebf963549f89de14139"
+version = "54.1.0"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2277,9 +2275,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-catalog-listing"
-version = "54.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897c70f871277f9ce99aa38347be0d679bbe3e617156c4d2a8378cec8a2a0891"
+version = "54.1.0"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2300,9 +2297,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common"
-version = "54.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "121c9ded5d87d9172319e006f2afdb9928d72dbacd6a90a458d8acb1e3b43a65"
+version = "54.1.0"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -2326,9 +2322,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common-runtime"
-version = "54.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "981b9dae74f78ee3d9f714fb49b01919eab975461b56149510c3ba9ea11287d1"
+version = "54.1.0"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
 dependencies = [
  "futures",
  "log",
@@ -2337,9 +2332,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource"
-version = "54.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffd7d295b2ec7c00d8a56562f41ed41062cf0af75549ed891c12a0a09eddfefe"
+version = "54.1.0"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
 dependencies = [
  "arrow",
  "async-compression",
@@ -2373,9 +2367,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-arrow"
-version = "54.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552b0b3f342f7ec41b3fbd70f6339dc82a30cfd0349e7f280e7852528085349f"
+version = "54.1.0"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -2397,9 +2390,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-csv"
-version = "54.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68850aa426b897e879c8b87e512ea8124f1d0a2869a4e51808ddaaddf1bc0ada"
+version = "54.1.0"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2420,9 +2412,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-json"
-version = "54.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402f93242ae08ef99139ee2c528a49d087efe88d5c7b2c3ff5480855a40ce54f"
+version = "54.1.0"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2443,9 +2434,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-parquet"
-version = "54.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffd2499c1bee0eeccf6a57156105700eeeb17bc701899ac719183c4e74231450"
+version = "54.1.0"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2474,15 +2464,13 @@ dependencies = [
 
 [[package]]
 name = "datafusion-doc"
-version = "54.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb9e7e5d11130c48c8bd4e80c79a9772dd28ce6dc330baca9246205d245b9e2e"
+version = "54.1.0"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
 
 [[package]]
 name = "datafusion-execution"
-version = "54.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37a8643ab852eb68864e1b72ae789e8066282dce48eea6347ffb0aee33d1ccc0"
+version = "54.1.0"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -2502,9 +2490,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr"
-version = "54.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6932f4d71eed9c8d9341476a2b845aadfabde5495d08dbcd8fc23881f49fa7a0"
+version = "54.1.0"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -2525,9 +2512,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr-common"
-version = "54.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0225491839a31b1f7d2cb8092c2d50792e2fe1c1724e4e6d08e011f5feaf4ed2"
+version = "54.1.0"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2537,9 +2523,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions"
-version = "54.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14872c47bfc3d21e53ec82f57074e6987a15941c1e2f43cde4ac6ae2746634e3"
+version = "54.1.0"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -2569,9 +2554,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-aggregate"
-version = "54.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a2ca14e1b609be21e657e2d3130b2f446456b08393b377bb721a33952d2e09"
+version = "54.1.0"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2590,9 +2574,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-aggregate-common"
-version = "54.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ece74ba09092d2ef9c9b54a38445450aea292a1f8b04faf531936b723a24b3c"
+version = "54.1.0"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2615,9 +2598,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-nested"
-version = "54.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f3e3f9ee8ca59bf70518802107de6f1b88a9509efdc629fadc5de9d6b2d5ef5"
+version = "54.1.0"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -2640,9 +2622,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-table"
-version = "54.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89161dffc22cf2b50f9f4b1bee83b5221d3b4ed7c2e37fd7aa2b22a5297b3a26"
+version = "54.1.0"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2656,9 +2637,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-window"
-version = "54.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7339345b226b3874037708bf5023ba1c2de705128f8457a095aae5ae9cb9c78"
+version = "54.1.0"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2673,9 +2653,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-window-common"
-version = "54.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa84836dc2392df6f43d6a29d37fb56a8ebdc8b3f4e10ae8dc15861fd20278fb"
+version = "54.1.0"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -2683,9 +2662,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-macros"
-version = "54.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "587164e03ad68732aa9e7bfe5686e3f25970d4c64fd4bd80790749840892dae5"
+version = "54.1.0"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -2694,9 +2672,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-optimizer"
-version = "54.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77f20e8cf9e8654d92f4c16b24c487353ee5bf153ffc12d5772cd399ab8cd281"
+version = "54.1.0"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
 dependencies = [
  "arrow",
  "chrono",
@@ -2728,9 +2705,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr"
-version = "54.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f015a4a82f6f7ff7e1d8d4bf3870a936752fa38b17705dfcc14adef95aa8922c"
+version = "54.1.0"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2750,9 +2726,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr-adapter"
-version = "54.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51e6ffff8acdfe54e0ea15ccf38115c4a9184433b0439f42907637928d00a235"
+version = "54.1.0"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2765,9 +2740,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr-common"
-version = "54.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7967a3e171c6a4bf09474b3f7a14f1a3db13ed1714ba12156f33fcce2bba54e8"
+version = "54.1.0"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
 dependencies = [
  "arrow",
  "chrono",
@@ -2782,9 +2756,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-optimizer"
-version = "54.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ff803e2a96054cb6d83f35f9e60fd4f42eac515e1932bd1b2dbc91d5fcbf36"
+version = "54.1.0"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2801,9 +2774,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-plan"
-version = "54.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "776ee54d47d15bdb126452f9ca17b03761e3b004682914beaedd3f86eb507fbc"
+version = "54.1.0"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
 dependencies = [
  "arrow",
  "arrow-data",
@@ -2857,9 +2829,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-proto"
-version = "54.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd15a1ba5d3af93808241065c6c44dbca8296a189845e8a587c45c07bf0ffae"
+version = "54.1.0"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
 dependencies = [
  "arrow",
  "chrono",
@@ -2884,9 +2855,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-proto-common"
-version = "54.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90042982cf9462eb06a0b81f92efa4188dae871e7ea3ab8dc61aa9c9349b2530"
+version = "54.1.0"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2895,9 +2865,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-pruning"
-version = "54.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fb9e5774660aa69c3ba93c610f175f75b65cb8c3776edb3626de8f3a4f4ee3"
+version = "54.1.0"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2911,9 +2880,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-session"
-version = "54.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15ce715fa2a61f4623cc234bcc14a3ef6a91f189128d5b14b468a6a17cdfc417"
+version = "54.1.0"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -2925,8 +2893,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-sql"
-version = "54.0.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?branch=timefusion-update-from-54#5aa045c05653e37454b4085ac0478ffcf72ab845"
+version = "54.1.0"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -6200,7 +6168,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -9470,7 +9438,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -248,6 +248,7 @@ strip = "none"
 [patch.crates-io]
 # libpq 18 requires a ProtocolVersionNegotiation response that reports every
 # unsupported `_pq_.*` startup option, even when protocol 3.2 itself matches.
+# MemPortalStore also exposes statement cleanup for SQL DEALLOCATE ALL.
 pgwire = { path = "vendor/pgwire" }
 # datafusion-postgres ecosystem on our fork's DataFusion 54 branch
 # (apitoolkit/datafusion-postgres @ timefusion-df54, off v0.16.0). Includes
@@ -256,12 +257,41 @@ pgwire = { path = "vendor/pgwire" }
 # arrow-pg/datafusion-pg-catalog from the same git workspace, so those need no
 # separate patch.
 datafusion-postgres = { git = "https://github.com/apitoolkit/datafusion-postgres.git", branch = "timefusion-df54" }
-# datafusion-sql on our fork (tonyalaribe/datafusion @ timefusion-update-from-54,
-# off tag 54.0.0): removes the SQL planner's defensive
-# `not_impl_err!("UPDATE ... FROM is not supported")` guard so `UPDATE ... FROM`
-# reaches TF's DmlQueryPlanner (Delta MergeBuilder / MemBuffer hash-join).
-# Mirrors apache/datafusion#21530; drop once upstream merges #19950.
-datafusion-sql = { git = "https://github.com/tonyalaribe/datafusion.git", branch = "timefusion-update-from-54" }
+# DataFusion 54.1 with SQL DEALLOCATE ALL and the existing UPDATE FROM support.
+# Keep the workspace crates on one source so their public Rust types agree.
+datafusion = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
+datafusion-catalog = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
+datafusion-catalog-listing = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
+datafusion-common = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
+datafusion-common-runtime = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
+datafusion-datasource = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
+datafusion-datasource-arrow = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
+datafusion-datasource-csv = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
+datafusion-datasource-json = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
+datafusion-datasource-parquet = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
+datafusion-doc = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
+datafusion-execution = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
+datafusion-expr = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
+datafusion-expr-common = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
+datafusion-functions = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
+datafusion-functions-aggregate = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
+datafusion-functions-aggregate-common = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
+datafusion-functions-nested = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
+datafusion-functions-table = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
+datafusion-functions-window = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
+datafusion-functions-window-common = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
+datafusion-macros = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
+datafusion-optimizer = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
+datafusion-physical-expr = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
+datafusion-physical-expr-adapter = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
+datafusion-physical-expr-common = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
+datafusion-physical-optimizer = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
+datafusion-physical-plan = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
+datafusion-proto = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
+datafusion-proto-common = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
+datafusion-pruning = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
+datafusion-session = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
+datafusion-sql = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
 # tikv-jemalloc-sys 0.6.1 vendored with a single build.rs delta: honour
 # `JEMALLOC_SYS_PROF_BACKTRACE` so the heap profiler can be built with a working
 # unwinder (`--enable-prof-libunwind`). Upstream passes `--enable-prof` alone and

--- a/src/dml.rs
+++ b/src/dml.rs
@@ -201,6 +201,10 @@ pub(crate) fn substitute(plan: &LogicalPlan, matched: &LogicalPlan, replacement:
 
 #[async_trait]
 impl QueryPlanner for DmlQueryPlanner {
+    fn supports_update_from(&self) -> bool {
+        true
+    }
+
     #[instrument(
         name = "dml.create_physical_plan",
         skip_all,

--- a/src/read/optimizers.rs
+++ b/src/read/optimizers.rs
@@ -1719,7 +1719,10 @@ pub struct PgCoalesceUdf {
 /// workspace pin, or this check would pass against the wrong version. By the
 /// same token, fork upgrades that keep the version string still need the
 /// manual audit — the tripwire only catches plain `cargo update`s.
-const AUDITED_DATAFUSION_VERSION: &str = "54.0.0";
+// 54.1.0 audit: ScalarUDFImpl and the built-in coalesce implementation are
+// byte-identical to 54.0.0. The audit also restored the missing conditional-
+// argument and documentation forwarding from the previous wrapper.
+const AUDITED_DATAFUSION_VERSION: &str = "54.1.0";
 // Byte loop because `&str` equality (PartialEq) isn't const-callable on
 // stable — assert!(a == b) won't compile in a const block.
 const _: () = {
@@ -1754,8 +1757,14 @@ impl datafusion::logical_expr::ScalarUDFImpl for PgCoalesceUdf {
     fn invoke_with_args(&self, args: datafusion::logical_expr::ScalarFunctionArgs) -> Result<datafusion::logical_expr::ColumnarValue> {
         self.inner.inner().invoke_with_args(args)
     }
+    fn conditional_arguments<'a>(&self, args: &'a [Expr]) -> Option<(Vec<&'a Expr>, Vec<&'a Expr>)> {
+        self.inner.inner().conditional_arguments(args)
+    }
     fn short_circuits(&self) -> bool {
         self.inner.inner().short_circuits()
+    }
+    fn documentation(&self) -> Option<&datafusion::logical_expr::Documentation> {
+        self.inner.inner().documentation()
     }
     fn simplify(
         &self, args: Vec<Expr>, info: &datafusion::logical_expr::simplify::SimplifyContext,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1991,6 +1991,30 @@ mod streaming_tests {
             anyhow::Ok(())
         })
         .await??;
+        // Driver cleanup must invalidate both SQL PREPARE and protocol Parse
+        // statements, whether sent through the simple or extended protocol.
+        tokio::time::timeout(std::time::Duration::from_secs(10), async {
+            let peer_statement = other.prepare("SELECT 77::BIGINT").await?;
+            for extended in [false, true] {
+                let statement = client.prepare("SELECT 42::BIGINT").await?;
+                client.batch_execute("PREPARE sql_statement AS SELECT 42::BIGINT").await?;
+                client.simple_query("EXECUTE sql_statement").await?;
+                if extended {
+                    client.execute("DEALLOCATE ALL", &[]).await?;
+                } else {
+                    client.batch_execute("DEALLOCATE ALL").await?;
+                }
+                let error = client.query(&statement, &[]).await.unwrap_err();
+                assert_eq!(error.code(), Some(&tokio_postgres::error::SqlState::INVALID_SQL_STATEMENT_NAME));
+                let error = client.simple_query("EXECUTE sql_statement").await.unwrap_err();
+                assert!(error.as_db_error().unwrap().message().contains("does not exist"));
+                assert_eq!(other.query_one(&peer_statement, &[]).await?.get::<_, i64>(0), 77);
+            }
+            client.batch_execute("DEALLOCATE ALL; DEALLOCATE PREPARE ALL").await?;
+            assert_eq!(client.query_one("SELECT 42::BIGINT", &[]).await?.get::<_, i64>(0), 42);
+            anyhow::Ok(())
+        })
+        .await??;
         drop(tasks);
         Ok(())
     }

--- a/src/server/pg_compat.rs
+++ b/src/server/pg_compat.rs
@@ -29,7 +29,7 @@ use datafusion_postgres::{
         api::{
             ClientInfo, Type,
             auth::{DefaultServerParameterProvider, ServerParameterProvider},
-            results::{DataRowEncoder, FieldFormat, FieldInfo, QueryResponse, Response},
+            results::{DataRowEncoder, FieldFormat, FieldInfo, QueryResponse, Response, Tag},
         },
         error::{PgWireError, PgWireResult},
     },
@@ -313,8 +313,11 @@ impl PgCompatibilityHook {
 #[async_trait]
 impl QueryHook for PgCompatibilityHook {
     async fn handle_simple_query(
-        &self, statement: &Statement, _session_context: &SessionContext, client: &mut dyn HookClient,
+        &self, statement: &Statement, session_context: &SessionContext, client: &mut dyn HookClient,
     ) -> Option<PgWireResult<Response>> {
+        if let Some(result) = deallocate_all(statement, session_context, client).await {
+            return Some(result);
+        }
         if let Some(fields) = self.role_probe(statement) {
             return Some(role_probe_response(&fields).map(Response::Query));
         }
@@ -331,9 +334,14 @@ impl QueryHook for PgCompatibilityHook {
     }
 
     async fn handle_extended_query(
-        &self, statement: Option<&Statement>, _logical_plan: &LogicalPlan, _params: &datafusion::common::ParamValues, _session_context: &SessionContext,
+        &self, statement: Option<&Statement>, _logical_plan: &LogicalPlan, _params: &datafusion::common::ParamValues, session_context: &SessionContext,
         client: &mut dyn HookClient,
     ) -> Option<PgWireResult<Response>> {
+        if let Some(statement) = statement
+            && let Some(result) = deallocate_all(statement, session_context, client).await
+        {
+            return Some(result);
+        }
         // Deliberately NOT intercepted for the role probe: `handle_extended_parse_query`
         // already returned a plan that produces the row, and letting the normal
         // executor run it is what encodes the columns in the result format the
@@ -341,6 +349,24 @@ impl QueryHook for PgCompatibilityHook {
         // client requesting binary cannot decode for int4/bool.
         statement.and_then(|statement| self.show(statement, client)).map(|(name, value)| show_response(&name, &value).map(Response::Query))
     }
+}
+
+/// SQL and wire-protocol prepares have separate stores. Clear both on this
+/// connection, preserving session settings and already-bound portals.
+async fn deallocate_all(statement: &Statement, session_context: &SessionContext, client: &mut dyn HookClient) -> Option<PgWireResult<Response>> {
+    let Statement::Deallocate { name, .. } = statement else {
+        return None;
+    };
+    if name.quote_style.is_some() || !name.value.eq_ignore_ascii_case("all") {
+        return None;
+    }
+    Some(match session_context.sql(&statement.to_string()).await {
+        Ok(_) => {
+            client.portal_store().clear_statements();
+            Ok(Response::Execution(Tag::new("DEALLOCATE")))
+        }
+        Err(error) => Err(PgWireError::ApiError(Box::new(error))),
+    })
 }
 
 fn is_pg_roles(relation: &TableFactor) -> bool {

--- a/vendor/pgwire/src/api/store.rs
+++ b/vendor/pgwire/src/api/store.rs
@@ -43,6 +43,16 @@ pub struct MemPortalStore<S> {
     portals: RwLock<BTreeMap<String, Arc<Portal<S>>>>,
 }
 
+impl<S> MemPortalStore<S> {
+    /// Remove every prepared statement, retaining already-bound portals.
+    ///
+    /// This supports SQL `DEALLOCATE ALL`: existing portals keep their own
+    /// statement references, but new binds can no longer find the statements.
+    pub fn clear_statements(&self) {
+        self.statements.write().unwrap().clear();
+    }
+}
+
 impl<S: Clone + Send + Sync + 'static> PortalStore for MemPortalStore<S> {
     type Statement = S;
 
@@ -83,5 +93,35 @@ impl<S: Clone + Send + Sync + 'static> PortalStore for MemPortalStore<S> {
     fn get_portal(&self, name: &str) -> Option<Arc<Portal<Self::Statement>>> {
         let guard = self.portals.read().unwrap();
         guard.get(name).cloned()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::DEFAULT_NAME;
+
+    #[test]
+    fn clearing_statements_preserves_bound_portals() {
+        let store = MemPortalStore::<String>::new();
+        for name in ["named", DEFAULT_NAME] {
+            store.put_statement(Arc::new(StoredStatement::new(
+                name.to_owned(),
+                "SELECT 1".to_owned(),
+                vec![],
+            )));
+        }
+        let portal = Arc::new(Portal {
+            name: "bound".to_owned(),
+            statement: store.get_statement("named").unwrap(),
+            ..Default::default()
+        });
+        store.put_portal(portal.clone());
+        store.clear_statements();
+        store.clear_statements();
+        for name in ["named", DEFAULT_NAME] {
+            assert!(store.get_statement(name).is_none());
+        }
+        assert!(Arc::ptr_eq(&store.get_portal("bound").unwrap(), &portal));
     }
 }


### PR DESCRIPTION
Production connections repeatedly failed `DEALLOCATE ALL` with “Prepared statement all does not exist.” It now clears both SQL-prepared plans and wire-protocol prepared statements on the current connection, while retaining session settings, bound portals, and other connections’ statements. Quoted `"all"` remains a named statement.

The DataFusion 54.1 fork represents ALL explicitly and is pinned consistently across its workspace crates. TimeFusion retains UPDATE FROM through a custom-planner capability; default DataFusion still rejects unsupported execution. The vendored pgwire store exposes statement cleanup. The required coalesce-wrapper audit also restores missing conditional-argument and documentation forwarding.

Validation: the TCP regression fails before and passes after for simple and extended protocol paths, including expired-statement errors and connection isolation. `cargo lint` passes; all 1,399 TimeFusion nextest tests pass (16 skipped; one subprocess-handle leak reported, with no matching test processes remaining afterward). The DataFusion fork passes all 2,776 relevant tests and its full lint suite, including the default UPDATE FROM rejection regression. The pgwire store passes its default and minimal/server/ring/client feature tests and CI lint checks.
