### PR TITLE
Preserve physical row order for Delta deletion vectors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2200,7 +2200,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -2252,7 +2252,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2276,7 +2276,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2298,7 +2298,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -2323,7 +2323,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
 dependencies = [
  "futures",
  "log",
@@ -2333,7 +2333,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
 dependencies = [
  "arrow",
  "async-compression",
@@ -2368,7 +2368,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-arrow"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -2391,7 +2391,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2413,7 +2413,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2435,7 +2435,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2465,12 +2465,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
 
 [[package]]
 name = "datafusion-execution"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -2491,7 +2491,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -2513,7 +2513,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2524,7 +2524,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -2555,7 +2555,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2575,7 +2575,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2599,7 +2599,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -2623,7 +2623,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2654,7 +2654,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -2663,7 +2663,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -2673,7 +2673,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
 dependencies = [
  "arrow",
  "chrono",
@@ -2706,7 +2706,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2727,7 +2727,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-adapter"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2741,7 +2741,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
 dependencies = [
  "arrow",
  "chrono",
@@ -2757,7 +2757,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2775,7 +2775,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
 dependencies = [
  "arrow",
  "arrow-data",
@@ -2830,7 +2830,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
 dependencies = [
  "arrow",
  "chrono",
@@ -2856,7 +2856,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-common"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2866,7 +2866,7 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2881,7 +2881,7 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -2894,7 +2894,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=a442435c7a4781ea4cc5b9043e2f0634d603705a#a442435c7a4781ea4cc5b9043e2f0634d603705a"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -2963,7 +2963,7 @@ dependencies = [
 [[package]]
 name = "deltalake"
 version = "1.0.0"
-source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=c6fec3f249fa4aad005eccd9c6d823d9ee99d050#c6fec3f249fa4aad005eccd9c6d823d9ee99d050"
+source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=f9dac4665949539523dc5bdb16f86ac878fcd7d9#f9dac4665949539523dc5bdb16f86ac878fcd7d9"
 dependencies = [
  "buoyant_kernel 0.24.0",
  "ctor",
@@ -2974,7 +2974,7 @@ dependencies = [
 [[package]]
 name = "deltalake-aws"
 version = "1.0.0"
-source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=c6fec3f249fa4aad005eccd9c6d823d9ee99d050#c6fec3f249fa4aad005eccd9c6d823d9ee99d050"
+source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=f9dac4665949539523dc5bdb16f86ac878fcd7d9#f9dac4665949539523dc5bdb16f86ac878fcd7d9"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -2997,7 +2997,7 @@ dependencies = [
 [[package]]
 name = "deltalake-core"
 version = "1.0.0"
-source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=c6fec3f249fa4aad005eccd9c6d823d9ee99d050#c6fec3f249fa4aad005eccd9c6d823d9ee99d050"
+source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=f9dac4665949539523dc5bdb16f86ac878fcd7d9#f9dac4665949539523dc5bdb16f86ac878fcd7d9"
 dependencies = [
  "alloc-stdlib",
  "arrow",
@@ -3055,7 +3055,7 @@ dependencies = [
 [[package]]
 name = "deltalake-derive"
 version = "1.0.0"
-source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=c6fec3f249fa4aad005eccd9c6d823d9ee99d050#c6fec3f249fa4aad005eccd9c6d823d9ee99d050"
+source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=f9dac4665949539523dc5bdb16f86ac878fcd7d9#f9dac4665949539523dc5bdb16f86ac878fcd7d9"
 dependencies = [
  "convert_case 0.9.0",
  "itertools 0.14.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ regex = "1.11.1"
 # push, which busts cargo-chef's recipe.json and forces a full dependency
 # recompile in CI. Bump deliberately to pick up fork changes:
 #   cargo update -p deltalake --precise <new-sha>   (then update this rev)
-deltalake = { git = "https://github.com/tonyalaribe/delta-rs-timefusion.git", rev = "c6fec3f249fa4aad005eccd9c6d823d9ee99d050", features = [
+deltalake = { git = "https://github.com/tonyalaribe/delta-rs-timefusion.git", rev = "f9dac4665949539523dc5bdb16f86ac878fcd7d9", features = [
   "datafusion",
   "s3",
 ] }
@@ -257,41 +257,42 @@ pgwire = { path = "vendor/pgwire" }
 # arrow-pg/datafusion-pg-catalog from the same git workspace, so those need no
 # separate patch.
 datafusion-postgres = { git = "https://github.com/apitoolkit/datafusion-postgres.git", branch = "timefusion-df54" }
-# DataFusion 54.1 with SQL DEALLOCATE ALL and the existing UPDATE FROM support.
+# DataFusion 54.1 with positional Parquet scan protection, SQL DEALLOCATE ALL,
+# and the existing UPDATE FROM support.
 # Keep the workspace crates on one source so their public Rust types agree.
-datafusion = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
-datafusion-catalog = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
-datafusion-catalog-listing = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
-datafusion-common = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
-datafusion-common-runtime = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
-datafusion-datasource = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
-datafusion-datasource-arrow = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
-datafusion-datasource-csv = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
-datafusion-datasource-json = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
-datafusion-datasource-parquet = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
-datafusion-doc = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
-datafusion-execution = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
-datafusion-expr = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
-datafusion-expr-common = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
-datafusion-functions = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
-datafusion-functions-aggregate = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
-datafusion-functions-aggregate-common = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
-datafusion-functions-nested = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
-datafusion-functions-table = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
-datafusion-functions-window = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
-datafusion-functions-window-common = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
-datafusion-macros = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
-datafusion-optimizer = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
-datafusion-physical-expr = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
-datafusion-physical-expr-adapter = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
-datafusion-physical-expr-common = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
-datafusion-physical-optimizer = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
-datafusion-physical-plan = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
-datafusion-proto = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
-datafusion-proto-common = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
-datafusion-pruning = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
-datafusion-session = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
-datafusion-sql = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "a442435c7a4781ea4cc5b9043e2f0634d603705a" }
+datafusion = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
+datafusion-catalog = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
+datafusion-catalog-listing = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
+datafusion-common = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
+datafusion-common-runtime = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
+datafusion-datasource = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
+datafusion-datasource-arrow = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
+datafusion-datasource-csv = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
+datafusion-datasource-json = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
+datafusion-datasource-parquet = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
+datafusion-doc = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
+datafusion-execution = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
+datafusion-expr = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
+datafusion-expr-common = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
+datafusion-functions = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
+datafusion-functions-aggregate = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
+datafusion-functions-aggregate-common = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
+datafusion-functions-nested = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
+datafusion-functions-table = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
+datafusion-functions-window = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
+datafusion-functions-window-common = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
+datafusion-macros = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
+datafusion-optimizer = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
+datafusion-physical-expr = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
+datafusion-physical-expr-adapter = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
+datafusion-physical-expr-common = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
+datafusion-physical-optimizer = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
+datafusion-physical-plan = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
+datafusion-proto = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
+datafusion-proto-common = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
+datafusion-pruning = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
+datafusion-session = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
+datafusion-sql = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
 # tikv-jemalloc-sys 0.6.1 vendored with a single build.rs delta: honour
 # `JEMALLOC_SYS_PROF_BACKTRACE` so the heap profiler can be built with a working
 # unwinder (`--enable-prof-libunwind`). Upstream passes `--enable-prof` alone and

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -19439,6 +19439,73 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn dv_scan_preserves_physical_positions_under_file_repartitioning() -> Result<()> {
+        use datafusion::arrow::{
+            array::Int32Array,
+            datatypes::{DataType as ArrowType, Field, Schema},
+        };
+        use deltalake::delta_datafusion::TableProviderBuilder;
+        use deltalake::kernel::{DataType, PrimitiveType, StructField, transaction::CommitBuilder};
+        use deltalake::operations::deletion_vectors::{FileDeletion, write_deletion_vectors};
+
+        let store = Arc::new(object_store::memory::InMemory::new());
+        let url = Url::parse("memory:///dv_physical_positions")?;
+        let mut table = DeltaTableBuilder::from_url(url.clone())?
+            .with_storage_backend(store, url)
+            .build()?
+            .create()
+            .with_columns(vec![StructField::new("id", DataType::Primitive(PrimitiveType::Integer), true)])
+            .with_configuration(HashMap::from([("delta.enableDeletionVectors".to_string(), Some("true".to_string()))]))
+            .await?;
+        let schema = Arc::new(Schema::new(vec![Field::new("id", ArrowType::Int32, true)]));
+        table = table.write(vec![RecordBatch::try_new(schema, vec![Arc::new(Int32Array::from(vec![1, 2, 3, 4])) as _])?]).await?;
+        let table_ref = Arc::new(RwLock::new(table.clone()));
+        let targets = live_adds(&table_ref).await;
+        assert_eq!(targets.len(), 1);
+        let log_store = table.log_store();
+        let actions =
+            write_deletion_vectors(log_store.as_ref(), log_store.root_url(), vec![FileDeletion { add: targets[0].clone(), deleted_indexes: vec![1] }]).await?;
+        let committed = CommitBuilder::default()
+            .with_actions(actions)
+            .build(Some(table.snapshot()?), log_store.clone(), deltalake::protocol::DeltaOperation::Delete { predicate: Some("id = 2".into()) })
+            .await?;
+        table.state = Some(committed.snapshot().clone());
+        let provider = TableProviderBuilder::default()
+            .with_log_store(log_store)
+            .with_eager_snapshot(Arc::new(table.snapshot()?.snapshot().clone()))
+            .with_file_column("file_id")
+            .with_row_index_column("row_ordinal")
+            .build()
+            .await?;
+        // Force the optimizer's splitting threshold below this tiny fixture.
+        let mut config = datafusion::prelude::SessionConfig::new().with_batch_size(1).with_target_partitions(4);
+        config.options_mut().optimizer.repartition_file_min_size = 0;
+        let ctx = datafusion::prelude::SessionContext::new_with_config(config);
+        ctx.register_table("dv", Arc::new(provider))?;
+        let plan = ctx.sql("SELECT id, row_ordinal FROM dv").await?.create_physical_plan().await?;
+        let mut pending = vec![Arc::clone(&plan)];
+        let mut files = 0;
+        while let Some(node) = pending.pop() {
+            if let Some(source) = node.downcast_ref::<datafusion_datasource::source::DataSourceExec>()
+                && let Some(scan) = source.data_source().downcast_ref::<datafusion_datasource::file_scan_config::FileScanConfig>()
+            {
+                for file in scan.file_groups.iter().flat_map(|group| group.iter()) {
+                    assert!(file.range.is_none(), "deletion masks and physical ordinals require whole-file scans");
+                    files += 1;
+                }
+            }
+            pending.extend(node.children().into_iter().cloned());
+        }
+        assert!(files > 0, "must inspect the actual Parquet scan");
+        let batches = datafusion::physical_plan::collect(plan, ctx.task_ctx()).await?;
+        assert_eq!(
+            datafusion::arrow::util::pretty::pretty_format_batches(&batches)?.to_string(),
+            "+----+-------------+\n| id | row_ordinal |\n+----+-------------+\n| 1  | 1           |\n| 3  | 3           |\n| 4  | 4           |\n+----+-------------+"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn wave_rejects_a_superseded_deletion_vector() -> Result<()> {
         use datafusion::arrow::{
             array::Int32Array,


### PR DESCRIPTION
Delta applies deletion vectors and assigns row ordinals using physical file positions. DataFusion can split a Parquet file into byte ranges below DeltaScan and coalesce those ranges in a different order. Deleted rows can then reappear, and maintenance scans disagree with their count oracle.

Pin DataFusion and Delta forks that prevent file splitting when deletion masks or physical row ordinals are required. Ordinary scans retain the existing repartitioning behavior, and separate files can still scan in parallel.

A frozen production file reproduced 49,784 scanned rows versus 49,492 independently verified visible rows. With these changes, two scans returned exactly the expected 49,492 rows and physical row ordinals. A portable Delta regression fails before the fix and passes afterward; all 112 Delta scan tests pass against the published DataFusion revision. DataFusion's full Clippy, standard lint, Parquet tests, core/CLI tests, and all 473 SQL logic test files pass.

TimeFusion now includes a four-row in-memory regression that forces the optimizer splitting threshold, checks whole-file scanning, and verifies exact surviving row ordinals. The same test fails against the previous pins and passes against the new pins.

Fork changes: [DataFusion file-splitting control](https://github.com/tonyalaribe/datafusion/commit/f903e21147c4172294fb8befdfe1d5e361d4fc38) and [Delta positional-scan protection](https://github.com/tonyalaribe/delta-rs-timefusion/commit/f9dac4665949539523dc5bdb16f86ac878fcd7d9).

TimeFusion validation: formatting, full lint, and all 1,194 library tests pass on the final locked dependency graph (8 existing tests skipped). The lockfile changes only 37 intended dependency sources. CI will validate the complete integration before deployment.
