### PR TITLE
Preserve deletion vectors when resetting Delta scans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2963,7 +2963,7 @@ dependencies = [
 [[package]]
 name = "deltalake"
 version = "1.0.0"
-source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=a17379858779815fd93bac998910c9e506a6dc8d#a17379858779815fd93bac998910c9e506a6dc8d"
+source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=c6fec3f249fa4aad005eccd9c6d823d9ee99d050#c6fec3f249fa4aad005eccd9c6d823d9ee99d050"
 dependencies = [
  "buoyant_kernel 0.24.0",
  "ctor",
@@ -2974,7 +2974,7 @@ dependencies = [
 [[package]]
 name = "deltalake-aws"
 version = "1.0.0"
-source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=a17379858779815fd93bac998910c9e506a6dc8d#a17379858779815fd93bac998910c9e506a6dc8d"
+source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=c6fec3f249fa4aad005eccd9c6d823d9ee99d050#c6fec3f249fa4aad005eccd9c6d823d9ee99d050"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -2997,7 +2997,7 @@ dependencies = [
 [[package]]
 name = "deltalake-core"
 version = "1.0.0"
-source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=a17379858779815fd93bac998910c9e506a6dc8d#a17379858779815fd93bac998910c9e506a6dc8d"
+source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=c6fec3f249fa4aad005eccd9c6d823d9ee99d050#c6fec3f249fa4aad005eccd9c6d823d9ee99d050"
 dependencies = [
  "alloc-stdlib",
  "arrow",
@@ -3055,7 +3055,7 @@ dependencies = [
 [[package]]
 name = "deltalake-derive"
 version = "1.0.0"
-source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=a17379858779815fd93bac998910c9e506a6dc8d#a17379858779815fd93bac998910c9e506a6dc8d"
+source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=c6fec3f249fa4aad005eccd9c6d823d9ee99d050#c6fec3f249fa4aad005eccd9c6d823d9ee99d050"
 dependencies = [
  "convert_case 0.9.0",
  "itertools 0.14.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ regex = "1.11.1"
 # push, which busts cargo-chef's recipe.json and forces a full dependency
 # recompile in CI. Bump deliberately to pick up fork changes:
 #   cargo update -p deltalake --precise <new-sha>   (then update this rev)
-deltalake = { git = "https://github.com/tonyalaribe/delta-rs-timefusion.git", rev = "a17379858779815fd93bac998910c9e506a6dc8d", features = [
+deltalake = { git = "https://github.com/tonyalaribe/delta-rs-timefusion.git", rev = "c6fec3f249fa4aad005eccd9c6d823d9ee99d050", features = [
   "datafusion",
   "s3",
 ] }


### PR DESCRIPTION
Resetting a Delta physical scan after its first execution can return rows that its deletion vector removed. The scan consumed a mask shared by the plan and its clones; DataFusion reset_plan_states rebuilt the scan with that depleted mask. A real Delta fixture returns one survivor initially and all five physical rows after reset.

Pin delta-rs to c6fec3f249fa4aad005eccd9c6d823d9ee99d050. The fork keeps the mask unchanged and gives each scan execution its own per-file cursor. It preserves batch boundaries, trailing-mask padding, and physical row positions without copying whole masks per partition. Masks remain retained until the plan is dropped so resets can reuse them.

Validation in the fork: the supported-reset regression fails before the change and passes afterward; all 111 scan tests pass; Clippy passes with existing unrelated warnings. Three stale integration-test API calls were updated with the missing optional argument, and all three affected tests pass. Exploratory real byte-range partition tests through 64 partitions pass; no partition-specific behavior was changed.

This fixes the reproduced reset bug. The separately observed production scan/oracle count mismatch and sort-memory failures remain under investigation.

TimeFusion validation: all seven focused deletion-vector tests pass. Locked Cargo metadata resolves successfully, with only the four Delta source revisions changed in the lockfile. The full repository cargo lint alias also passes. PR CI is pending.
