### PR TITLE
Fix Delta reader deadlock from blocking-pool result delivery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1349,10 +1349,10 @@ dependencies = [
 [[package]]
 name = "buoyant_kernel"
 version = "0.24.0"
-source = "git+https://github.com/buoyant-data/delta-kernel-rs?rev=393fbf662f56c4bb04445e1d36805a33e32b8fbc#393fbf662f56c4bb04445e1d36805a33e32b8fbc"
+source = "git+https://github.com/tonyalaribe/delta-kernel-rs.git?rev=6817692622f376208c95246ca7ea1a4cb4231438#6817692622f376208c95246ca7ea1a4cb4231438"
 dependencies = [
  "arrow",
- "buoyant_kernel_derive 1.0.0 (git+https://github.com/buoyant-data/delta-kernel-rs?rev=393fbf662f56c4bb04445e1d36805a33e32b8fbc)",
+ "buoyant_kernel_derive 1.0.0 (git+https://github.com/tonyalaribe/delta-kernel-rs.git?rev=6817692622f376208c95246ca7ea1a4cb4231438)",
  "bytes",
  "chrono",
  "crc",
@@ -1392,7 +1392,7 @@ dependencies = [
 [[package]]
 name = "buoyant_kernel_derive"
 version = "1.0.0"
-source = "git+https://github.com/buoyant-data/delta-kernel-rs?rev=393fbf662f56c4bb04445e1d36805a33e32b8fbc#393fbf662f56c4bb04445e1d36805a33e32b8fbc"
+source = "git+https://github.com/tonyalaribe/delta-kernel-rs.git?rev=6817692622f376208c95246ca7ea1a4cb4231438#6817692622f376208c95246ca7ea1a4cb4231438"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -301,3 +301,8 @@ datafusion-sql = { git = "https://github.com/tonyalaribe/datafusion.git", rev = 
 # frame (2026-07-31). Re-vendor from the registry on upgrade; see the PATCH
 # comment in vendor/tikv-jemalloc-sys/build.rs.
 tikv-jemalloc-sys = { path = "vendor/tikv-jemalloc-sys" }
+
+# Delta's synchronous readers must deliver async results without waiting for
+# another slot in the same blocking pool (production DV-reader deadlock).
+[patch."https://github.com/buoyant-data/delta-kernel-rs"]
+buoyant_kernel = { git = "https://github.com/tonyalaribe/delta-kernel-rs.git", rev = "6817692622f376208c95246ca7ea1a4cb4231438" }


### PR DESCRIPTION
Telemetry query planning stalled when hundreds of Delta deletion-vector readers filled Tokio’s blocking pool. The kernel executor queued result delivery onto that same pool, so completed async work could not release the waiting readers. A production stack snapshot found 465 readers on this path; a one-slot kernel regression reproduces the deadlock.

Pin Delta’s kernel dependency to the tested result-delivery fix: https://github.com/tonyalaribe/delta-kernel-rs/pull/1. Both executor implementations deliver through their unbounded channel without requesting another blocking thread. The lockfile changes only the kernel and its derive crate’s source; other dependency versions remain unchanged.

Validation: the dependency regression fails before and passes after; all nine executor tests and 2,988 kernel unit tests pass (seven ignored). Kernel Clippy and TimeFusion locked dependency resolution pass. Both application CI shards pass: 716 + 714 = 1,430 tests, using the required Nextest runner and a healthy MinIO service; E2E also passes. Local Nextest passed 1,193 unit tests; seven storage tests remained blocked by the local MinIO free-space threshold, so application storage validation comes from CI. Rust CodeQL is still running.

The patch can be removed when Delta’s pinned kernel includes this result-delivery fix. The separate direct registry dependency on kernel 0.22 is unchanged; the patch targets Delta’s kernel 0.24.
