### PR TITLE
fix: invalidate rollups built with obsolete source visibility

### DIFF
--- a/src/database/maintain.rs
+++ b/src/database/maintain.rs
@@ -2617,18 +2617,6 @@ impl Database {
                     continue;
                 }
                 if derived {
-                    // A current coverage range cannot authorize files from an
-                    // older materialization generation that overlap that range.
-                    if !add
-                        .tags
-                        .as_ref()
-                        .and_then(|tags| tags.get(crate::maintenance_coordinator::TAG_GENERATION))
-                        .and_then(Option::as_ref)
-                        .is_some_and(|generation| base_generations.contains(generation))
-                    {
-                        skipped_generation += 1;
-                        continue;
-                    }
                     // OVERLAP, not containment. A base file is tagged with the
                     // slice of the UNIT that wrote it, and that unit's width is
                     // unrelated to this one's: the backfill writes day-wide base
@@ -2676,24 +2664,11 @@ impl Database {
                                 continue;
                             }
                         }
-                        // No slice tags — a file written before tagging existed.
-                        // Prune it on its OWN timestamp statistics, exactly as the
-                        // base branch above already does, instead of dropping it.
-                        //
-                        // Dropping it was silent and permanent: prod 2026-08-18
-                        // logged `maintenance_rollup_untagged_input` 15 times in 20
-                        // minutes, and EVERY rollup published in that window was a
-                        // derived unit with rows=0. The 1h tier — the one 14d/30d
-                        // queries read — sat at 6 days while the 1m tier had 22,
-                        // because history written before tagging can never reach it.
-                        //
-                        // Safe because this is pruning, not correctness: the
-                        // candidate set is already scoped to this (project, date)
-                        // partition, and the aggregation SQL filters `project_id`,
-                        // `date` and the timestamp range itself. A file kept here
-                        // that does not belong costs IO; a file dropped here loses
-                        // its rows for good. Missing statistics therefore mean
-                        // KEEP, never skip.
+                        // Without slice tags, prune unrelated files by their own
+                        // timestamp statistics. Missing statistics retain a candidate
+                        // for generation validation below. Dropping overlapping
+                        // inputs and publishing an empty derived cell was the #169
+                        // failure; unknown generations now require base rebuilding.
                         _ => {
                             untagged_inputs = untagged_inputs.saturating_add(1);
                             if let Ok(Some(stats)) = add.get_stats()
@@ -2706,6 +2681,18 @@ impl Database {
                                 continue;
                             }
                         }
+                    }
+                    // A current coverage range cannot authorize files from an
+                    // older materialization generation that overlap that range.
+                    if !add
+                        .tags
+                        .as_ref()
+                        .and_then(|tags| tags.get(crate::maintenance_coordinator::TAG_GENERATION))
+                        .and_then(Option::as_ref)
+                        .is_some_and(|generation| base_generations.contains(generation))
+                    {
+                        skipped_generation += 1;
+                        continue;
                     }
                 }
                 let decoded = estimated_decoded_bytes(add.size);
@@ -2744,31 +2731,51 @@ impl Database {
             stats.rollup_base_file_skipped_tag_range.fetch_add(skipped_tag_range, Relaxed);
         }
         if skipped_generation > 0 {
+            crate::observability::maintenance_stats().rollup_base_file_skipped_generation.fetch_add(skipped_generation, Relaxed);
             warn!(source = %key.source, target = %key.physical_table, project_id = %key.project_id, skipped_generation,
                 event = "maintenance_rollup_obsolete_inputs", "derived rollup refused obsolete base materializations");
         }
         if untagged_inputs > 0 {
             crate::observability::maintenance_stats().rollup_untagged_inputs.fetch_add(untagged_inputs, std::sync::atomic::Ordering::Relaxed);
-            // Since #169 these files are KEPT — pruned on their own timestamp
-            // statistics rather than discarded — so this is no longer a report of
-            // data that can never arrive. It now measures how much of the base
-            // tier predates tagging and is therefore being selected by the wider,
-            // stats-only test. Left at `warn` while that population is still
-            // large; it should shrink as those partitions are rewritten.
-            //
-            // The old text said "their rows can never reach this tier", which was
-            // true when it was written and false the moment #169 shipped. Stale
-            // log text is worse than none: this exact line was the evidence used
-            // to diagnose the empty coarse tier, and it would have been read the
-            // same way again.
+            // Preserve visibility into tag loss even when its generation is
+            // also missing. Such files need a base rebuild before derivation;
+            // a timestamp range alone cannot prove current reader semantics.
             warn!(
                 table = %key.physical_table,
                 project_id = %key.project_id,
                 slice_start = key.slice.start_micros,
                 untagged_inputs,
                 event = "maintenance_rollup_untagged_input",
-                "base files carry no slice tags; selected on timestamp statistics instead"
+                "base files carry no slice tags; checked by timestamp range and materialization generation"
             );
+        }
+        if skipped_generation > 0 {
+            // Excluding an unverified file is not evidence that its rows were
+            // empty. Rebuild this base range from its source and retry the
+            // derived unit, even if an in-memory coverage claim still spans it.
+            let base_spec = source_schema
+                .rollups
+                .iter()
+                .find(|candidate| candidate.table_name(&key.source) == from)
+                .ok_or_else(|| anyhow::anyhow!("derived rollup {} has no base spec", key.physical_table))?;
+            let base_key = crate::maintenance_coordinator::TaskKey {
+                physical_table: from.clone(),
+                operation: if base_spec.derive_from.is_some() {
+                    crate::maintenance_coordinator::Operation::DerivedRollup
+                } else {
+                    crate::maintenance_coordinator::Operation::BaseRollup
+                },
+                ..key.clone()
+            };
+            let now = crate::support::now_micros();
+            {
+                let mut journal = self.journal();
+                journal.enqueue(base_key, now, MAX_DECODED_BYTES, u64::try_from(now.div_euclid(1_000)).unwrap_or_default());
+                journal.checkpoint()?;
+            }
+            let attempts = self.journal().attempts(&key);
+            retry("base_generation_unverified".to_owned(), std::time::Duration::from_secs(60u64 << attempts.min(5)))?;
+            return Ok(true);
         }
         // A DERIVED unit's witness describes the RAW partition, but its INPUT is
         // the base tier — witness table != input table, which is the one
