### PR TITLE
Filter Delta rows before dedup without shifting deletion vectors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2963,7 +2963,7 @@ dependencies = [
 [[package]]
 name = "deltalake"
 version = "1.0.0"
-source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=a0f68b0c#a0f68b0c5bdd8f0d0c15297e777db06ee87d9839"
+source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=a17379858779815fd93bac998910c9e506a6dc8d#a17379858779815fd93bac998910c9e506a6dc8d"
 dependencies = [
  "buoyant_kernel 0.24.0",
  "ctor",
@@ -2974,7 +2974,7 @@ dependencies = [
 [[package]]
 name = "deltalake-aws"
 version = "1.0.0"
-source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=a0f68b0c#a0f68b0c5bdd8f0d0c15297e777db06ee87d9839"
+source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=a17379858779815fd93bac998910c9e506a6dc8d#a17379858779815fd93bac998910c9e506a6dc8d"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -2997,7 +2997,7 @@ dependencies = [
 [[package]]
 name = "deltalake-core"
 version = "1.0.0"
-source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=a0f68b0c#a0f68b0c5bdd8f0d0c15297e777db06ee87d9839"
+source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=a17379858779815fd93bac998910c9e506a6dc8d#a17379858779815fd93bac998910c9e506a6dc8d"
 dependencies = [
  "alloc-stdlib",
  "arrow",
@@ -3055,7 +3055,7 @@ dependencies = [
 [[package]]
 name = "deltalake-derive"
 version = "1.0.0"
-source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=a0f68b0c#a0f68b0c5bdd8f0d0c15297e777db06ee87d9839"
+source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=a17379858779815fd93bac998910c9e506a6dc8d#a17379858779815fd93bac998910c9e506a6dc8d"
 dependencies = [
  "convert_case 0.9.0",
  "itertools 0.14.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ regex = "1.11.1"
 # push, which busts cargo-chef's recipe.json and forces a full dependency
 # recompile in CI. Bump deliberately to pick up fork changes:
 #   cargo update -p deltalake --precise <new-sha>   (then update this rev)
-deltalake = { git = "https://github.com/tonyalaribe/delta-rs-timefusion.git", rev = "a0f68b0c", features = [
+deltalake = { git = "https://github.com/tonyalaribe/delta-rs-timefusion.git", rev = "a17379858779815fd93bac998910c9e506a6dc8d", features = [
   "datafusion",
   "s3",
 ] }

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -10019,7 +10019,26 @@ impl ProjectRoutingTable {
         };
 
         let coerced = Self::coerce_plan_to_schema(delta_plan, &target_schema)?;
-        self.gate_if_wide(coerced, filters)
+        // Delta may leave predicates inexact, especially when a deletion vector
+        // prevents Parquet filtering. Apply immutable predicates AFTER its row
+        // masks, but BEFORE dedup has to retain every row in the selected files.
+        let mutable = Self::version_mutable_columns(&self.table_name);
+        let schema = coerced.schema();
+        let predicate = filters
+            .iter()
+            .filter(|f| {
+                !Self::references_tombstone(&self.table_name, f)
+                    && f.column_refs().iter().all(|c| schema.index_of(&c.name).is_ok() && !mutable.as_ref().is_some_and(|m| m.contains(&c.name)))
+            })
+            .cloned()
+            .reduce(Expr::and);
+        let filtered: Arc<dyn ExecutionPlan> = if let Some(predicate) = predicate {
+            let predicate = state.create_physical_expr(predicate, &schema.as_ref().clone().try_into()?)?;
+            Arc::new(datafusion::physical_plan::filter::FilterExec::try_new(predicate, coerced)?)
+        } else {
+            coerced
+        };
+        self.gate_if_wide(filtered, filters)
     }
 
     /// How far back a scan reaches (`now - min_ts`), in micros. `None` = no

--- a/tests/e2e/flush_warm.rs
+++ b/tests/e2e/flush_warm.rs
@@ -56,6 +56,9 @@ async fn body_read_cost(env: &E2eEnv) -> anyhow::Result<(u64, u64, usize)> {
 #[tokio::test(flavor = "multi_thread")]
 async fn evicted_hot_tail_body_read_served_from_foyer_not_s3() -> anyhow::Result<()> {
     let env = E2eEnv::builder().with_foyer_enabled().with_warm_full_files().start().await?;
+    // Measure this read's cache traffic, without the boot preloader issuing
+    // unrelated GETs against tables that do not exist in the fresh bucket.
+    env.db().cancel_maintenance();
     insert_and_flush(&env).await?;
 
     // While still in the MemBuffer, the read touches neither parquet nor Foyer.

--- a/tests/suite/dedup_compaction_test.rs
+++ b/tests/suite/dedup_compaction_test.rs
@@ -3883,3 +3883,32 @@ async fn a_pruned_to_nothing_delta_scan_does_not_panic() -> Result<()> {
     assert_eq!(found, 0, "the needle is in no file — and getting there must not panic");
     Ok(())
 }
+
+/// A DV scan must retain physical row positions until its mask is consumed,
+/// then discard out-of-window rows before the read-side dedup buffers them.
+#[serial]
+#[tokio::test]
+async fn dv_window_filters_before_read_dedup() -> Result<()> {
+    let (db, project_id) = buffered_db("dv_window_filter").await?;
+    let ts = (chrono::Utc::now() - chrono::Duration::hours(3)).timestamp_micros();
+    write_to(&db, "mor_dormant", &project_id, (0..30).map(|i| mor_row(&format!("k{i}"), "v", &project_id, ts + i * 1_000_000, None)).collect(), true).await?;
+    let mut ctx = Arc::clone(&db).create_session_context();
+    db.setup_session_context(&mut ctx)?;
+    ctx.sql(&format!("DELETE FROM mor_dormant WHERE project_id = '{project_id}' AND id IN ('k2', 'k12')")).await?.collect().await?;
+    let table = db.resolve_table(&project_id, "mor_dormant").await?;
+    assert!(
+        table.read().await.snapshot()?.snapshot().log_data().iter().any(|f| f.deletion_vector_descriptor().is_some()),
+        "fixture must contain a real deletion vector"
+    );
+    let at = |offset: i64| chrono::DateTime::<chrono::Utc>::from_timestamp_micros(ts + offset * 1_000_000).unwrap().format("%Y-%m-%d %H:%M:%S%.f").to_string();
+    let sql = format!("SELECT id FROM mor_dormant WHERE project_id = '{project_id}' AND timestamp >= '{}' AND timestamp < '{}'", at(10), at(15));
+    let plan = ctx.sql(&sql).await?.create_physical_plan().await?;
+    let batches = datafusion::physical_plan::collect(plan.clone(), ctx.task_ctx()).await?;
+    let mut ids: Vec<_> = batches.iter().flat_map(|b| (0..b.num_rows()).map(|i| array_get_str(b.column(0).as_ref(), i))).collect();
+    ids.sort();
+    assert_eq!(ids, ["k10", "k11", "k13", "k14"], "filtering must not shift deletion-vector row positions");
+    let dedup = find_node(&plan, "DedupExec").expect("fixture must exercise read-side dedup");
+    let input_rows = dedup.metrics().unwrap().sum_by_name("input_rows").unwrap().as_usize();
+    assert_eq!(input_rows, 4, "out-of-window rows reached dedup: {}", rendered(&plan));
+    Ok(())
+}


### PR DESCRIPTION
A five-minute production query returned 21,264 rows but fed 20.36 million rows through read-side deduplication and took about 31 seconds warm. Delta leaves timestamp predicates inexact when deletion vectors prevent Parquet filtering, so those predicates were only enforced above deduplication.

Apply immutable predicates after the Delta scan consumes deletion-vector masks and before read-side deduplication. Mutable fields and tombstones remain excluded. Pin the Delta fork's companion fix: physical and dynamic filter pushdown must stop at deletion-vector masks and retained physical row indices. Without that boundary, moving the filter earlier resurrected a deleted row in the regression.

Validation:
- Real-DV regression before: correct four IDs, but 28 rows enter deduplication.
- Earlier filter alone: deleted row reappears, demonstrating the optimizer boundary defect.
- Both fixes: correct four IDs and only four dedup inputs.
- All 113 Delta scan tests pass, including static and dynamic filter rejection.
- Full TimeFusion lint passed. All 1,401 default tests passed. The end-to-end run passed 62 tests; one cache-counter race was fixed by cancelling background preload in that fixture, and both cache tests passed on rerun. The zero-S3 assertions are unchanged.

This reduces downstream merge/dedup work. Files carrying deletion vectors still preserve physical row positions during Parquet decoding; this change does not claim to eliminate their read amplification.
