### PR TITLE
fix: account for shared buffers in external sort reservations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2200,7 +2200,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -2252,7 +2252,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2276,7 +2276,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2298,7 +2298,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -2323,7 +2323,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
 dependencies = [
  "futures",
  "log",
@@ -2333,7 +2333,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
 dependencies = [
  "arrow",
  "async-compression",
@@ -2368,7 +2368,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-arrow"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -2391,7 +2391,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2413,7 +2413,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2435,7 +2435,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2465,12 +2465,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
 
 [[package]]
 name = "datafusion-execution"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -2491,7 +2491,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -2513,7 +2513,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2524,7 +2524,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -2555,7 +2555,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2575,7 +2575,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2599,7 +2599,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -2623,7 +2623,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2654,7 +2654,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -2663,7 +2663,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -2673,7 +2673,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
 dependencies = [
  "arrow",
  "chrono",
@@ -2706,7 +2706,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2727,7 +2727,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-adapter"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2741,7 +2741,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
 dependencies = [
  "arrow",
  "chrono",
@@ -2757,7 +2757,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2775,7 +2775,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
 dependencies = [
  "arrow",
  "arrow-data",
@@ -2830,7 +2830,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
 dependencies = [
  "arrow",
  "chrono",
@@ -2856,7 +2856,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-common"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2866,7 +2866,7 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2881,7 +2881,7 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -2894,7 +2894,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=f903e21147c4172294fb8befdfe1d5e361d4fc38#f903e21147c4172294fb8befdfe1d5e361d4fc38"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
 dependencies = [
  "arrow",
  "bigdecimal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -257,42 +257,42 @@ pgwire = { path = "vendor/pgwire" }
 # arrow-pg/datafusion-pg-catalog from the same git workspace, so those need no
 # separate patch.
 datafusion-postgres = { git = "https://github.com/apitoolkit/datafusion-postgres.git", branch = "timefusion-df54" }
-# DataFusion 54.1 with positional Parquet scan protection, SQL DEALLOCATE ALL,
+# DataFusion 54.1 with shared sort-buffer reservations, positional Parquet scan protection, SQL DEALLOCATE ALL,
 # and the existing UPDATE FROM support.
 # Keep the workspace crates on one source so their public Rust types agree.
-datafusion = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
-datafusion-catalog = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
-datafusion-catalog-listing = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
-datafusion-common = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
-datafusion-common-runtime = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
-datafusion-datasource = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
-datafusion-datasource-arrow = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
-datafusion-datasource-csv = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
-datafusion-datasource-json = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
-datafusion-datasource-parquet = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
-datafusion-doc = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
-datafusion-execution = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
-datafusion-expr = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
-datafusion-expr-common = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
-datafusion-functions = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
-datafusion-functions-aggregate = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
-datafusion-functions-aggregate-common = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
-datafusion-functions-nested = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
-datafusion-functions-table = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
-datafusion-functions-window = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
-datafusion-functions-window-common = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
-datafusion-macros = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
-datafusion-optimizer = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
-datafusion-physical-expr = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
-datafusion-physical-expr-adapter = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
-datafusion-physical-expr-common = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
-datafusion-physical-optimizer = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
-datafusion-physical-plan = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
-datafusion-proto = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
-datafusion-proto-common = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
-datafusion-pruning = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
-datafusion-session = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
-datafusion-sql = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "f903e21147c4172294fb8befdfe1d5e361d4fc38" }
+datafusion = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
+datafusion-catalog = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
+datafusion-catalog-listing = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
+datafusion-common = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
+datafusion-common-runtime = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
+datafusion-datasource = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
+datafusion-datasource-arrow = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
+datafusion-datasource-csv = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
+datafusion-datasource-json = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
+datafusion-datasource-parquet = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
+datafusion-doc = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
+datafusion-execution = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
+datafusion-expr = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
+datafusion-expr-common = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
+datafusion-functions = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
+datafusion-functions-aggregate = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
+datafusion-functions-aggregate-common = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
+datafusion-functions-nested = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
+datafusion-functions-table = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
+datafusion-functions-window = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
+datafusion-functions-window-common = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
+datafusion-macros = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
+datafusion-optimizer = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
+datafusion-physical-expr = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
+datafusion-physical-expr-adapter = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
+datafusion-physical-expr-common = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
+datafusion-physical-optimizer = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
+datafusion-physical-plan = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
+datafusion-proto = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
+datafusion-proto-common = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
+datafusion-pruning = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
+datafusion-session = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
+datafusion-sql = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
 # tikv-jemalloc-sys 0.6.1 vendored with a single build.rs delta: honour
 # `JEMALLOC_SYS_PROF_BACKTRACE` so the heap profiler can be built with a working
 # unwinder (`--enable-prof-libunwind`). Upstream passes `--enable-prof` alone and


### PR DESCRIPTION
External sorts can reject batches that fit the memory budget because output batches share large string buffers, but DataFusion reserves their capacity once per batch. This updates all DataFusion workspace patches to the reviewed candidate in https://github.com/tonyalaribe/datafusion/pull/1, which counts shared buffers once and retains each reservation until the last queued batch using that buffer is released.

The reproduction admits 8,192 rows, then fails during output reservation on the old dependency. The corrected sorter emits sorted rows within a 24 MiB pool and releases all reservations on completion or early stream drop. Cargo.lock changes only the DataFusion source revision; other dependency edges are preserved.

Validation:
- DataFusion: 458 common tests, 1,440 physical-plan tests, 2,163 additional core/CLI/doc tests, and 473 SQL files passed; workspace all-target/all-feature Clippy passed.
- TimeFusion formatting, locked metadata, and full lint passed.
- Initial library suite: 1,199 passed, 8 skipped. After restoring incidental lockfile edges, 1,192 passed and seven storage-backed tests failed with local MinIO HTTP 507 (disk full); after compressing completed diagnostic artifacts to free disk space, all seven passed on rerun (10.13 seconds). The final dependency graph therefore has passing results for all 1,199 library tests.

Production deployment and verification of the original failing query are pending. Memory limits and query semantics remain the same.
