### PR TITLE
Preserve deletion-vector positions in count and ordinary scans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2963,7 +2963,7 @@ dependencies = [
 [[package]]
 name = "deltalake"
 version = "1.0.0"
-source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=f9dac4665949539523dc5bdb16f86ac878fcd7d9#f9dac4665949539523dc5bdb16f86ac878fcd7d9"
+source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=8724b0c3b59bad831e87840edb450e4cc80ada73#8724b0c3b59bad831e87840edb450e4cc80ada73"
 dependencies = [
  "buoyant_kernel 0.24.0",
  "ctor",
@@ -2974,7 +2974,7 @@ dependencies = [
 [[package]]
 name = "deltalake-aws"
 version = "1.0.0"
-source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=f9dac4665949539523dc5bdb16f86ac878fcd7d9#f9dac4665949539523dc5bdb16f86ac878fcd7d9"
+source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=8724b0c3b59bad831e87840edb450e4cc80ada73#8724b0c3b59bad831e87840edb450e4cc80ada73"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -2997,7 +2997,7 @@ dependencies = [
 [[package]]
 name = "deltalake-core"
 version = "1.0.0"
-source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=f9dac4665949539523dc5bdb16f86ac878fcd7d9#f9dac4665949539523dc5bdb16f86ac878fcd7d9"
+source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=8724b0c3b59bad831e87840edb450e4cc80ada73#8724b0c3b59bad831e87840edb450e4cc80ada73"
 dependencies = [
  "alloc-stdlib",
  "arrow",
@@ -3055,7 +3055,7 @@ dependencies = [
 [[package]]
 name = "deltalake-derive"
 version = "1.0.0"
-source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=f9dac4665949539523dc5bdb16f86ac878fcd7d9#f9dac4665949539523dc5bdb16f86ac878fcd7d9"
+source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=8724b0c3b59bad831e87840edb450e4cc80ada73#8724b0c3b59bad831e87840edb450e4cc80ada73"
 dependencies = [
  "convert_case 0.9.0",
  "itertools 0.14.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ regex = "1.11.1"
 # push, which busts cargo-chef's recipe.json and forces a full dependency
 # recompile in CI. Bump deliberately to pick up fork changes:
 #   cargo update -p deltalake --precise <new-sha>   (then update this rev)
-deltalake = { git = "https://github.com/tonyalaribe/delta-rs-timefusion.git", rev = "f9dac4665949539523dc5bdb16f86ac878fcd7d9", features = [
+deltalake = { git = "https://github.com/tonyalaribe/delta-rs-timefusion.git", rev = "8724b0c3b59bad831e87840edb450e4cc80ada73", features = [
   "datafusion",
   "s3",
 ] }

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -19482,26 +19482,34 @@ mod tests {
         config.options_mut().optimizer.repartition_file_min_size = 0;
         let ctx = datafusion::prelude::SessionContext::new_with_config(config);
         ctx.register_table("dv", Arc::new(provider))?;
-        let plan = ctx.sql("SELECT id, row_ordinal FROM dv").await?.create_physical_plan().await?;
-        let mut pending = vec![Arc::clone(&plan)];
-        let mut files = 0;
-        while let Some(node) = pending.pop() {
-            if let Some(source) = node.downcast_ref::<datafusion_datasource::source::DataSourceExec>()
-                && let Some(scan) = source.data_source().downcast_ref::<datafusion_datasource::file_scan_config::FileScanConfig>()
-            {
-                for file in scan.file_groups.iter().flat_map(|group| group.iter()) {
-                    assert!(file.range.is_none(), "deletion masks and physical ordinals require whole-file scans");
-                    files += 1;
+        for (query, expected) in [
+            ("SELECT id FROM dv", "+----+\n| id |\n+----+\n| 1  |\n| 3  |\n| 4  |\n+----+"),
+            (
+                "SELECT id, row_ordinal FROM dv",
+                "+----+-------------+\n| id | row_ordinal |\n+----+-------------+\n| 1  | 1           |\n| 3  | 3           |\n| 4  | 4           |\n+----+-------------+",
+            ),
+        ] {
+            let plan = ctx.sql(query).await?.create_physical_plan().await?;
+            let mut pending = vec![Arc::clone(&plan)];
+            let mut files = 0;
+            while let Some(node) = pending.pop() {
+                if let Some(source) = node.downcast_ref::<datafusion_datasource::source::DataSourceExec>()
+                    && let Some(scan) = source.data_source().downcast_ref::<datafusion_datasource::file_scan_config::FileScanConfig>()
+                {
+                    for file in scan.file_groups.iter().flat_map(|group| group.iter()) {
+                        assert!(file.range.is_none(), "deletion masks and physical ordinals require whole-file scans");
+                        files += 1;
+                    }
                 }
+                pending.extend(node.children().into_iter().cloned());
             }
-            pending.extend(node.children().into_iter().cloned());
+            assert!(files > 0, "must inspect the actual Parquet scan");
+            let batches = datafusion::physical_plan::collect(plan, ctx.task_ctx()).await?;
+            assert_eq!(datafusion::arrow::util::pretty::pretty_format_batches(&batches)?.to_string(), expected);
         }
-        assert!(files > 0, "must inspect the actual Parquet scan");
-        let batches = datafusion::physical_plan::collect(plan, ctx.task_ctx()).await?;
-        assert_eq!(
-            datafusion::arrow::util::pretty::pretty_format_batches(&batches)?.to_string(),
-            "+----+-------------+\n| id | row_ordinal |\n+----+-------------+\n| 1  | 1           |\n| 3  | 3           |\n| 4  | 4           |\n+----+-------------+"
-        );
+        let count = ctx.sql("SELECT COUNT(*) FROM dv WHERE id >= 2").await?.collect().await?;
+        let count = count[0].column(0).as_any().downcast_ref::<datafusion::arrow::array::Int64Array>().expect("count is int64");
+        assert_eq!(count.value(0), 2, "filtered count must exclude the deleted row");
         Ok(())
     }
 


### PR DESCRIPTION
COUNT and ordinary projections can still split deletion-vector scans across byte ranges or execution partitions. Each partition restarts the positional deletion mask, producing incorrect rows and causing maintenance count/scan mismatches. Pin the Delta fork that uses actual DV presence to preserve physical file order and require a single input partition.

The previous guard protected retained row ordinals, but read its DV signal from file tuples whose mask fields were always empty. Extend the application regression to cover ordinary projection, retained ordinals, and filtered COUNT. The lockfile changes only the four Delta source revisions.

Validation:
- Reproduced on a frozen production file: COUNT 23,707 versus projected 19,138. Independent PyArrow/roaring oracle confirms 19,138 visible rows.
- Baseline small regression fails; the candidate passes all 112 Delta scan tests.
- Candidate passes two frozen production fixtures twice each: 19,138 and 49,492 rows, with exact independent physical row ordinal equality.
- Delta Clippy completed with existing warnings; no warning suppressions or weakened types added.
- TimeFusion formatting, diff checks, expanded application regression, and cargo lint passed. All 1,195 library tests passed (8 existing skips). All CI checks, including E2E and Rust CodeQL, passed.

Fork: https://github.com/tonyalaribe/delta-rs-timefusion/commit/8724b0c3b59bad831e87840edb450e4cc80ada73

Review notes: the fork requires a single input partition only for actual deletion vectors or retained physical row ordinals. Other scans retain parallelism. The filtered COUNT regression asserts the observable result; ordinary and ordinal projections additionally inspect whole-file scans, and both production fixtures independently validate COUNT and exact projected ordinals.
