### PR TITLE
Separate failure-driven task splitting from byte measurements

### DIFF
--- a/src/database/maintain.rs
+++ b/src/database/maintain.rs
@@ -1334,6 +1334,7 @@ impl Database {
                         base_tier_present: false,
                         input: Some(footprint),
                         parent_measured_bytes: None,
+                        preflight_decoded_bytes: None,
                         backfill_priority_micros: None,
                     });
                 }
@@ -1363,6 +1364,7 @@ impl Database {
                             base_tier_present: false,
                             input: Some(footprint),
                             parent_measured_bytes: None,
+                            preflight_decoded_bytes: None,
                             backfill_priority_micros: None,
                         });
                     }
@@ -2218,7 +2220,7 @@ impl Database {
         let input_footprint = crate::maintenance_coordinator::InputFootprint::new(selected_paths, whole_file_bytes);
         // Before the split test, because a unit that FITS still needs this: a
         // later timeout bisect knows only the key.
-        if self.journal().record_input(&key, input_footprint) {
+        if self.journal().record_preflight(&key, Some(input_footprint), estimated_bytes) {
             self.journal().checkpoint()?;
         }
         if estimated_bytes > MAX_DECODED_BYTES && key.slice.width() > crate::maintenance_coordinator::MIN_SLICE_MICROS {
@@ -2723,7 +2725,7 @@ impl Database {
         // Same reason as the dedup preflight: record it on every claim, not only
         // when this one splits, or a timeout bisect mints footprint-less
         // children that fusion can only sum.
-        if self.journal().record_input(&key, input_footprint) {
+        if self.journal().record_preflight(&key, Some(input_footprint), estimated_bytes) {
             self.journal().checkpoint()?;
         }
         if skipped_tag_project + skipped_tag_range > 0 {

--- a/src/maintenance_coordinator.rs
+++ b/src/maintenance_coordinator.rs
@@ -7810,6 +7810,33 @@ mod tests {
         assert!(!widths.is_empty() && widths.iter().all(|w| *w < DAY_MICROS), "bisection must leave smaller claimable children; got {widths:?}");
     }
 
+    #[test_case::test_case(true, 0 ; "timeout without a byte estimate")]
+    #[test_case::test_case(true, MAX_DECODED_BYTES / 2 ; "timeout below byte budget")]
+    #[test_case::test_case(false, 0 ; "capacity failure without a byte estimate")]
+    #[test_case::test_case(false, 2 * MAX_DECODED_BYTES ; "capacity failure with an estimate")]
+    fn failure_driven_splits_do_not_fabricate_byte_measurements(via_timeout: bool, estimate: u64) {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let mut journal = TaskJournal::load(dir.path()).expect("journal");
+        let mut unit = task("p", 0, DAY_MICROS, Operation::Dedup);
+        unit.estimated_decoded_bytes = estimate;
+        unit.state = TaskState::Running;
+        unit.attempts = 2;
+        let key = unit.key.clone();
+        journal.upsert(unit);
+        if via_timeout {
+            journal.abandon_running(&key, 0, None);
+        } else {
+            journal.retry_or_split(&key, "Not enough memory to continue external sort".to_owned(), 0, 2);
+        }
+        journal.checkpoint().expect("persist split");
+        let journal = TaskJournal::load(dir.path()).expect("reload split");
+        assert_eq!(journal.state(&key), Some(TaskState::Superseded));
+        let children: Vec<_> = journal.tasks().filter(|task| task.state == TaskState::Pending).collect();
+        assert_eq!(children.len(), 2, "a repeated failure still bisects the task");
+        assert_eq!(children.iter().map(|task| task.estimated_decoded_bytes).sum::<u64>(), estimate, "bisection apportions the existing estimate");
+        assert!(children.iter().all(|task| task.parent_measured_bytes.is_none()), "a failure supplies no byte measurement to persist");
+    }
+
     /// Only capacity failures shrink. A missing object or a commit conflict says
     /// nothing about size, and splitting on it would shred a healthy slice.
     #[test]

--- a/src/maintenance_coordinator.rs
+++ b/src/maintenance_coordinator.rs
@@ -423,6 +423,10 @@ pub struct MaintenanceTask {
     /// they did before.
     #[serde(default)]
     pub parent_measured_bytes: Option<u64>,
+    /// Byte estimate from this claim's input preflight, before time-share modelling.
+    /// Older journals have no observation; a timeout itself supplies none.
+    #[serde(default)]
+    pub preflight_decoded_bytes: Option<u64>,
     /// Scheduling weight inherited from the backfill unit this task was split
     /// out of. `None` means "weigh me by my own width".
     ///
@@ -588,13 +592,10 @@ const SPLIT_MUST_SHED_DENOMINATOR: u64 = 4;
 /// `None` — no parent evidence — always splits: that is the first measurement
 /// of this lineage and there is nothing yet to compare against.
 ///
-/// The window is deliberately two-sided. A child that measured MORE than its
-/// parent is not evidence of the floor, it is evidence the parent's number was
-/// never a measurement — which is exactly what `retry_or_split` stamps when it
-/// forces a bisection with a synthetic `MAX_DECODED_BYTES + 1`. Declining there
-/// would freeze that lineage forever, the immortal-unit shape this file already
-/// has three incidents of. Let it split once more; the next preflight stamps a
-/// real number and the guard starts working.
+/// The window is deliberately two-sided. A larger child preflight may reflect
+/// input growth, or a historical journal whose parent carried a synthetic byte
+/// count. Allow that preflight to establish a new baseline. New failure splits
+/// retain preflight evidence when available and never manufacture a byte count.
 fn split_sheds_enough(parent_measured_bytes: Option<u64>, observed_bytes: u64) -> bool {
     split_sheds_enough_at(parent_measured_bytes, observed_bytes, SPLIT_MUST_SHED_NUMERATOR, SPLIT_MUST_SHED_DENOMINATOR)
 }
@@ -629,6 +630,26 @@ pub fn byte_bounded_units(task: &MaintenanceTask, observed_or_estimated_bytes: u
         task.estimated_decoded_bytes = observed_or_estimated_bytes;
         return vec![task];
     }
+    if let Some(children) = bisect_time_unit(task, observed_or_estimated_bytes) {
+        return children.into();
+    }
+
+    let shards_u64 = observed_or_estimated_bytes.div_ceil(MAX_DECODED_BYTES).max(2);
+    let shards = u32::try_from(shards_u64).unwrap_or(u32::MAX);
+    let per_shard = observed_or_estimated_bytes.div_ceil(u64::from(shards));
+    (0..shards)
+        .map(|hash_shard| {
+            let mut shard = task.clone();
+            shard.hash_shard = hash_shard;
+            shard.hash_shards = shards;
+            shard.estimated_decoded_bytes = per_shard;
+            shard
+        })
+        .collect()
+}
+
+/// Bisect time independently of whether a byte estimate exceeds the budget.
+fn bisect_time_unit(task: &MaintenanceTask, observed_or_estimated_bytes: u64) -> Option<[MaintenanceTask; 2]> {
     // Time-bisection stops at the width where a slice stops shedding FILES, not
     // at the narrowest slice the journal can express.
     //
@@ -659,22 +680,17 @@ pub fn byte_bounded_units(task: &MaintenanceTask, observed_or_estimated_bytes: u
             let mut right = task.clone();
             right.key.slice.start_micros = midpoint;
             right.estimated_decoded_bytes = observed_or_estimated_bytes.saturating_sub(left_bytes);
-            return vec![left, right];
+            return Some([left, right]);
         }
     }
 
-    let shards_u64 = observed_or_estimated_bytes.div_ceil(MAX_DECODED_BYTES).max(2);
-    let shards = u32::try_from(shards_u64).unwrap_or(u32::MAX);
-    let per_shard = observed_or_estimated_bytes.div_ceil(u64::from(shards));
-    (0..shards)
-        .map(|hash_shard| {
-            let mut shard = task.clone();
-            shard.hash_shard = hash_shard;
-            shard.hash_shards = shards;
-            shard.estimated_decoded_bytes = per_shard;
-            shard
-        })
-        .collect()
+    None
+}
+
+#[derive(Clone, Copy)]
+enum SplitTrigger {
+    Preflight(u64),
+    RepeatedFailure,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
@@ -1743,6 +1759,7 @@ impl TaskJournal {
                 // guessing one would let the next width up under-price itself.
                 input: price.unanimous_input(),
                 parent_measured_bytes: None,
+                preflight_decoded_bytes: None,
                 backfill_priority_micros: None,
             });
         }
@@ -2173,6 +2190,20 @@ impl TaskJournal {
             return false;
         }
         task.input = Some(input);
+        task.preflight_decoded_bytes = None;
+        self.dirty_tasks.insert(key.clone());
+        true
+    }
+
+    /// Retain the current input estimate even when the unit fits and is dispatched.
+    pub fn record_preflight(&mut self, key: &TaskKey, input: Option<InputFootprint>, decoded_bytes: u64) -> bool {
+        let input_changed = input.is_some_and(|input| self.record_input(key, input));
+        let Some(index) = self.task_indices.get(key).copied() else { return false };
+        let task = &mut self.snapshot.tasks[index];
+        if task.preflight_decoded_bytes == Some(decoded_bytes) {
+            return input_changed;
+        }
+        task.preflight_decoded_bytes = Some(decoded_bytes);
         self.dirty_tasks.insert(key.clone());
         true
     }
@@ -2362,6 +2393,7 @@ impl TaskJournal {
             base_tier_present,
             input,
             parent_measured_bytes: None,
+            preflight_decoded_bytes: None,
             backfill_priority_micros: None,
         });
         true
@@ -2511,6 +2543,7 @@ impl TaskJournal {
                         base_tier_present: false,
                         input: None,
                         parent_measured_bytes: None,
+                        preflight_decoded_bytes: None,
                         backfill_priority_micros: None,
                     });
                     self.dirty_tasks.insert(key);
@@ -2527,6 +2560,7 @@ impl TaskJournal {
             return false;
         }
         task.state = TaskState::Running;
+        task.preflight_decoded_bytes = None;
         task.attempts = task.attempts.saturating_add(1);
         true
     }