@@ -4621,10 +4628,11 @@ impl Database {
         // more than any older one and the bound costs nothing it would have got.
         // Re-running hourly advances the frontier: a republished slice carries a
         // witness, leaves this list, and the next pass takes the next `BOUND`.
-        let mut ordered: Vec<_> = slices.iter().collect();
+        let mut ordered: Vec<_> = slices.iter().collect::<HashSet<_>>().into_iter().collect();
         ordered.sort_unstable_by_key(|(_, slice)| std::cmp::Reverse(slice.start_micros));
         const BOUND: usize = 512;
-        let queued = ordered.len().min(BOUND);
+        let total = ordered.len();
+        let queued = total.min(BOUND);
         let mut journal = self.journal();
         for (project_id, slice) in ordered.into_iter().take(BOUND) {
             let key = TaskKey { physical_table: target.to_owned(), source: source.to_owned(), project_id: project_id.clone(), slice: *slice, operation };
@@ -4637,7 +4645,7 @@ impl Database {
             queued,
             // Named, never silent: a cap that does not say what it dropped reads
             // as "everything is queued" and hides the real size of the backlog.
-            deferred = slices.len().saturating_sub(queued),
+            deferred = total.saturating_sub(queued),
             ?reason,
             event = "rollup_unverifiable_rebuild_queued",
             "unverifiable slices queued for republish, newest first"
@@ -4679,6 +4687,7 @@ impl Database {
                     measures: entry.measures.as_ref().map(|names| names.iter().cloned().collect()),
                 };
                 if !Self::rollup_generation_current(&source, &table_name, &project_id, &date, &coverage) {
+                    crate::observability::maintenance_stats().rollup_ledger_seed_rejected_generation.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                     continue;
                 }
                 self.rollup_slice_coverage.insert((project_id.clone(), source.clone(), table_name.clone(), entry.start_micros, entry.end_micros), coverage);
@@ -5034,20 +5043,35 @@ impl Database {
                 if publication.source_rows.is_none() {
                     witnessless.push((key.project_id.clone(), key.slice));
                 }
-                self.rollup_slice_coverage.insert(
-                    (key.project_id.clone(), source.to_string(), target.clone(), key.slice.start_micros, key.slice.end_micros),
-                    RollupCoverage {
-                        source_fp: publication.source_fingerprint,
-                        source_epoch: None,
-                        generation: publication.generation.clone(),
-                        source_rows: publication.source_rows,
-                        covered_through: key.slice.end_micros,
-                        // The journal records no measure evidence, so this route
-                        // can only say "unproven". Harmless for a slice that also
-                        // has tags: the tagged loop below overwrites this entry.
-                        measures: None,
-                    },
+                let Some(date) = chrono::DateTime::from_timestamp_micros(key.slice.start_micros).map(|time| time.date_naive().to_string()) else { continue };
+                let identity = (
+                    key.project_id.clone(),
+                    key.slice.start_micros,
+                    key.slice.end_micros,
+                    publication.generation.clone(),
+                    publication.source_fingerprint,
+                    publication.source_rows,
                 );
+                let coverage = RollupCoverage {
+                    source_fp: publication.source_fingerprint,
+                    source_epoch: None,
+                    generation: publication.generation.clone(),
+                    source_rows: publication.source_rows,
+                    covered_through: key.slice.end_micros,
+                    // The journal alone has no measure proof. Use matching file
+                    // evidence when available, including partial measure sets.
+                    measures: measures_by_identity.get(&identity).and_then(Option::as_ref).map(|names| names.iter().cloned().collect()),
+                };
+                if !Self::rollup_generation_current(source, &target, &key.project_id, &date, &coverage) {
+                    // The tagged loop queues identities it sees. A journal-only
+                    // publication still needs rebuilding when the tags are absent.
+                    if !measures_by_identity.contains_key(&identity) {
+                        obsolete_generations.push((key.project_id.clone(), key.slice));
+                    }
+                    continue;
+                }
+                self.rollup_slice_coverage
+                    .insert((key.project_id.clone(), source.to_string(), target.clone(), key.slice.start_micros, key.slice.end_micros), coverage);
                 recovered += 1;
             }
             if !tagged.is_empty() {

--- a/src/database/maintain.rs
+++ b/src/database/maintain.rs
@@ -3,6 +3,12 @@
 use super::*;
 use tap::Tap;
 
+#[derive(Clone, Copy, Debug)]
+enum RollupRebuildReason {
+    MissingRowWitness,
+    ObsoleteGeneration,
+}
+
 /// Estimated decoded (in-memory) bytes for a Parquet file of `compressed_size` on
 /// disk — a fixed 12x compression-ratio guess used for budgeting, not measurement.
 /// One tier's contribution to a fleet contiguity gauge, or `None` to abstain.
@@ -2517,6 +2523,7 @@ impl Database {
         // Tagged base files the derived selection loop refuses, by reason. See
         // the counters' declarations and the skip site below.
         let (mut skipped_tag_project, mut skipped_tag_range) = (0u64, 0u64);
+        let mut skipped_generation = 0u64;
         // Read STRICTLY BEFORE the snapshot below, and evaluated after it — see
         // the derived base-coverage gate. Coverage is inserted only AFTER the
         // base unit's Delta commit and only ever grows, so a range collected
@@ -2532,15 +2539,24 @@ impl Database {
         // only claim a measure its base cells proved — see
         // `materialized_measures`.
         let mut base_evidence = None;
+        let mut base_generations = HashSet::new();
         let base_covered: Vec<(i64, i64)> = if derived {
             let cells = self
                 .rollup_slice_coverage
                 .iter()
                 .filter(|entry| {
                     let (project, source, table, start, end) = entry.key();
-                    *project == key.project_id && *source == key.source && *table == from && key.slice.overlaps(*start, *end)
+                    *project == key.project_id
+                        && *source == key.source
+                        && *table == from
+                        && key.slice.overlaps(*start, *end)
+                        && chrono::DateTime::from_timestamp_micros(*start)
+                            .is_some_and(|time| Self::rollup_generation_current(source, table, project, &time.date_naive().to_string(), entry.value()))
                 })
-                .map(|entry| ((entry.key().3, entry.key().4), entry.value().measures.clone()))
+                .map(|entry| {
+                    base_generations.insert(entry.value().generation.clone());
+                    ((entry.key().3, entry.key().4), entry.value().measures.clone())
+                })
                 .collect::<Vec<_>>();
             base_evidence = crate::rollup::base_measure_evidence(spec, cells.iter().map(|(_, measures)| measures.as_ref()));
             cells.into_iter().map(|(span, _)| span).collect()
@@ -2601,6 +2617,18 @@ impl Database {
                     continue;
                 }
                 if derived {
+                    // A current coverage range cannot authorize files from an
+                    // older materialization generation that overlap that range.
+                    if !add
+                        .tags
+                        .as_ref()
+                        .and_then(|tags| tags.get(crate::maintenance_coordinator::TAG_GENERATION))
+                        .and_then(Option::as_ref)
+                        .is_some_and(|generation| base_generations.contains(generation))
+                    {
+                        skipped_generation += 1;
+                        continue;
+                    }
                     // OVERLAP, not containment. A base file is tagged with the
                     // slice of the UNIT that wrote it, and that unit's width is
                     // unrelated to this one's: the backfill writes day-wide base
@@ -2714,6 +2742,10 @@ impl Database {
             let stats = crate::observability::maintenance_stats();
             stats.rollup_base_file_skipped_tag_project.fetch_add(skipped_tag_project, Relaxed);
             stats.rollup_base_file_skipped_tag_range.fetch_add(skipped_tag_range, Relaxed);
+        }
+        if skipped_generation > 0 {
+            warn!(source = %key.source, target = %key.physical_table, project_id = %key.project_id, skipped_generation,
+                event = "maintenance_rollup_obsolete_inputs", "derived rollup refused obsolete base materializations");
         }
         if untagged_inputs > 0 {
             crate::observability::maintenance_stats().rollup_untagged_inputs.fetch_add(untagged_inputs, std::sync::atomic::Ordering::Relaxed);
@@ -4567,8 +4599,9 @@ impl Database {
     /// fully-covered day says "republish me" — the claim is unverifiable, not
     /// missing. Enqueue is idempotent (keyed), so re-running hourly re-queues only
     /// what has not drained.
-    fn enqueue_witnessless_rebuilds(
-        &self, source: &str, spec: &crate::schema::RollupSpec, target: &str, slices: &[(String, crate::maintenance_coordinator::TimeSlice)],
+    fn enqueue_unverifiable_rebuilds(
+        &self, source: &str, spec: &crate::schema::RollupSpec, target: &str, reason: RollupRebuildReason,
+        slices: &[(String, crate::maintenance_coordinator::TimeSlice)],
     ) {
         use crate::maintenance_coordinator::{MAX_DECODED_BYTES, Operation, TaskKey};
         if slices.is_empty() {
@@ -4605,8 +4638,9 @@ impl Database {
             // Named, never silent: a cap that does not say what it dropped reads
             // as "everything is queued" and hides the real size of the backlog.
             deferred = slices.len().saturating_sub(queued),
-            event = "rollup_witnessless_rebuild_queued",
-            "slices predating the row witness cannot be verified and were queued for republish, newest first"
+            ?reason,
+            event = "rollup_unverifiable_rebuild_queued",
+            "unverifiable slices queued for republish, newest first"
         );
     }
 
@@ -4627,28 +4661,27 @@ impl Database {
     /// attempt to route at all. The ledger already holds that answer durably, so
     /// routing can be correct from the first query after boot.
     ///
-    /// Sound only because the ledger records exactly the slices that passed the
-    /// read path's own filters — see `record_readable_coverage`. It seeds rather
-    /// than replaces: the replay still runs, still verifies, and overwrites
-    /// anything here, so a stale ledger costs one interval of narrower coverage
-    /// and never a wrong answer.
+    /// Revalidate materialization generations before restoring coverage: a
+    /// ledger accepted by an older reader does not prove the current semantics.
+    /// Delta tag recovery still runs and replaces the restored evidence.
     pub fn seed_routing_from_ledger(&self) -> usize {
         use crate::storage::CoverageLedger as _;
         let mut seeded = 0usize;
         for cell in self.coverage_ledger.cells() {
-            let (source, project_id, table_name, _date) = cell.clone();
+            let (source, project_id, table_name, date) = cell.clone();
             for entry in self.coverage_ledger.coverage(&cell) {
-                self.rollup_slice_coverage.insert(
-                    (project_id.clone(), source.clone(), table_name.clone(), entry.start_micros, entry.end_micros),
-                    RollupCoverage {
-                        source_fp: entry.source_fingerprint,
-                        source_epoch: None,
-                        generation: entry.generation.clone(),
-                        source_rows: entry.source_rows.and_then(|rows| u64::try_from(rows).ok()),
-                        covered_through: entry.end_micros,
-                        measures: entry.measures.as_ref().map(|names| names.iter().cloned().collect()),
-                    },
-                );
+                let coverage = RollupCoverage {
+                    source_fp: entry.source_fingerprint,
+                    source_epoch: None,
+                    generation: entry.generation.clone(),
+                    source_rows: entry.source_rows.and_then(|rows| u64::try_from(rows).ok()),
+                    covered_through: entry.end_micros,
+                    measures: entry.measures.as_ref().map(|names| names.iter().cloned().collect()),
+                };
+                if !Self::rollup_generation_current(&source, &table_name, &project_id, &date, &coverage) {
+                    continue;
+                }
+                self.rollup_slice_coverage.insert((project_id.clone(), source.clone(), table_name.clone(), entry.start_micros, entry.end_micros), coverage);
                 seeded += 1;
             }
         }
@@ -4946,6 +4979,7 @@ impl Database {
             // the general queue they compete with ~7,000 other units behind a restart
             // cadence measured in tens of minutes. Queue them explicitly instead.
             let mut witnessless: Vec<(String, crate::maintenance_coordinator::TimeSlice)> = Vec::new();
+            let mut obsolete_generations = Vec::new();
             // The BACKLOG comes from the Delta tags, which are durable and unaffected
             // by journal state. Counting it from `published_rollups` instead made the
             // gauge lie the moment it worked: enqueueing a slice flips its task off
@@ -5067,6 +5101,7 @@ impl Database {
                     if crate::rollup::generation_id(spec, source, &project_id, &date, source_fp, restrict.as_deref()) != generation {
                         fate(UnverifiableFate::StaleGeneration);
                         stale_generation += 1;
+                        obsolete_generations.push((project_id.clone(), slice));
                         continue;
                     }
                     if source_rows.is_none() {
@@ -5105,11 +5140,13 @@ impl Database {
                     recovered += 1;
                 }
                 self.record_readable_coverage(source, &target, readable);
-                self.enqueue_witnessless_rebuilds(source, spec, &target, &witnessless);
+                self.enqueue_unverifiable_rebuilds(source, spec, &target, RollupRebuildReason::MissingRowWitness, &witnessless);
+                self.enqueue_unverifiable_rebuilds(source, spec, &target, RollupRebuildReason::ObsoleteGeneration, &obsolete_generations);
                 self.recover_date_coverage(source, &target).await;
                 continue;
             }
-            self.enqueue_witnessless_rebuilds(source, spec, &target, &witnessless);
+            self.enqueue_unverifiable_rebuilds(source, spec, &target, RollupRebuildReason::MissingRowWitness, &witnessless);
+            self.enqueue_unverifiable_rebuilds(source, spec, &target, RollupRebuildReason::ObsoleteGeneration, &obsolete_generations);
             self.recover_date_coverage(source, &target).await;
             if !published.is_empty() {
                 continue;

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -13614,7 +13614,7 @@ mod tests {
                 "fixture must persist an obsolete generation"
             );
             publication.generation = coverage.generation.clone();
-            assert!(db.journal().publish(&key, publication));
+            assert!(db.journal().publish(&key, publication.clone()));
             let mut actions = Vec::new();
             for mut add in adds {
                 actions.push(Action::Remove(remove_for_add(&add, false)));
@@ -13654,6 +13654,49 @@ mod tests {
             4,
             "rebuilt rollup agrees with the four source rows"
         );
+
+        // A rewrite that loses all tags cannot turn a nonempty base into a
+        // trusted empty derived publication. It must request a base rebuild.
+        {
+            let mut table = tier.read().await.clone();
+            let store = table.log_store().object_store(None);
+            #[allow(deprecated)]
+            let adds: Vec<_> = table.snapshot()?.log_data().iter().map(|file| file.add_action()).collect();
+            let file_count = adds.len();
+            assert!(file_count > 0);
+            let mut actions = Vec::new();
+            for mut add in adds {
+                actions.push(Action::Remove(remove_for_add(&add, false)));
+                let path = format!("{}-untagged.parquet", add.path.trim_end_matches(".parquet"));
+                store.copy(&deltalake::Path::from(add.path.clone()), &deltalake::Path::from(path.clone())).await?;
+                add.path = path;
+                add.tags = None;
+                add.data_change = false;
+                actions.push(Action::Add(add));
+            }
+            let op = deltalake::protocol::DeltaOperation::Write { mode: deltalake::protocol::SaveMode::Append, partition_by: None, predicate: None };
+            let finalized = CommitBuilder::default().with_actions(actions).build(Some(table.snapshot()? as &dyn TableReference), table.log_store(), op).await?;
+            table.state = Some(finalized.snapshot());
+            assert_eq!(table.snapshot()?.log_data().iter().count(), file_count);
+            *tier.write().await = table;
+        }
+        let missing_tags = db.run_unit_once("otel_logs_and_spans", &project, day, Operation::DerivedRollup, 24, 0).await?;
+        assert_eq!(missing_tags.state, Some(TaskState::Retry), "missing generation evidence must not silently drop base rows");
+        assert_eq!(db.journal().tasks().find(|task| task.key == key).unwrap().state, TaskState::Pending, "the refused input must trigger base rebuilding");
+        assert!(db.journal().publish(&key, publication));
+        assert_eq!(db.journal().tasks().find(|task| task.key == key).unwrap().state, TaskState::Complete);
+        db.recover_rollup_coverage("otel_logs_and_spans").await?;
+        assert_eq!(
+            db.journal().tasks().find(|task| task.key == key).unwrap().state,
+            TaskState::Pending,
+            "an obsolete journal-only publication must also be requeued"
+        );
+        db.run_unit_once("otel_logs_and_spans", &project, day, Operation::BaseRollup, 24, 0).await?;
+        let repaired = db.run_unit_once("otel_logs_and_spans", &project, day, Operation::DerivedRollup, 24, 0).await?;
+        assert_eq!(repaired.state, Some(TaskState::Complete), "base rebuilding must unblock the derived tier");
+        let derived_table = schema.rollups.iter().find(|spec| spec.derive_from.is_some()).unwrap().table_name("otel_logs_and_spans");
+        let batches = ctx.sql(&format!("SELECT SUM(request_count) FROM {derived_table} WHERE project_id='{project}'")).await?.collect().await?;
+        assert_eq!(batches[0].column(0).as_any().downcast_ref::<arrow::array::Int64Array>().unwrap().value(0), 4);
 
         Ok(())
     }

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -4363,6 +4363,14 @@ impl Database {
         Ok(built)
     }
 
+    fn rollup_generation_current(source: &str, target: &str, project: &str, date: &str, coverage: &RollupCoverage) -> bool {
+        let Some(spec) = get_schema(source).and_then(|schema| schema.rollups.iter().find(|spec| spec.table_name(source) == target)) else {
+            return false;
+        };
+        let measures = coverage.measures.as_ref().map(|names| names.iter().cloned().collect::<Vec<_>>());
+        coverage.generation == crate::rollup::generation_id(spec, source, project, date, coverage.source_fp, measures.as_deref())
+    }
+
     pub(crate) async fn rollup_sql(
         &self, logical_plan: &datafusion::logical_expr::LogicalPlan, session: &datafusion::execution::context::SessionState,
     ) -> std::result::Result<Option<RollupRewrite>, crate::rollup::MissReason> {
@@ -4544,7 +4552,10 @@ impl Database {
                     .or_else(|| fingerprints.get(&("default".to_string(), date.clone())))
                     .map_or(0, |stats| stats.fingerprint);
                 let source_epoch = self.rollup_source_epochs.get(&(project.clone(), route.source.clone(), date.clone())).map_or(0, |entry| *entry.value());
-                if coverage.source_fp != source_fp || coverage.source_epoch != Some(source_epoch) {
+                if !Self::rollup_generation_current(&route.source, &route.target, project, &date, &coverage)
+                    || coverage.source_fp != source_fp
+                    || coverage.source_epoch != Some(source_epoch)
+                {
                     miss = miss.or(Some(crate::rollup::MissReason::StaleCoverage));
                     continue;
                 }
@@ -4634,6 +4645,10 @@ impl Database {
                     }
                 }
                 for (key, coverage) in fresh {
+                    if !Self::rollup_generation_current(&route.source, &route.target, project, &date, &coverage) {
+                        miss = miss.or(Some(crate::rollup::MissReason::StaleCoverage));
+                        continue;
+                    }
                     // Per slice, like the witness above and for the same reason:
                     // a slice built before the measure existed sends only ITS
                     // range to the raw fringe, while siblings that do carry the
@@ -13504,6 +13519,196 @@ mod tests {
         Ok(())
     }
 
+    #[tokio::test(flavor = "multi_thread")]
+    async fn rollup_routing_rejects_legacy_materialization_generations() -> Result<()> {
+        use object_store::ObjectStoreExt as _;
+        use std::hash::{Hash, Hasher};
+        let db = Arc::new(Database::with_config(create_test_config("rollup-generation-read")).await?);
+        db.cancel_maintenance();
+        let project = format!("generation_{}", uuid::Uuid::new_v4().simple());
+        let day = (Utc::now() - chrono::Duration::days(3)).date_naive();
+        for hour in [1, 7, 13, 19] {
+            let at = day.and_hms_opt(hour, 0, 0).unwrap().and_utc().timestamp_micros();
+            db.insert_records_batch(
+                &project,
+                "otel_logs_and_spans",
+                vec![json_to_batch(vec![test_span_ts(&format!("row-{hour}"), "op", &project, at)])?],
+                true,
+                None,
+            )
+            .await?;
+        }
+        db.run_unit_once("otel_logs_and_spans", &project, day, crate::maintenance_coordinator::Operation::BaseRollup, 24, 0).await?;
+        let mut ctx = Arc::clone(&db).create_session_context();
+        db.setup_session_context(&mut ctx)?;
+        let state = ctx.state();
+        let lo = day.and_hms_opt(0, 0, 0).unwrap().and_utc().timestamp_micros();
+        let hi = lo + crate::maintenance_coordinator::DAY_MICROS;
+        let sql = format!(
+            "SELECT COUNT(*) FROM otel_logs_and_spans WHERE project_id='{project}' AND timestamp >= to_timestamp_micros({lo}) AND timestamp < to_timestamp_micros({hi})"
+        );
+        let plan = state.optimize(&state.create_logical_plan(&sql).await?)?;
+        assert!(matches!(db.rollup_sql(&plan, &state).await, Ok(Some(_))), "fresh materializations must route");
+        let schema = get_schema("otel_logs_and_spans").unwrap();
+        let legacy = |target: &str, coverage: &RollupCoverage| {
+            let spec = schema.rollups.iter().find(|s| s.table_name("otel_logs_and_spans") == target).unwrap();
+            let restricted = crate::schema::RollupSpec {
+                measures: spec.measures.iter().filter(|m| coverage.measures.as_ref().is_none_or(|held| held.contains(&m.name))).cloned().collect(),
+                ..spec.clone()
+            };
+            // The persisted generation algorithm before source-read semantics were versioned.
+            let mut hasher = fnv::FnvHasher::default();
+            format!("{restricted:?}").hash(&mut hasher);
+            ("otel_logs_and_spans", project.as_str(), day.to_string().as_str()).hash(&mut hasher);
+            format!("{:016x}", hasher.finish())
+        };
+        for mut entry in db.rollup_coverage.iter_mut() {
+            if entry.key().0 == project {
+                entry.value_mut().generation = legacy(&entry.key().2, entry.value());
+            }
+        }
+        for mut entry in db.rollup_slice_coverage.iter_mut() {
+            if entry.key().0 == project {
+                entry.value_mut().generation = legacy(&entry.key().2, entry.value());
+            }
+        }
+        let outcome = db.rollup_sql(&plan, &state).await;
+        // The coarser, unbuilt tier may supply the first miss; either coverage
+        // refusal is valid, but no legacy generation may produce a rewrite.
+        assert!(
+            matches!(outcome, Err(crate::rollup::MissReason::StaleCoverage | crate::rollup::MissReason::NotBuilt)),
+            "matching source rows cannot validate a pre-fix materialization: {:?}",
+            outcome.as_ref().map(|route| route.as_ref().map(|r| r.sql.as_str())).map_err(|reason| reason.label())
+        );
+        let target = schema.rollups.iter().find(|spec| spec.derive_from.is_none()).unwrap().table_name("otel_logs_and_spans");
+        let (key, mut publication) =
+            db.journal().published_rollups("otel_logs_and_spans", &target).into_iter().find(|(key, _)| key.project_id == project).unwrap();
+        let derived = db.run_unit_once("otel_logs_and_spans", &project, day, crate::maintenance_coordinator::Operation::DerivedRollup, 24, 0).await?;
+        assert_eq!(derived.state, Some(crate::maintenance_coordinator::TaskState::Retry), "a derived unit must wait for a current base generation");
+
+        // Persist the obsolete identity too. Recovery must requeue a completed
+        // publication, then a real rebuild must replace its files and restore reads.
+        use crate::maintenance_coordinator::{Operation, TAG_GENERATION, TaskState};
+        use deltalake::kernel::{
+            Action,
+            transaction::{CommitBuilder, TableReference},
+        };
+        let tier = db.get_or_create_table(&project, &target).await?;
+        let obsolete_paths;
+        {
+            let mut table = tier.read().await.clone();
+            let store = table.log_store().object_store(None);
+            #[allow(deprecated)]
+            let adds: Vec<_> = table.snapshot()?.log_data().iter().map(|file| file.add_action()).collect();
+            let file_count = adds.len();
+            obsolete_paths = adds.iter().map(|add| format!("{}-fixture.parquet", add.path.trim_end_matches(".parquet"))).collect::<Vec<_>>();
+            assert!(!obsolete_paths.is_empty());
+            let coverage = db
+                .rollup_slice_coverage
+                .get(&(project.clone(), "otel_logs_and_spans".to_owned(), target.clone(), key.slice.start_micros, key.slice.end_micros))
+                .unwrap()
+                .value()
+                .clone();
+            assert!(
+                !Database::rollup_generation_current("otel_logs_and_spans", &target, &project, &day.to_string(), &coverage),
+                "fixture must persist an obsolete generation"
+            );
+            publication.generation = coverage.generation.clone();
+            assert!(db.journal().publish(&key, publication));
+            let mut actions = Vec::new();
+            for mut add in adds {
+                actions.push(Action::Remove(remove_for_add(&add, false)));
+                add.tags.as_mut().unwrap().insert(TAG_GENERATION.to_owned(), Some(coverage.generation.clone()));
+                // Use a distinct path: a Remove/Add pair for one path can be
+                // replayed as a removal, which would erase the fixture's evidence.
+                let path = format!("{}-fixture.parquet", add.path.trim_end_matches(".parquet"));
+                store.copy(&deltalake::Path::from(add.path.clone()), &deltalake::Path::from(path.clone())).await?;
+                add.path = path;
+                add.data_change = false;
+                actions.push(Action::Add(add));
+            }
+            let op = deltalake::protocol::DeltaOperation::Write { mode: deltalake::protocol::SaveMode::Append, partition_by: None, predicate: None };
+            let finalized = CommitBuilder::default().with_actions(actions).build(Some(table.snapshot()? as &dyn TableReference), table.log_store(), op).await?;
+            table.state = Some(finalized.snapshot());
+            assert_eq!(table.snapshot()?.log_data().iter().count(), file_count, "retagging preserves every fixture file");
+            *tier.write().await = table;
+        }
+        assert_eq!(db.journal().tasks().find(|task| task.key == key).unwrap().state, TaskState::Complete);
+        db.recover_rollup_coverage("otel_logs_and_spans").await?;
+        let task_states = db.journal().tasks().map(|task| (task.key.clone(), task.state)).collect::<Vec<_>>();
+        assert_eq!(
+            task_states.iter().find(|(task, _)| *task == key).unwrap().1,
+            TaskState::Pending,
+            "obsolete completed materializations must be rebuilt; key={key:?}, tasks={task_states:?}, coverage={:?}",
+            db.rollup_slice_coverage.iter().map(|entry| (entry.key().clone(), entry.value().clone())).collect::<Vec<_>>()
+        );
+        assert!(!matches!(db.rollup_sql(&plan, &state).await, Ok(Some(_))), "recovery must not restore an obsolete publication");
+        let rebuilt = db.run_unit_once("otel_logs_and_spans", &project, day, Operation::BaseRollup, 24, 0).await?;
+        assert_eq!(rebuilt.state, Some(TaskState::Complete));
+        let live = live_paths(&db, &project, &target).await;
+        assert!(obsolete_paths.iter().all(|path| !live.contains(path)), "the rebuild retires the obsolete files");
+        let rewrite = db.rollup_sql(&plan, &state).await.map_err(|reason| anyhow::anyhow!("{}", reason.label()))?.expect("rebuilt coverage must route");
+        let batches = ctx.sql(&rewrite.sql).await?.collect().await?;
+        assert_eq!(
+            batches[0].column(0).as_any().downcast_ref::<arrow::array::Int64Array>().unwrap().value(0),
+            4,
+            "rebuilt rollup agrees with the four source rows"
+        );
+
+        Ok(())
+    }
+
+    // Keep persisted generation and measure evidence consistent when modeling
+    // a materialization that predates a measure. Recover through the real tag path.
+    async fn strip_rollup_measure(db: &Database, project: &str, day: chrono::NaiveDate, measure: &str) -> Result<()> {
+        use crate::maintenance_coordinator::{TAG_GENERATION, TAG_MEASURES, TAG_PROJECT, TAG_SLICE_START};
+        use deltalake::kernel::{
+            Action,
+            transaction::{CommitBuilder, TableReference},
+        };
+        use object_store::ObjectStoreExt as _;
+        let source = "otel_logs_and_spans";
+        for spec in &get_schema(source).expect("source schema").rollups {
+            let tier = db.get_or_create_table(project, &spec.table_name(source)).await?;
+            let mut table = tier.read().await.clone();
+            let store = table.log_store().object_store(None);
+            #[allow(deprecated)]
+            let adds: Vec<_> = table.snapshot()?.log_data().iter().map(|file| file.add_action()).collect();
+            let file_count = adds.len();
+            let mut actions = Vec::new();
+            for mut add in adds {
+                let Some(tags) = add.tags.as_mut() else { continue };
+                let at = tags.get(TAG_SLICE_START).and_then(Option::as_ref).and_then(|s| s.parse().ok()).and_then(chrono::DateTime::from_timestamp_micros);
+                if tags.get(TAG_PROJECT).and_then(Option::as_deref) != Some(project) || at.is_none_or(|at| at.date_naive() != day) {
+                    continue;
+                }
+                let held = tags.get(TAG_MEASURES).and_then(Option::as_deref).expect("fresh build proves its measures");
+                assert!(held.split(',').any(|name| name == measure));
+                let names: Vec<String> = held.split(',').filter(|name| *name != measure).map(str::to_owned).collect();
+                tags.insert(TAG_MEASURES.to_owned(), Some(names.join(",")));
+                tags.insert(TAG_GENERATION.to_owned(), Some(crate::rollup::generation_id(spec, source, project, &day.to_string(), 0, Some(&names))));
+                actions.push(Action::Remove(remove_for_add(&add, false)));
+                // Use a distinct path: a Remove/Add pair for one path can be
+                // replayed as a removal, which would erase the fixture's evidence.
+                let path = format!("{}-fixture.parquet", add.path.trim_end_matches(".parquet"));
+                store.copy(&deltalake::Path::from(add.path.clone()), &deltalake::Path::from(path.clone())).await?;
+                add.path = path;
+                add.data_change = false;
+                actions.push(Action::Add(add));
+            }
+            if actions.is_empty() {
+                continue;
+            }
+            let op = deltalake::protocol::DeltaOperation::Write { mode: deltalake::protocol::SaveMode::Append, partition_by: None, predicate: None };
+            let finalized = CommitBuilder::default().with_actions(actions).build(Some(table.snapshot()? as &dyn TableReference), table.log_store(), op).await?;
+            table.state = Some(finalized.snapshot());
+            assert_eq!(table.snapshot()?.log_data().iter().count(), file_count, "retagging preserves every fixture file");
+            *tier.write().await = table;
+        }
+        db.recover_rollup_coverage(source).await?;
+        Ok(())
+    }
+
     /// A date whose cells cannot PROVE they hold a measure must fall to the raw
     /// fringe while its siblings keep routing.
     ///
@@ -13597,21 +13802,8 @@ mod tests {
 
         // The older day's cells lose their proof — exactly the prod shape, where
         // the column was declared before any file carried it.
-        let strip = |measures: &mut Option<HashSet<String>>| {
-            *measures = Some(measures.clone().unwrap_or_default().into_iter().filter(|name| name != DIGEST).collect());
-        };
         let stripped = days[0].to_string();
-        for mut entry in db.rollup_slice_coverage.iter_mut() {
-            if entry.key().0 == project && chrono::DateTime::from_timestamp_micros(entry.key().3).is_some_and(|time| time.date_naive().to_string() == stripped)
-            {
-                strip(&mut entry.value_mut().measures);
-            }
-        }
-        for mut entry in db.rollup_coverage.iter_mut() {
-            if entry.key().0 == project && entry.key().3 == stripped {
-                strip(&mut entry.value_mut().measures);
-            }
-        }
+        strip_rollup_measure(&db, &project, days[0], DIGEST).await?;
 
         let misses = || crate::observability::maintenance_stats().rollup_miss_measure_not_stored.load(std::sync::atomic::Ordering::Relaxed);
         for (index, select) in shapes.iter().enumerate() {
@@ -13641,16 +13833,7 @@ mod tests {
         // can prove it. That is the shape a not-yet-servable measure produces by
         // construction, and it is the case the counter could not report.
         {
-            for mut entry in db.rollup_slice_coverage.iter_mut() {
-                if entry.key().0 == project {
-                    strip(&mut entry.value_mut().measures);
-                }
-            }
-            for mut entry in db.rollup_coverage.iter_mut() {
-                if entry.key().0 == project {
-                    strip(&mut entry.value_mut().measures);
-                }
-            }
+            strip_rollup_measure(&db, &project, days[1], DIGEST).await?;
             let total = route(&db, sql(&shapes[1], true)).await;
             let reason = total.expect_err("no date can prove the digest, so nothing may route").to_string();
             assert!(
@@ -13909,13 +14092,8 @@ mod tests {
         // The base cells lose their digest proof — the prod shape, where the
         // column was declared before any base file carried a value for it. The
         // base tier's SCHEMA keeps it, which is what used to be consulted.
-        for mut entry in db.rollup_slice_coverage.iter_mut() {
-            if entry.key().0 == project && entry.key().2 == base_tier {
-                let held = entry.value().measures.clone().unwrap_or_default();
-                assert!(held.contains(DIGEST), "a fresh base build must prove the digest, or stripping it proves nothing");
-                entry.value_mut().measures = Some(held.into_iter().filter(|name| name != DIGEST).collect());
-            }
-        }
+        assert!(measures(&base_tier).iter().all(|held| held.as_ref().is_some_and(|held| held.contains(DIGEST))), "fresh base proves the digest");
+        strip_rollup_measure(&db, &project, day, DIGEST).await?;
         db.run_unit_once("otel_logs_and_spans", &project, day, Operation::DerivedRollup, 4, 20).await?;
 
         let published = measures(&derived_tier);
@@ -14569,6 +14747,28 @@ mod tests {
         db.recover_rollup_coverage("otel_logs_and_spans").await?;
         assert!(db.coverage_ledger.coverage(&ancient).is_empty(), "a cell past the rollup horizon is retired");
         assert_eq!(db.coverage_ledger.coverage(&cell), recorded, "and an in-window cell is untouched by retirement");
+
+        // Restart seeding must validate the materialization semantics independently
+        // of Delta replay. Recreate the pre-version generation from its real spec.
+        use std::hash::{Hash, Hasher};
+        let spec = get_schema(&cell.0).unwrap().rollups.iter().find(|spec| spec.table_name(&cell.0) == cell.2).unwrap();
+        let mut legacy = recorded.clone();
+        for entry in &mut legacy {
+            let restricted = crate::schema::RollupSpec {
+                measures: spec.measures.iter().filter(|m| entry.measures.as_ref().is_none_or(|names| names.contains(&m.name))).cloned().collect(),
+                ..spec.clone()
+            };
+            let mut hasher = fnv::FnvHasher::default();
+            format!("{restricted:?}").hash(&mut hasher);
+            (cell.0.as_str(), project.as_str(), cell.3.as_str()).hash(&mut hasher);
+            entry.generation = format!("{:016x}", hasher.finish());
+        }
+        db.coverage_ledger.replace(&cell, legacy);
+        db.rollup_slice_coverage.clear();
+        assert_eq!(db.seed_routing_from_ledger(), 0, "an old reader's ledger cannot authorize current reads");
+        db.coverage_ledger.replace(&cell, recorded);
+        assert!(db.seed_routing_from_ledger() > 0, "current persisted coverage survives restart");
+
         Ok(())
     }
 

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -1144,6 +1144,11 @@ atomic_stats! {
         /// selection hypothesis confirmed.
         rollup_base_file_skipped_tag_project,
         rollup_base_file_skipped_tag_range,
+        /// Relevant base files whose materialization generation could not be proved.
+        /// Each refusal schedules base rebuilding and retries the derived unit.
+        rollup_base_file_skipped_generation,
+        /// Persisted coverage entries rejected during restart generation validation.
+        rollup_ledger_seed_rejected_generation,
         /// Splits refused because the unit measured nearly what its parent measured:
         /// bisection has hit the row-group floor and halving the width again buys
         /// nothing but journal units.

--- a/src/rollup.rs
+++ b/src/rollup.rs
@@ -113,11 +113,10 @@ fn sql_literal(value: &str) -> String {
 /// that does not hold a measure is refused for queries needing it and serves
 /// every other query unchanged.
 ///
-/// Restricting rather than dropping measures from the hash is what keeps the
-/// change backward compatible: measures are appended, so the restricted spec's
-/// `Debug` is byte-identical to the spec that was live when the cell was built,
-/// and the generation already on S3 still matches. `None` — a cell with no tag,
-/// which proves nothing — keeps the old whole-spec comparison.
+/// Within one materialization version, restricting the spec preserves the
+/// generation when measures are appended. Redefined measures and source-read
+/// semantic changes require a new generation. `None` uses the whole spec;
+/// measure availability remains a separate proof at read time.
 pub fn generation_id(spec: &RollupSpec, source: &str, project_id: &str, date: &str, _source_fp: u64, measures: Option<&[String]>) -> String {
     use std::hash::{Hash, Hasher};
     let restricted;
@@ -129,6 +128,11 @@ pub fn generation_id(spec: &RollupSpec, source: &str, project_id: &str, date: &s
         None => spec,
     };
     let mut hasher = fnv::FnvHasher::default();
+    // Materialized aggregates depend on source-read semantics as well as the
+    // SQL spec. Older generations may contain results from incorrect physical
+    // deletion-vector row positions and must be rebuilt from the fixed reader.
+    const MATERIALIZATION_VERSION: u8 = 1;
+    MATERIALIZATION_VERSION.hash(&mut hasher);
     format!("{spec:?}").hash(&mut hasher);
     (source, project_id, date).hash(&mut hasher);
     format!("{:016x}", hasher.finish())


### PR DESCRIPTION
Persisted rollups can outlive changes to how source rows are read. In production, a ten-minute window returns COUNT(*) = 11,848 through a dashboard rollup, while SUM(1), a complete logical-key projection, and an independent frozen-data oracle agree on 11,542. The rollup itself stores 11,848. Source row-count witnesses alone cannot invalidate aggregates built with the old deletion-vector reader.

Version materialization semantics in the generation identity and validate that identity when routing date/slice coverage, restoring the coverage ledger, and selecting base inputs for derived rollups. Recovery validates journal-only publications as well as file tags and queues obsolete completed materializations for rebuild, deduplicating requests before the bounded, newest-first queue cap. Derived builds prune unrelated files by range, then require current generation evidence for every relevant input; an unverified input requests a base rebuild and retries the derived unit instead of publishing partial results. Counters expose rejected base-file generations and ledger entries. Affected ranges use raw scans until current materializations are available, so historical query latency and rebuild load need monitoring during rollout.

Validation:

- The pre-fix regression accepted an obsolete generation; the candidate refuses it while preserving the current-generation positive control.
- Integration coverage persists an obsolete generation in Delta and the journal, verifies completed work is requeued, rebuilds it, checks old files are retired, and executes the rebuilt rollup against the expected source count.
- Ledger restart coverage rejects obsolete generations and accepts current ones. Tag-loss coverage reproduces the prior Complete-vs-Retry failure, verifies a base rebuild is requested, exercises obsolete journal-only recovery, and checks the repaired derived SUM against all source rows. Measure-availability regressions retain their partial-coverage behavior.
- Fixtures copy Parquet to distinct paths when changing tags and assert file counts are preserved, so metadata replacement cannot erase the test inputs.
- cargo +1.91 nextest run --lib --no-fail-fast: 1,199 passed, 8 skipped.
- cargo +1.91 lint and formatting/diff checks passed.

After deployment, verify COUNT(*), SUM(1), and the full logical-key projection agree on the production window; monitor raw query latency, obsolete-generation rebuilds, and maintenance timeouts. This PR has not yet been validated in production.

The generation version applies to all prior materializations. A rollback to a reader without that version also rejects materializations rebuilt by this release, so rollback would require another rebuild pass.
