### PR TITLE
Recover expired maintenance history and count short-query progress

### DIFF
--- a/src/database/maintain.rs
+++ b/src/database/maintain.rs
@@ -899,7 +899,7 @@ impl Database {
         // replay while Docker health checks remained green.
         let mut queued = 0usize;
         let tables = self.all_tables().await;
-        for (storage_project, source, table_ref) in &tables {
+        'sources: for (storage_project, source, table_ref) in &tables {
             let Some(schema) = get_schema(source).filter(|schema| !schema.rollups.is_empty()) else { continue };
             let (version, log_store) = {
                 let table = table_ref.read().await;
@@ -986,8 +986,26 @@ impl Database {
                     }
                     let table = handle.read().await;
                     for file in table.snapshot()?.log_data().iter() {
-                        let partition = Self::maintenance_partition_from_action(&file.path(), None, "default")
-                            .ok_or_else(|| anyhow::anyhow!("cannot reconcile partition for {} in {name}", file.path()))?;
+                        // A valid Delta file need not use Hive directory labels.
+                        // Read only partition scalars, without materializing file statistics.
+                        let values = file.partition_values().map(|values| {
+                            values
+                                .fields()
+                                .iter()
+                                .zip(values.values())
+                                .map(|(field, value)| {
+                                    (field.name().to_owned(), (!value.is_null()).then(|| deltalake::kernel::scalars::ScalarExt::serialize(value)))
+                                })
+                                .collect::<HashMap<_, _>>()
+                        });
+                        let Some(partition) = Self::maintenance_partition_from_action(&file.path(), values.as_ref(), "default")
+                            .filter(|(_, date)| chrono::NaiveDate::parse_from_str(date, "%Y-%m-%d").is_ok())
+                        else {
+                            // Do not advance past unknown data, but do not let this
+                            // source prevent healthy sources reconciling their cursors.
+                            warn!(source, storage_project, cursor, table = name, path = %file.path(), event = "maintenance_partition_reconcile_failed");
+                            continue 'sources;
+                        };
                         partition_hours.insert(partition, crate::rollup::ALL_HOURS);
                     }
                 }

--- a/src/database/maintain.rs
+++ b/src/database/maintain.rs
@@ -219,6 +219,24 @@ mod liveness_clock_tests {
         assert_eq!(progress.load(Relaxed), 5_000, "the task-local reached the counter the clock reads");
     }
 
+    /// Completing many plans faster than the sampling tick is still progress.
+    #[tokio::test(start_paused = true)]
+    async fn short_queries_keep_the_unit_alive_between_watcher_ticks() -> anyhow::Result<()> {
+        let ctx = datafusion::prelude::SessionContext::new();
+        let progress = Arc::new(AtomicU64::new(0));
+        let work = async {
+            for _ in 0..40 {
+                let batches = super::collect_watched(&ctx, "SELECT 1").await?;
+                assert_eq!(batches.iter().map(|batch| batch.num_rows()).sum::<usize>(), 1);
+                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+            }
+            Ok::<_, anyhow::Error>("committed")
+        };
+        let result = super::run_until_idle(std::time::Duration::from_secs(30), progress, work).await??;
+        assert_eq!(result, "committed", "completed short queries must prevent a false idle timeout");
+        Ok(())
+    }
+
     #[test]
     fn note_unit_progress_outside_a_unit_is_a_no_op() {
         super::note_unit_progress(1);
@@ -236,10 +254,13 @@ mod liveness_clock_tests {
             .scope(Arc::clone(&progress), async {
                 let ctx = SessionContext::new();
                 let plan = ctx.sql("SELECT 1 AS a UNION ALL SELECT 2 ORDER BY a").await.expect("plan").create_physical_plan().await.expect("physical");
-                let _watch = super::PlanProgress::watch(Arc::clone(&plan));
+                let watch = super::PlanProgress::watch(Arc::clone(&plan));
                 datafusion::physical_plan::collect(Arc::clone(&plan), ctx.task_ctx()).await.expect("collect");
                 // One tick past the watcher's interval.
                 tokio::time::sleep(std::time::Duration::from_secs(20)).await;
+                let sampled = progress.load(Relaxed);
+                drop(watch);
+                assert_eq!(progress.load(Relaxed), sampled, "the final sample must not count previously sampled rows twice");
             })
             .await;
         assert!(progress.load(Relaxed) > 0, "the plan's own row counters must reach the clock the unit is judged by");
@@ -539,35 +560,50 @@ pub(crate) fn note_unit_progress(rows: usize) {
 /// DRIVEN. That holds end-to-end because the caller polls the output stream
 /// immediately and polling a blocking operator is what drives its children — but
 /// a watcher held over a plan nobody polls reports nothing, correctly.
-pub(crate) struct PlanProgress(Option<tokio::task::JoinHandle<()>>);
+pub(crate) struct PlanProgress(Option<(tokio::task::JoinHandle<()>, Arc<PlanProgressState>)>);
+
+struct PlanProgressState {
+    plan: Arc<dyn datafusion::physical_plan::ExecutionPlan>,
+    progress: Arc<std::sync::atomic::AtomicU64>,
+    last_rows: std::sync::atomic::AtomicU64,
+}
+
+impl PlanProgressState {
+    fn sample(&self) {
+        use std::sync::atomic::Ordering::Relaxed;
+        let rows = plan_output_rows(self.plan.as_ref());
+        // The periodic sample and final sample may race. Each observed row
+        // contributes once even if the background task is still unwinding.
+        let previous = self.last_rows.fetch_max(rows, Relaxed);
+        self.progress.fetch_add(rows.saturating_sub(previous), Relaxed);
+    }
+}
 
 impl PlanProgress {
     pub(crate) fn watch(plan: Arc<dyn datafusion::physical_plan::ExecutionPlan>) -> Self {
-        /// Long enough to cost nothing against an hour-scale window, short
-        /// enough that a stalled plan is still detected inside it.
         const TICK: std::time::Duration = std::time::Duration::from_secs(15);
         let Ok(progress) = UNIT_PROGRESS.try_with(Arc::clone) else {
-            // Not inside a unit (cron paths, tests): nothing to keep alive.
             return Self(None);
         };
-        Self(Some(tokio::spawn(async move {
-            let mut last = 0u64;
+        let state = Arc::new(PlanProgressState { plan, progress, last_rows: std::sync::atomic::AtomicU64::new(0) });
+        let periodic = Arc::clone(&state);
+        let handle = tokio::spawn(async move {
             loop {
                 tokio::time::sleep(TICK).await;
-                let rows = plan_output_rows(plan.as_ref());
-                // The counter is monotonic and read as "has it moved", so feed
-                // it the DELTA rather than the total.
-                progress.fetch_add(rows.saturating_sub(last), std::sync::atomic::Ordering::Relaxed);
-                last = rows;
+                periodic.sample();
             }
-        })))
+        });
+        Self(Some((handle, state)))
     }
 }
 
 impl Drop for PlanProgress {
     fn drop(&mut self) {
-        if let Some(handle) = self.0.take() {
+        if let Some((handle, state)) = self.0.take() {
             handle.abort();
+            // A sequence of queries shorter than TICK must still keep its unit
+            // alive. The old guard discarded all their completed work.
+            state.sample();
         }
     }
 }
@@ -830,6 +866,27 @@ impl Database {
         journal.checkpoint().map_err(std::io::Error::other)
     }
 
+    fn enqueue_maintenance_partition(&self, project_id: &str, source: &str, date: &str) -> Result<()> {
+        let Some(schema) = get_schema(source) else { return Ok(()) };
+        let day = chrono::NaiveDate::parse_from_str(date, "%Y-%m-%d")?;
+        let start = day.and_hms_opt(0, 0, 0).ok_or_else(|| anyhow::anyhow!("invalid maintenance date"))?.and_utc().timestamp_micros();
+        let observed_at_micros = crate::support::now_micros();
+        let mut journal = self.journal();
+        for spec in &schema.rollups {
+            journal.invalidate_coarse(crate::maintenance_coordinator::Invalidation {
+                source_table: source,
+                rollup_table: &spec.table_name(source),
+                source,
+                project_id,
+                start_micros: start,
+                end_micros: start.saturating_add(DAY_MICROS),
+                observed_at_micros,
+                derived: spec.derive_from.is_some(),
+            })?;
+        }
+        journal.checkpoint()
+    }
+
     /// Reconcile the durable task cursor with each live Delta snapshot. This is
     /// intentionally metadata-only and conservative: commits after the cursor
     /// contribute only the partitions named by data-changing Add/Remove actions.
@@ -841,8 +898,9 @@ impl Database {
         // foreground reader and ingest writer behind a multi-minute Delta-log
         // replay while Docker health checks remained green.
         let mut queued = 0usize;
-        for (storage_project, source, table_ref) in self.all_tables().await {
-            let Some(schema) = get_schema(&source).filter(|schema| !schema.rollups.is_empty()) else { continue };
+        let tables = self.all_tables().await;
+        for (storage_project, source, table_ref) in &tables {
+            let Some(schema) = get_schema(source).filter(|schema| !schema.rollups.is_empty()) else { continue };
             let (version, log_store) = {
                 let table = table_ref.read().await;
                 (table.version().unwrap_or_default(), table.log_store())
@@ -875,11 +933,12 @@ impl Database {
             // +5,876 pending base rollups in one hour from ONE restart — the
             // queue's dominant growth source under deploy churn.
             let mut partition_hours: HashMap<(String, String), u32> = HashMap::new();
+            let mut missing_commit = None;
             for commit_version in cursor.saturating_add(1)..=version {
-                let bytes = log_store
-                    .read_commit_entry(commit_version)
-                    .await?
-                    .ok_or_else(|| anyhow::anyhow!("source commit {commit_version} is unavailable for {cursor_key}; cursor remains at {cursor}"))?;
+                let Some(bytes) = log_store.read_commit_entry(commit_version).await? else {
+                    missing_commit = Some(commit_version);
+                    break;
+                };
                 let mut partitions_with_adds = HashSet::new();
                 let mut remove_only: HashSet<(String, String)> = HashSet::new();
                 for action in deltalake::logstore::get_actions(commit_version, &bytes)? {
@@ -915,10 +974,47 @@ impl Database {
                     }
                 }
             }
+            if let Some(missing) = missing_commit {
+                // A current snapshot replaces unavailable change history only
+                // after ALL known source and output partitions are invalidated.
+                // Output-only partitions matter: a missed DELETE can leave no
+                // active source Add while its old aggregate still exists.
+                let targets: HashSet<_> = schema.rollups.iter().map(|spec| spec.table_name(source)).collect();
+                for (project, name, handle) in &tables {
+                    if project != storage_project || (name != source && !targets.contains(name)) {
+                        continue;
+                    }
+                    let table = handle.read().await;
+                    for file in table.snapshot()?.log_data().iter() {
+                        let partition = Self::maintenance_partition_from_action(&file.path(), None, "default")
+                            .ok_or_else(|| anyhow::anyhow!("cannot reconcile partition for {} in {name}", file.path()))?;
+                        partition_hours.insert(partition, crate::rollup::ALL_HOURS);
+                    }
+                }
+                // Keep any remove-only partitions already observed before the
+                // gap as well. The missing commits make every bound uncertain.
+                partition_hours.values_mut().for_each(|hours| *hours = crate::rollup::ALL_HOURS);
+                warn!(
+                    source,
+                    storage_project,
+                    cursor,
+                    missing,
+                    version,
+                    partitions = partition_hours.len(),
+                    event = "maintenance_history_gap_recovery",
+                    "requeueing whole partitions from live metadata before advancing an expired cursor"
+                );
+            }
             for ((partition_project, date), hours) in partition_hours {
                 let project = if storage_project.is_empty() { partition_project } else { storage_project.clone() };
-                self.enqueue_maintenance_hours(&project, &source, &date, hours)?;
-                queued = queued.saturating_add(usize::try_from(hours.count_ones()).unwrap_or(24) * schema.rollups.len());
+                if missing_commit.is_some() {
+                    self.enqueue_maintenance_partition(&project, source, &date)?;
+                    queued = queued.saturating_add(schema.rollups.len());
+                } else {
+                    self.enqueue_maintenance_hours(&project, source, &date, hours)?;
+                    queued = queued.saturating_add(usize::try_from(hours.count_ones()).unwrap_or(24) * schema.rollups.len());
+                }
+                tokio::task::yield_now().await;
             }
             let mut journal = self.journal();
             journal.set_source_cursor(cursor_key, version);

--- a/src/database/maintain.rs
+++ b/src/database/maintain.rs
@@ -957,18 +957,6 @@ impl Database {
                 let dv_dedup_commit = actions.iter().any(
                     |action| matches!(action, deltalake::kernel::Action::CommitInfo(ci) if ci.info.get(DV_DEDUP_COMMIT_KEY).and_then(serde_json::Value::as_bool) == Some(true)),
                 );
-                eprintln!(
-                    "RECONCILE-DBG {cursor_key} v{commit_version} tagged={dv_dedup_commit} actions={:?}",
-                    actions
-                        .iter()
-                        .map(|a| match a {
-                            deltalake::kernel::Action::Add(x) => format!("Add({},dc={})", x.path, x.data_change),
-                            deltalake::kernel::Action::Remove(x) => format!("Rm({},dc={})", x.path, x.data_change),
-                            deltalake::kernel::Action::CommitInfo(ci) => format!("CI({:?})", ci.info.keys().collect::<Vec<_>>()),
-                            other => format!("{other:?}").chars().take(30).collect(),
-                        })
-                        .collect::<Vec<_>>()
-                );
                 let mut partitions_with_adds = HashSet::new();
                 let mut remove_only: HashSet<(String, String)> = HashSet::new();
                 for action in actions {
@@ -1064,7 +1052,7 @@ impl Database {
                 let project = if storage_project.is_empty() { partition_project.clone() } else { storage_project.clone() };
                 if missing_commit.is_some() {
                     self.enqueue_maintenance_partition(&project, source, &date)?;
-                    queued = queued.saturating_add(schema.rollups.len());
+                    queued = queued.saturating_add(1 + schema.rollups.len());
                 } else {
                     let with_dedup = dedup_hours.get(&(partition_project, date.clone())).copied().unwrap_or(0) & hours;
                     self.enqueue_maintenance_hours(&project, source, &date, with_dedup, true)?;

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -15379,13 +15379,18 @@ mod tests {
     /// Retained Delta history may start after a durable maintenance cursor.
     /// Reconstruct conservative work from the live metadata before advancing,
     /// rather than failing every restart on the same expired commit.
+    #[test_case::test_case(true; "partition metadata without directory labels")]
+    #[test_case::test_case(false; "malformed source leaves healthy sources running")]
     #[tokio::test]
-    async fn maintenance_reconciliation_recovers_expired_history() -> Result<()> {
+    async fn maintenance_reconciliation_recovers_expired_history(valid_partition_metadata: bool) -> Result<()> {
         use object_store::ObjectStoreExt;
         let db = Database::with_config(create_test_config("reconcile-expired-history")).await?;
         let source = "otel_logs_and_spans";
         let table = db.get_or_create_unified_table(source).await?;
         db.reconcile_maintenance_task_cursors().await?;
+        // A malformed source must not prevent a healthy source establishing its cursor.
+        let healthy = db.get_or_create_unified_table("otel_metrics").await?;
+        let healthy_version = healthy.read().await.version().unwrap();
         let project = format!("recon_{}", uuid::Uuid::new_v4().simple());
         let ts = (Utc::now() - chrono::Duration::days(2)).timestamp_micros();
         insert_a_span(&db, &project, "a", ts).await?;
@@ -15401,23 +15406,49 @@ mod tests {
         let target_ref = db.get_or_create_unified_table(&target_name).await?;
         {
             let mut target = target_ref.read().await.clone();
-            let add = deltalake::kernel::Add {
-                path: format!("project_id={removed_project}/date={date}/metadata-only.parquet"),
+            let mut actions = Vec::new();
+            if !valid_partition_metadata {
+                use deltalake::kernel::MetadataExt;
+                // A legacy layout can store date in the rows rather than partition metadata.
+                let metadata = deltalake::kernel::Metadata::try_new(
+                    None,
+                    None,
+                    target.snapshot()?.schema(),
+                    vec!["project_id".into()],
+                    Utc::now().timestamp_millis(),
+                    target.snapshot()?.metadata().configuration().clone(),
+                )?
+                .with_table_id(target.snapshot()?.metadata().id().to_owned())?;
+                actions.push(deltalake::kernel::Action::Metadata(metadata));
+            }
+            let mut add = deltalake::kernel::Add {
+                path: "metadata-only.parquet".into(),
                 partition_values: HashMap::from([("project_id".into(), Some(removed_project.clone())), ("date".into(), Some(date))]),
                 size: 1,
                 data_change: false,
                 ..Default::default()
             };
+            if !valid_partition_metadata {
+                add.partition_values.remove("date");
+            }
+            actions.push(deltalake::kernel::Action::Add(add));
             let op = deltalake::protocol::DeltaOperation::Write { mode: deltalake::protocol::SaveMode::Append, partition_by: None, predicate: None };
             let committed = deltalake::kernel::transaction::CommitBuilder::default()
-                .with_actions(vec![deltalake::kernel::Action::Add(add)])
+                .with_actions(actions)
                 .build(Some(target.snapshot()? as &dyn deltalake::kernel::transaction::TableReference), target.log_store(), op)
                 .await?;
             target.state = Some(committed.snapshot());
             *target_ref.write().await = target;
         }
         store.delete(&object_store::path::Path::from(format!("_delta_log/{version:020}.json"))).await?;
-        assert!(db.reconcile_maintenance_task_cursors().await? > 0);
+        let queued = db.reconcile_maintenance_task_cursors().await?;
+        assert_eq!(db.journal().source_cursor(":otel_metrics"), Some(healthy_version));
+        if !valid_partition_metadata {
+            assert_eq!(queued, 0);
+            assert_eq!(db.journal().source_cursor(":otel_logs_and_spans"), Some(0), "an unknown partition must never be skipped past");
+            return Ok(());
+        }
+        assert!(queued > 0);
         let day_start = midnight_micros(chrono::DateTime::from_timestamp_micros(ts).unwrap().date_naive());
         {
             let journal = crate::maintenance_coordinator::TaskJournal::load(&db.config.core.timefusion_data_dir)?;

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -4993,19 +4993,21 @@ impl Database {
                             if !reconcile_db.wait_for_preload(&reconcile_cancel).await {
                                 return;
                             }
-                            match reconcile_db.reconcile_maintenance_task_cursors().await {
-                                Ok(reconciled_tasks) => info!(reconciled_tasks, event = "maintenance_task_reconcile_complete"),
-                                Err(error) => {
-                                    warn!(%error, event = "maintenance_task_reconcile_failed");
+                            loop {
+                                tokio::select! {
+                                    () = reconcile_cancel.cancelled() => return,
+                                    result = reconcile_db.reconcile_maintenance_task_cursors() => match result {
+                                        Ok(reconciled_tasks) => info!(reconciled_tasks, event = "maintenance_task_reconcile_complete"),
+                                        Err(error) => warn!(%error, event = "maintenance_task_reconcile_failed"),
+                                    }
+                                }
+                                // Keep the durable cursor within Delta log retention
+                                // during long uptimes, not only across frequent deploys.
+                                tokio::select! {
+                                    () = reconcile_cancel.cancelled() => return,
+                                    () = tokio::time::sleep(std::time::Duration::from_secs(60)) => {}
                                 }
                             }
-                            // Do not discover fresh file-rewrite debt in the
-                            // boot burst. Durable journal work is already being
-                            // drained above; the coordinator's normal 60-second
-                            // planner tick discovers new debt after preload and
-                            // PGWire handoff have settled. Planning here raced
-                            // repair/resume staging and recreated the exact
-                            // startup contention this runtime isolates.
                         });
 
                         let coverage_db = Arc::clone(&db);
@@ -15371,6 +15373,72 @@ mod tests {
 
         assert_eq!(db.reconcile_maintenance_task_cursors().await?, 0);
         assert_eq!(db.maintenance_tasks.lock().unwrap().source_cursor(cursor_key), Some(version));
+        Ok(())
+    }
+
+    /// Retained Delta history may start after a durable maintenance cursor.
+    /// Reconstruct conservative work from the live metadata before advancing,
+    /// rather than failing every restart on the same expired commit.
+    #[tokio::test]
+    async fn maintenance_reconciliation_recovers_expired_history() -> Result<()> {
+        use object_store::ObjectStoreExt;
+        let db = Database::with_config(create_test_config("reconcile-expired-history")).await?;
+        let source = "otel_logs_and_spans";
+        let table = db.get_or_create_unified_table(source).await?;
+        db.reconcile_maintenance_task_cursors().await?;
+        let project = format!("recon_{}", uuid::Uuid::new_v4().simple());
+        let ts = (Utc::now() - chrono::Duration::days(2)).timestamp_micros();
+        insert_a_span(&db, &project, "a", ts).await?;
+        let (version, store) = {
+            let table = table.read().await;
+            (table.version().unwrap(), table.log_store().object_store(None))
+        };
+        // An output-only partition models a missed DELETE. Its intentionally
+        // unreadable parquet proves this recovery uses metadata, not row scans.
+        let removed_project = format!("{project}_removed");
+        let date = chrono::DateTime::from_timestamp_micros(ts).unwrap().date_naive().to_string();
+        let target_name = crate::schema::get_schema(source).unwrap().rollups[0].table_name(source);
+        let target_ref = db.get_or_create_unified_table(&target_name).await?;
+        {
+            let mut target = target_ref.read().await.clone();
+            let add = deltalake::kernel::Add {
+                path: format!("project_id={removed_project}/date={date}/metadata-only.parquet"),
+                partition_values: HashMap::from([("project_id".into(), Some(removed_project.clone())), ("date".into(), Some(date))]),
+                size: 1,
+                data_change: false,
+                ..Default::default()
+            };
+            let op = deltalake::protocol::DeltaOperation::Write { mode: deltalake::protocol::SaveMode::Append, partition_by: None, predicate: None };
+            let committed = deltalake::kernel::transaction::CommitBuilder::default()
+                .with_actions(vec![deltalake::kernel::Action::Add(add)])
+                .build(Some(target.snapshot()? as &dyn deltalake::kernel::transaction::TableReference), target.log_store(), op)
+                .await?;
+            target.state = Some(committed.snapshot());
+            *target_ref.write().await = target;
+        }
+        store.delete(&object_store::path::Path::from(format!("_delta_log/{version:020}.json"))).await?;
+        assert!(db.reconcile_maintenance_task_cursors().await? > 0);
+        let day_start = midnight_micros(chrono::DateTime::from_timestamp_micros(ts).unwrap().date_naive());
+        {
+            let journal = crate::maintenance_coordinator::TaskJournal::load(&db.config.core.timefusion_data_dir)?;
+            assert_eq!(journal.source_cursor(":otel_logs_and_spans"), Some(version));
+            for project_id in [&project, &removed_project] {
+                let coarse = journal
+                    .tasks()
+                    .filter(|task| {
+                        &task.key.project_id == project_id
+                            && task.key.slice.start_micros == day_start
+                            && task.key.slice.end_micros == day_start + 86_400_000_000
+                    })
+                    .count();
+                assert_eq!(
+                    coarse,
+                    1 + crate::schema::get_schema(source).unwrap().rollups.len(),
+                    "durable dedup and one task per tier, including output-only partitions"
+                );
+            }
+        }
+        assert_eq!(db.reconcile_maintenance_task_cursors().await?, 0, "recovery is durable and idempotent");
         Ok(())
     }
 

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -15457,7 +15457,7 @@ mod tests {
             assert_eq!(db.journal().source_cursor(":otel_logs_and_spans"), Some(0), "an unknown partition must never be skipped past");
             return Ok(());
         }
-        assert!(queued > 0);
+        assert_eq!(queued, 2 * (1 + crate::schema::get_schema(source).unwrap().rollups.len()), "one dedup and every rollup tier for both partitions");
         let day_start = midnight_micros(chrono::DateTime::from_timestamp_micros(ts).unwrap().date_naive());
         {
             let journal = crate::maintenance_coordinator::TaskJournal::load(&db.config.core.timefusion_data_dir)?;

--- a/src/maintenance_coordinator.rs
+++ b/src/maintenance_coordinator.rs
@@ -2393,7 +2393,27 @@ impl TaskJournal {
     /// invalidations are idempotent by `TaskKey`; an already-complete slice is
     /// made pending again and its quiet-period deadline moves forward.
     pub fn invalidate(&mut self, invalidation: Invalidation<'_>) -> anyhow::Result<()> {
-        let Invalidation { source_table, rollup_table, source, project_id, start_micros, end_micros, observed_at_micros, derived } = invalidation;
+        let Invalidation { start_micros, end_micros, derived, .. } = invalidation;
+        let normal_slices = TimeSlice::normal_units(start_micros, end_micros)?;
+        let rollup_slices = if derived {
+            let aligned_start = start_micros.div_euclid(DERIVED_SLICE_MICROS) * DERIVED_SLICE_MICROS;
+            let aligned_end = end_micros.saturating_add(DERIVED_SLICE_MICROS - 1).div_euclid(DERIVED_SLICE_MICROS) * DERIVED_SLICE_MICROS;
+            TimeSlice::fixed_units(aligned_start, aligned_end, DERIVED_SLICE_MICROS)?
+        } else {
+            normal_slices.clone()
+        };
+        self.invalidate_slices(invalidation, &normal_slices, &rollup_slices)
+    }
+
+    /// A history gap has no trustworthy per-hour change bounds. Requeue the
+    /// complete range as coarse work; ordinary capacity splitting still applies.
+    pub(crate) fn invalidate_coarse(&mut self, invalidation: Invalidation<'_>) -> anyhow::Result<()> {
+        let slice = TimeSlice::new(invalidation.start_micros, invalidation.end_micros)?;
+        self.invalidate_slices(invalidation, &[slice], &[slice])
+    }
+
+    fn invalidate_slices(&mut self, invalidation: Invalidation<'_>, normal_slices: &[TimeSlice], rollup_slices: &[TimeSlice]) -> anyhow::Result<()> {
+        let Invalidation { source_table, rollup_table, source, project_id, observed_at_micros, derived, .. } = invalidation;
         // Round up, never down: a bucket can delay eligibility slightly but
         // can never publish before the full quiet period. High-rate ingest
         // then journals one deadline extension per bucket rather than one full
@@ -2404,14 +2424,6 @@ impl TaskJournal {
             .div_euclid(INVALIDATION_DEADLINE_BUCKET_MICROS)
             .saturating_mul(INVALIDATION_DEADLINE_BUCKET_MICROS);
         let created_unix_ms = u64::try_from(observed_at_micros.div_euclid(1_000)).unwrap_or_default();
-        let normal_slices = TimeSlice::normal_units(start_micros, end_micros)?;
-        let rollup_slices = if derived {
-            let aligned_start = start_micros.div_euclid(DERIVED_SLICE_MICROS) * DERIVED_SLICE_MICROS;
-            let aligned_end = end_micros.saturating_add(DERIVED_SLICE_MICROS - 1).div_euclid(DERIVED_SLICE_MICROS) * DERIVED_SLICE_MICROS;
-            TimeSlice::fixed_units(aligned_start, aligned_end, DERIVED_SLICE_MICROS)?
-        } else {
-            normal_slices.clone()
-        };
         // HotPacking is deliberately NOT here. File hygiene is planned by DEBT,
         // not by the calendar: `plan_compaction_debt` scans the actual file list
         // per (project, date) every 60s and mints ONE day-wide unit when the
@@ -2432,8 +2444,7 @@ impl TaskJournal {
         // the "~450 durable tasks per (project, date)" expansion that coarse
         // planning exists to undo. This stops minting them rather than
         // collapsing them afterwards.
-        for (operation, slices) in
-            [(Operation::Dedup, normal_slices.as_slice()), (if derived { Operation::DerivedRollup } else { Operation::BaseRollup }, rollup_slices.as_slice())]
+        for (operation, slices) in [(Operation::Dedup, normal_slices), (if derived { Operation::DerivedRollup } else { Operation::BaseRollup }, rollup_slices)]
         {
             for &slice in slices {
                 let key = TaskKey {

--- a/tests/e2e/deletion_vectors.rs
+++ b/tests/e2e/deletion_vectors.rs
@@ -78,7 +78,14 @@ async fn dv_update_and_delete_hide_rows_without_rewriting_files() -> anyhow::Res
 async fn dv_dedup_drops_cross_file_duplicate_without_rewriting() -> anyhow::Result<()> {
     use std::collections::HashSet;
 
-    let env = E2eEnv::builder().with_deletion_vectors().with_bucket_duration(Duration::from_secs(60)).start().await?;
+    // The two explicit flushes define the two source files. A background tick
+    // between INSERTs can otherwise split the fixture on a busy test runner.
+    let env = E2eEnv::builder()
+        .with_deletion_vectors()
+        .with_bucket_duration(Duration::from_secs(60))
+        .with_flush_interval(Duration::from_secs(3600))
+        .start()
+        .await?;
     let client = env.pg_client().await?;
 
     let past = 1_735_689_600_000_000i64; // 2025-01-01, sealed relative to real now

--- a/tests/e2e/deletion_vectors.rs
+++ b/tests/e2e/deletion_vectors.rs
@@ -80,12 +80,8 @@ async fn dv_dedup_drops_cross_file_duplicate_without_rewriting() -> anyhow::Resu
 
     // The two explicit flushes define the two source files. A background tick
     // between INSERTs can otherwise split the fixture on a busy test runner.
-    let env = E2eEnv::builder()
-        .with_deletion_vectors()
-        .with_bucket_duration(Duration::from_secs(60))
-        .with_flush_interval(Duration::from_secs(3600))
-        .start()
-        .await?;
+    let env =
+        E2eEnv::builder().with_deletion_vectors().with_bucket_duration(Duration::from_secs(60)).with_flush_interval(Duration::from_secs(3600)).start().await?;
     let client = env.pg_client().await?;
 
     let past = 1_735_689_600_000_000i64; // 2025-01-01, sealed relative to real now


### PR DESCRIPTION
Two maintenance failures can discard or strand useful work. Production reconciliation stopped at expired logs commit 492767 with cursor 492766, then the next rollout independently hit expired metrics commit 152985 with cursor 152984. Separately, a sequence of short queries could hit the idle timeout because each progress watcher closed before its first 15-second sample.

When retained history has a gap, reconcile partitions from the loaded source and rollup metadata, including output-only partitions left by deletes. Persist coarse dedup/tier invalidations before advancing the cursor, then keep reconciliation running every 60 seconds. Retained commits continue to use precise hour bounds.

Sample plan progress when the watcher closes as well as periodically. Atomic high-water tracking ensures the final sample and periodic sample count each observed row once. Working sequences of short queries keep their unit alive; stalled units retain the existing timeout.

Validation: the deleted-commit fixture reproduces the original reconciliation error; 40 real short SQL queries over 40 virtual seconds reproduce the false 30-second idle timeout. Both pass after the fixes. Full lint and all 1,479 enabled all-feature tests pass on top of the current certification changes (17 existing skips unchanged).

The full run also exposed a DV fixture race: its background flusher could create extra files between setup inserts. Use the existing long test flush interval so the fixture's two explicit flushes define its two source files. Every file-identity, exact-deletion-vector, row-count and no-resurrection assertion is preserved.

Recovery reads parsed Delta partition metadata, including files without Hive directory labels. If a partition cannot be recovered, leave that source cursor unchanged and continue healthy sources. Both metadata-only paths and malformed-source isolation have before/after regression coverage.

Validated together with current master's DV-dedup scheduling: retained tagged commits still invalidate rollups without re-minting dedup; missing history conservatively invalidates both. The combined all-feature run passed all 1,479 enabled tests, with lint and formatting checks passing.