@@ -3004,10 +3038,7 @@ impl TaskJournal {
             return;
         }
         let attempts = self.task_indices.get(key).and_then(|index| self.snapshot.tasks.get(*index)).map_or(1, |task| task.attempts);
-        // `MAX_DECODED_BYTES + 1` is the smallest input that makes
-        // `byte_bounded_units` bisect, and a bisect is one halving: this asks
-        // for one split, never a shred down to the minimum slice.
-        if attempts >= 2 && self.split_time_task(key, MAX_DECODED_BYTES.saturating_add(1), None) {
+        if attempts >= 2 && self.split_task(key, SplitTrigger::RepeatedFailure, None) {
             return;
         }
         // Floored at this operation's OWN deadline. A unit that cannot be split
@@ -3058,27 +3089,7 @@ impl TaskJournal {
             self.park_schema_failure(key, crate::support::now_micros(), &reason);
             return;
         }
-        // Price the guard on the unit's OWN estimate, not a bare synthetic.
-        //
-        // This passed `MAX_DECODED_BYTES + 1`, which made `split_sheds_enough`
-        // compare a CONSTANT against the parent's real measured bytes: against
-        // any parent above ~683 MiB, 512 MiB always satisfies
-        // `observed * 4 < parent * 3`, so the shed test passed at EVERY level
-        // and the lineage bisected to `MIN_SLICE_MICROS`. The guard was
-        // structurally blind here — it cannot compare a measurement to a
-        // constant. Prod 2026-09-03: 147 live units at or below the 60 s floor
-        // (all `base_rollup`, one whale) and 8,595 completed there.
-        //
-        // `max(estimate, MAX + 1)` because the synthetic does TWO jobs and only
-        // one was wrong. It also forces `byte_bounded_units` past its
-        // `<= MAX_DECODED_BYTES` early return, so a unit that OVERRAN ITS
-        // DEADLINE still splits though its estimate claims it fits
-        // (`a_unit_that_overruns_its_deadline_twice_is_bisected`). Taking the
-        // max keeps that: a large real estimate reaches the guard intact, a
-        // small or unpriced one falls back to the synthetic and splits as before.
-        let estimate = self.task_indices.get(key).map_or(0, |index| self.snapshot.tasks[*index].estimated_decoded_bytes);
-        let observed = estimate.max(MAX_DECODED_BYTES.saturating_add(1));
-        if attempts >= 2 && is_capacity_failure(&reason) && self.split_time_task(key, observed, None) {
+        if attempts >= 2 && is_capacity_failure(&reason) && self.split_task(key, SplitTrigger::RepeatedFailure, None) {
             return;
         }
         // Split refused (already at minimum width, or would hash-shard) on a
@@ -3096,6 +3107,10 @@ impl TaskJournal {
     }
 
     pub fn split_time_task(&mut self, key: &TaskKey, observed_bytes: u64, input: Option<InputFootprint>) -> bool {
+        self.split_task(key, SplitTrigger::Preflight(observed_bytes), input)
+    }
+
+    fn split_task(&mut self, key: &TaskKey, trigger: SplitTrigger, input: Option<InputFootprint>) -> bool {
         // A Repair unit's cost is the FILE it rewrites, and time-bisection
         // cannot shrink a file. `coordinator_compaction_files` hands Repair
         // `take(1)` of a whole file whatever the slice width is, so every child
@@ -3130,11 +3145,19 @@ impl TaskJournal {
         // RUN — the runner already hash-shards internally at any width
         // (`database/maintain.rs:1623`), which bounds memory without minting a
         // single journal unit.
-        if !split_sheds_enough(parent.parent_measured_bytes, observed_bytes) {
+        let observed_bytes = match trigger {
+            SplitTrigger::Preflight(bytes) => Some(bytes),
+            SplitTrigger::RepeatedFailure => parent.preflight_decoded_bytes,
+        };
+        if observed_bytes.is_some_and(|bytes| !split_sheds_enough(parent.parent_measured_bytes, bytes)) {
             crate::observability::maintenance_stats().split_declined_at_floor.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             return false;
         }
-        let children = byte_bounded_units(&parent, observed_bytes);
+        let cost = observed_bytes.unwrap_or(parent.estimated_decoded_bytes);
+        let children = match trigger {
+            SplitTrigger::Preflight(_) => byte_bounded_units(&parent, cost),
+            SplitTrigger::RepeatedFailure => bisect_time_unit(&parent, cost).map(Vec::from).unwrap_or_default(),
+        };
         if children.len() <= 1 || children.iter().any(|child| child.hash_shards > 1) {
             // Counted for the same reason the floor decline is: a unit that can
             // neither finish nor shrink is invisible otherwise. See
@@ -3151,7 +3174,8 @@ impl TaskJournal {
         for mut child in children {
             // What the PARENT measured, not the child's modelled share — the
             // modelled share is the very number that cannot be trusted.
-            child.parent_measured_bytes = Some(observed_bytes);
+            child.parent_measured_bytes = observed_bytes;
+            child.preflight_decoded_bytes = None;
             child.state = TaskState::Pending;
             child.attempts = 0;
             child.retry_reason = None;
@@ -4167,8 +4191,9 @@ mod tests {
     ///
     /// The unit below shed NOTHING: its own estimate equals its parent's
     /// measurement, so bisecting again cannot help and must be declined.
-    #[test]
-    fn a_lineage_that_did_not_shed_is_not_split_again() {
+    #[test_case::test_case(true ; "timeout")]
+    #[test_case::test_case(false ; "capacity failure")]
+    fn a_lineage_that_did_not_shed_is_not_split_again(via_timeout: bool) {
         let dir = tempfile::tempdir().expect("temp dir");
         let mut journal = TaskJournal::load(dir.path()).expect("journal");
         const DAY: i64 = 86_400_000_000;
@@ -4180,7 +4205,12 @@ mod tests {
         let key = unit.key.clone();
         journal.upsert(unit);
 
-        journal.retry_or_split(&key, "resource_admission".into(), 1_000_000, 3);
+        journal.record_preflight(&key, None, MEASURED);
+        if via_timeout {
+            journal.abandon_running(&key, 1_000_000, None);
+        } else {
+            journal.retry_or_split(&key, "resource_admission".into(), 1_000_000, 3);
+        }
 
         assert_eq!(
             journal.state(&key),
@@ -4486,6 +4516,7 @@ mod tests {
             base_tier_present: false,
             input: None,
             parent_measured_bytes: None,
+            preflight_decoded_bytes: None,
             backfill_priority_micros: None,
         }
     }
@@ -7810,11 +7841,13 @@ mod tests {
         assert!(!widths.is_empty() && widths.iter().all(|w| *w < DAY_MICROS), "bisection must leave smaller claimable children; got {widths:?}");
     }
 
-    #[test_case::test_case(true, 0 ; "timeout without a byte estimate")]
-    #[test_case::test_case(true, MAX_DECODED_BYTES / 2 ; "timeout below byte budget")]
-    #[test_case::test_case(false, 0 ; "capacity failure without a byte estimate")]
-    #[test_case::test_case(false, 2 * MAX_DECODED_BYTES ; "capacity failure with an estimate")]
-    fn failure_driven_splits_do_not_fabricate_byte_measurements(via_timeout: bool, estimate: u64) {
+    #[test_case::test_case(true, 0, None ; "timeout without a byte estimate")]
+    #[test_case::test_case(true, MAX_DECODED_BYTES / 2, None ; "timeout below byte budget")]
+    #[test_case::test_case(false, 0, None ; "capacity failure without a byte estimate")]
+    #[test_case::test_case(false, 2 * MAX_DECODED_BYTES, None ; "capacity failure with an estimate")]
+    #[test_case::test_case(true, 0, Some(2 * MAX_DECODED_BYTES) ; "timeout retains actual preflight")]
+    #[test_case::test_case(false, 0, Some(MAX_DECODED_BYTES / 2) ; "capacity failure below byte budget retains actual preflight")]
+    fn failure_driven_splits_do_not_fabricate_byte_measurements(via_timeout: bool, estimate: u64, preflight: Option<u64>) {
         let dir = tempfile::tempdir().expect("temp dir");
         let mut journal = TaskJournal::load(dir.path()).expect("journal");
         let mut unit = task("p", 0, DAY_MICROS, Operation::Dedup);
@@ -7823,6 +7856,9 @@ mod tests {
         unit.attempts = 2;
         let key = unit.key.clone();
         journal.upsert(unit);
+        if let Some(bytes) = preflight {
+            journal.record_preflight(&key, None, bytes);
+        }
         if via_timeout {
             journal.abandon_running(&key, 0, None);
         } else {
@@ -7833,8 +7869,15 @@ mod tests {
         assert_eq!(journal.state(&key), Some(TaskState::Superseded));
         let children: Vec<_> = journal.tasks().filter(|task| task.state == TaskState::Pending).collect();
         assert_eq!(children.len(), 2, "a repeated failure still bisects the task");
-        assert_eq!(children.iter().map(|task| task.estimated_decoded_bytes).sum::<u64>(), estimate, "bisection apportions the existing estimate");
-        assert!(children.iter().all(|task| task.parent_measured_bytes.is_none()), "a failure supplies no byte measurement to persist");
+        assert_eq!(
+            children.iter().map(|task| task.estimated_decoded_bytes).sum::<u64>(),
+            preflight.unwrap_or(estimate),
+            "bisection apportions the available input estimate"
+        );
+        assert!(
+            children.iter().all(|task| task.parent_measured_bytes == preflight && task.preflight_decoded_bytes.is_none()),
+            "only actual preflight evidence belongs on children; each child needs its own fresh preflight"
+        );
     }
 
     /// Only capacity failures shrink. A missing object or a commit conflict says

--- a/src/maintenance_sim.rs
+++ b/src/maintenance_sim.rs
@@ -526,9 +526,7 @@ fn preflight(journal: &mut TaskJournal, model: &ByteModel, guard: SplitGuard, ta
     let observed = model.bytes(key);
     let footprint = model.footprint(key);
     report.preflight_measures += 1;
-    if let Some(footprint) = footprint {
-        journal.record_input(key, footprint);
-    }
+    journal.record_preflight(key, footprint, observed);
     if observed <= MAX_DECODED_BYTES || key.slice.width() <= MIN_SLICE_MICROS {
         return Some(observed);
     }
@@ -1186,6 +1184,7 @@ mod tests {
                 base_tier_present: false,
                 input: None,
                 parent_measured_bytes: None,
+                preflight_decoded_bytes: None,
                 backfill_priority_micros: None,
             };
             journal.upsert(task.clone());

--- a/src/maintenance_sim.rs
+++ b/src/maintenance_sim.rs
@@ -1435,13 +1435,28 @@ mod tests {
     }
 
     /// §3c.2 — the control. Bytes strictly proportional to width is the model
-    /// `byte_bounded_units` assumes; under it the same queue never approaches
-    /// the floor, with the guard on OR off. So the shred above is caused by the
-    /// floor, not by the scheduler.
+    /// `byte_bounded_units` assumes. Without independent execution timeouts,
+    /// byte-driven splitting must stop above the floor with either guard.
     #[test]
     fn a_floorless_whale_never_reaches_the_floor() {
         for guard in [SplitGuard::Off, SplitGuard::Shipped] {
-            let (report, whale, _) = synth_run(false, guard);
+            let start = 100 * DAY_MICROS;
+            let queue = synthetic_whale_queue(start, false, 100, 1);
+            let whale = queue.whale_cell;
+            // The duration model is independent of bytes. Its random timeouts
+            // can legitimately split even a small task, so isolate byte physics
+            // here; timeout bisection is exercised by the failure tests.
+            let cfg = SimConfig {
+                mint_frontier: false,
+                workers: 16,
+                horizon_micros: 6 * HOUR,
+                byte_model: Some(queue.model),
+                split_guard: guard,
+                duration_scale: 0.0,
+                ..Default::default()
+            };
+            let report = run(queue.journal, &cfg, start).unwrap();
+            assert_eq!(report.timeouts.values().sum::<u64>(), 0);
             // 255 units, not "tens": 100x MAX_DECODED_BYTES needs 128 leaves,
             // bisection only makes powers of two, and since bisection descends
             // ONE level per measurement the 127 intermediate parents are

--- a/src/maintenance_sim.rs
+++ b/src/maintenance_sim.rs
@@ -287,6 +287,9 @@ pub struct SimReport {
     pub max_cell: String,
     pub max_cell_units: usize,
     pub units_at_min_slice: usize,
+    /// Minimum-width tasks per cell, separating new splits from unrelated debris.
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub min_slice_units_per_cell: BTreeMap<String, usize>,
     pub samples: Vec<SimSample>,
 }
 
@@ -517,6 +520,47 @@ fn mint_stream(journal: &mut TaskJournal, stream: &Stream, start_micros: i64, en
     }
 }
 
+fn streams_from_journal(journal: &TaskJournal) -> Vec<Stream> {
+    // Streams from the journal: dedup tasks name the source table, rollup
+    // tasks name the tier tables. No tasks -> no minting (an empty journal
+    // just idles, which is itself a valid answer).
+    let mut streams: Vec<Stream> = Vec::new();
+    for task in journal.tasks() {
+        let key = &task.key;
+        let position = match streams.iter().position(|s| s.source == key.source && s.project_id == key.project_id) {
+            Some(position) => position,
+            None => {
+                streams.push(Stream {
+                    source_table: key.source.clone(),
+                    base_rollup_table: key.physical_table.clone(),
+                    derived_rollup_table: None,
+                    source: key.source.clone(),
+                    project_id: key.project_id.clone(),
+                    last_created_ms: 0,
+                });
+                streams.len() - 1
+            }
+        };
+        let stream = &mut streams[position];
+        stream.last_created_ms = stream.last_created_ms.max(task.created_unix_ms);
+        match key.operation {
+            Operation::Dedup | Operation::HotPacking => stream.source_table = key.physical_table.clone(),
+            Operation::BaseRollup => stream.base_rollup_table = key.physical_table.clone(),
+            Operation::DerivedRollup => stream.derived_rollup_table = Some(key.physical_table.clone()),
+            _ => {}
+        }
+    }
+    streams
+}
+
+/// A brief restart reconciles the touched hour from each stream, not its day.
+fn reconcile_restart(journal: &mut TaskJournal, streams: &[Stream], now: i64) {
+    let hour_start = now.div_euclid(HOUR_MICROS) * HOUR_MICROS;
+    for stream in streams {
+        mint_stream(journal, stream, hour_start, hour_start + HOUR_MICROS, now);
+    }
+}
+
 /// The claim-time preflight, mirroring `database/maintain.rs:1273-1278`:
 /// measure what the claimed slice reads, record it on the unit whether or not
 /// it splits, and split before dispatch when it is over budget and still wide
@@ -559,10 +603,10 @@ fn preflight(journal: &mut TaskJournal, model: &ByteModel, guard: SplitGuard, ta
 
 /// Clear the parent's measurement so `split_sheds_enough` takes its `None` arm
 /// — the only way to run the pre-fix behaviour without touching the shipped
-/// predicate. The claimed task is the journal's own post-`mark_running` copy,
-/// so re-upserting it changes exactly this one field.
+/// predicate. Read the current task so preflight evidence recorded since the
+/// claim is retained when changing the guard.
 fn defeat_guard(journal: &mut TaskJournal, task: &MaintenanceTask) {
-    let mut task = task.clone();
+    let mut task = journal.tasks().find(|current| current.key == task.key).cloned().expect("preflight task remains in the journal");
     task.parent_measured_bytes = None;
     journal.upsert(task);
 }
@@ -594,35 +638,7 @@ pub fn run(mut journal: TaskJournal, cfg: &SimConfig, start_micros: i64) -> anyh
     let mut rng = Rng(cfg.seed);
     let end = start_micros.saturating_add(cfg.horizon_micros);
 
-    // Streams from the journal: dedup tasks name the source table, rollup
-    // tasks name the tier tables. No tasks -> no minting (an empty journal
-    // just idles, which is itself a valid answer).
-    let mut streams: Vec<Stream> = Vec::new();
-    for task in journal.tasks() {
-        let key = &task.key;
-        let position = match streams.iter().position(|s| s.source == key.source && s.project_id == key.project_id) {
-            Some(position) => position,
-            None => {
-                streams.push(Stream {
-                    source_table: key.source.clone(),
-                    base_rollup_table: key.physical_table.clone(),
-                    derived_rollup_table: None,
-                    source: key.source.clone(),
-                    project_id: key.project_id.clone(),
-                    last_created_ms: 0,
-                });
-                streams.len() - 1
-            }
-        };
-        let stream = &mut streams[position];
-        stream.last_created_ms = stream.last_created_ms.max(task.created_unix_ms);
-        match key.operation {
-            Operation::Dedup | Operation::HotPacking => stream.source_table = key.physical_table.clone(),
-            Operation::BaseRollup => stream.base_rollup_table = key.physical_table.clone(),
-            Operation::DerivedRollup => stream.derived_rollup_table = Some(key.physical_table.clone()),
-            _ => {}
-        }
-    }
+    let mut streams = streams_from_journal(&journal);
     // Only streams that are actually INGESTING mint. Discovery walks every task
     // the journal ever held, so without this an account that stopped writing
     // weeks ago still generates frontier work forever — which is where the ~6x
@@ -756,24 +772,7 @@ pub fn run(mut journal: TaskJournal, cfg: &SimConfig, start_micros: i64) -> anyh
         }
 
         if now >= next_restart {
-            for stream in &streams {
-                // The boot reconcile enqueues per partition that saw commits
-                // while down. Models the 2026-08-18 behavior: touched hours are
-                // derived from commit file statistics, so a brief restart
-                // reconciles the CURRENT hour rather than the whole partition-day
-                // — ~13 tasks per stream rather than ~312, and 13/312 is 1/24,
-                // which is exactly this one-hour-instead-of-one-day change.
-                //
-                // It used to mint `[day_start, day_start + DAY)`. That was the
-                // PRE-fix shape and it dominated every restart backtest: measured
-                // 2026-08-23 on the real prod journal, 2 virtual hours of hourly
-                // restarts left pending at 57,444 against 22,484 with no
-                // restarts, for IDENTICAL work done (2,190 executions, identical
-                // completions). Keeping a stale model is worse than having none —
-                // it prices a fix that already shipped.
-                let hour_start = now.div_euclid(HOUR_MICROS) * HOUR_MICROS;
-                mint_stream(&mut journal, stream, hour_start, hour_start + HOUR_MICROS, now);
-            }
+            reconcile_restart(&mut journal, &streams, now);
             none_until = [0; 6];
             next_restart = if cfg.restart_every_micros > 0 { next_restart + cfg.restart_every_micros } else { i64::MAX };
         }
@@ -947,7 +946,10 @@ pub fn run(mut journal: TaskJournal, cfg: &SimConfig, start_micros: i64) -> anyh
     for task in journal.tasks() {
         *report.tasks_end.entry(format!("{:?}/{:?}", task.key.operation, task.state)).or_default() += 1;
         *report.units_per_cell.entry(cell_of(&task.key)).or_default() += 1;
-        report.units_at_min_slice += usize::from(task.key.slice.width() <= MIN_SLICE_MICROS);
+        if task.key.slice.width() <= MIN_SLICE_MICROS {
+            report.units_at_min_slice += 1;
+            *report.min_slice_units_per_cell.entry(cell_of(&task.key)).or_default() += 1;
+        }
     }
     if let Some((cell, units)) = report.units_per_cell.iter().max_by_key(|(_, units)| **units) {
         (report.max_cell, report.max_cell_units) = (cell.clone(), *units);
@@ -1346,31 +1348,21 @@ mod tests {
 
     #[test]
     fn a_restart_reconciles_only_the_touched_hour() {
-        // Pins the 2026-08-18 boot-reconcile behavior the model now mirrors:
-        // touched hours come from commit file statistics, so a restart
-        // re-invalidates the CURRENT HOUR per stream, not the whole
-        // partition-day. That is ~13 tasks per stream rather than ~312.
-        //
-        // The previous version of this test asserted the opposite — that hourly
-        // restarts add >100 pending — and it passed because the model still
-        // minted a whole day. Keeping it would have pinned a fix out of the
-        // model: measured 2026-08-23 on the real prod journal, the stale model
-        // reported 57,444 pending against 22,484 calm, while the corrected one
-        // reports 23,948. A backtest that prices an already-shipped fix as still
-        // broken is worse than no backtest.
-        let start = 100 * DAY_MICROS;
-        let calm = run(journal_with_streams(4), &cfg(2), start).unwrap();
-        let churning = run(journal_with_streams(4), &SimConfig { restart_every_micros: HOUR, ..cfg(2) }, start).unwrap();
-        assert!(churning.pending_end >= calm.pending_end, "a restart cannot REDUCE the queue: calm {} vs churning {}", calm.pending_end, churning.pending_end);
-        // An hour of reconcile per stream per restart, not a day of it. The
-        // bound is deliberately far below the old >100 assertion — that gap IS
-        // the fix.
+        let mut journal = journal_with_streams(4);
+        let before: HashMap<_, _> = journal.tasks().map(|task| (task.key.clone(), serde_json::to_value(task).unwrap())).collect();
+        let streams = streams_from_journal(&journal);
+        let hour_start = 100 * DAY_MICROS + 7 * HOUR;
+        reconcile_restart(&mut journal, &streams, hour_start + HOUR / 2);
+        let added: Vec<_> = journal.tasks().filter(|task| !before.contains_key(&task.key)).collect();
+        assert_eq!(added.len(), 13 * streams.len(), "each stream needs six dedup slices, six base slices, and one derived hour");
         assert!(
-            churning.pending_end < calm.pending_end + 100,
-            "an hour-scoped reconcile must not grow the queue like a day-scoped one: calm {} vs churning {}",
-            calm.pending_end,
-            churning.pending_end
+            added.iter().all(|task| task.key.slice.start_micros >= hour_start && task.key.slice.end_micros <= hour_start + HOUR),
+            "restart must only reconcile the touched hour"
         );
+        for (key, prior) in before {
+            let current = journal.tasks().find(|task| task.key == key).expect("unrelated task preserved");
+            assert_eq!(serde_json::to_value(current).unwrap(), prior, "unrelated history stays unchanged");
+        }
     }
 
     /// The §3c run: `synth:whale`, 6 virtual hours, 16 workers, no minting —
@@ -1457,7 +1449,7 @@ mod tests {
             // subtree). The discriminating property is unchanged and is the
             // only one asserted below: NOTHING reaches MIN_SLICE_MICROS.
             assert!(cell_units(&report, &whale) < 300, "{guard:?}: {} units", cell_units(&report, &whale));
-            assert_eq!(report.units_at_min_slice, 0, "{guard:?}: nothing may reach the floor");
+            assert_eq!(report.min_slice_units_per_cell.get(&whale).copied().unwrap_or_default(), 0, "{guard:?}: the floorless whale must not reach the floor");
         }
     }
 


### PR DESCRIPTION
Repeated maintenance failures force time bisection by passing a synthetic byte count to the byte-based splitter. That value also becomes parent_measured_bytes, so later decisions treat a request to split as evidence of input size. Production timeout descendants carried the exact synthetic value 536870913.

Separate preflight-driven splitting from repeated-failure splitting. Retain each claim’s preflight byte estimate in an optional journal field, and use it when deciding whether narrower slices reduced input cost. A failure can still request two smaller tasks below the byte budget, but cannot invent a measurement. Children receive apportioned estimates and only genuine preflight ancestry; each new claim collects fresh preflight evidence. Dedup, rollup, and simulation paths use the same recording method.

Repair refusal, minimum slice width, one-level splitting, retry backoff, and measured-cost floor checks remain. Older journals deserialize the new field as absent; no destructive migration is required.

Validation: all four original real-TaskJournal regression cases failed before the fix, including persisted/reloaded child estimates. Extended coverage checks retained preflight evidence and both timeout/capacity floor refusal. Local formatting and diff checks passed. CI34207703884 passed 1,441 tests across both shards, eight PostgreSQL smoke cases, E2E, Clippy, formatting, and attestation. Rust security analysis and all remaining PR checks passed on 4b7fdc1367be321bd7507caaceb81bfb9ec59fb3. The simulator byte-only control now excludes independent duration timeouts and asserts zero timeouts; timeout behavior remains covered separately. Restart reconciliation verifies exactly the touched hour and unchanged historical records. Production verification will inspect new claim measurements and retry descendants after deployment.
