### PR TITLE
fix: preserve positional scan ordering through optimization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2963,7 +2963,7 @@ dependencies = [
 [[package]]
 name = "deltalake"
 version = "1.0.0"
-source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=011769b39752ae13f4c4c3758d2254f598326465#011769b39752ae13f4c4c3758d2254f598326465"
+source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=12847eb612ad49a7d43850081639b4647c42d3ec#12847eb612ad49a7d43850081639b4647c42d3ec"
 dependencies = [
  "buoyant_kernel 0.24.0",
  "ctor",
@@ -2974,7 +2974,7 @@ dependencies = [
 [[package]]
 name = "deltalake-aws"
 version = "1.0.0"
-source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=011769b39752ae13f4c4c3758d2254f598326465#011769b39752ae13f4c4c3758d2254f598326465"
+source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=12847eb612ad49a7d43850081639b4647c42d3ec#12847eb612ad49a7d43850081639b4647c42d3ec"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -2997,7 +2997,7 @@ dependencies = [
 [[package]]
 name = "deltalake-core"
 version = "1.0.0"
-source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=011769b39752ae13f4c4c3758d2254f598326465#011769b39752ae13f4c4c3758d2254f598326465"
+source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=12847eb612ad49a7d43850081639b4647c42d3ec#12847eb612ad49a7d43850081639b4647c42d3ec"
 dependencies = [
  "alloc-stdlib",
  "arrow",
@@ -3055,7 +3055,7 @@ dependencies = [
 [[package]]
 name = "deltalake-derive"
 version = "1.0.0"
-source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=011769b39752ae13f4c4c3758d2254f598326465#011769b39752ae13f4c4c3758d2254f598326465"
+source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=12847eb612ad49a7d43850081639b4647c42d3ec#12847eb612ad49a7d43850081639b4647c42d3ec"
 dependencies = [
  "convert_case 0.9.0",
  "itertools 0.14.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2200,7 +2200,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=2c2974878bb805bfded84580981d1a6e31ca709f#2c2974878bb805bfded84580981d1a6e31ca709f"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -2252,7 +2252,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=2c2974878bb805bfded84580981d1a6e31ca709f#2c2974878bb805bfded84580981d1a6e31ca709f"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2276,7 +2276,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=2c2974878bb805bfded84580981d1a6e31ca709f#2c2974878bb805bfded84580981d1a6e31ca709f"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2298,7 +2298,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=2c2974878bb805bfded84580981d1a6e31ca709f#2c2974878bb805bfded84580981d1a6e31ca709f"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -2323,7 +2323,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=2c2974878bb805bfded84580981d1a6e31ca709f#2c2974878bb805bfded84580981d1a6e31ca709f"
 dependencies = [
  "futures",
  "log",
@@ -2333,7 +2333,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=2c2974878bb805bfded84580981d1a6e31ca709f#2c2974878bb805bfded84580981d1a6e31ca709f"
 dependencies = [
  "arrow",
  "async-compression",
@@ -2368,7 +2368,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-arrow"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=2c2974878bb805bfded84580981d1a6e31ca709f#2c2974878bb805bfded84580981d1a6e31ca709f"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -2391,7 +2391,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=2c2974878bb805bfded84580981d1a6e31ca709f#2c2974878bb805bfded84580981d1a6e31ca709f"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2413,7 +2413,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=2c2974878bb805bfded84580981d1a6e31ca709f#2c2974878bb805bfded84580981d1a6e31ca709f"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2435,7 +2435,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=2c2974878bb805bfded84580981d1a6e31ca709f#2c2974878bb805bfded84580981d1a6e31ca709f"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2465,12 +2465,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=2c2974878bb805bfded84580981d1a6e31ca709f#2c2974878bb805bfded84580981d1a6e31ca709f"
 
 [[package]]
 name = "datafusion-execution"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=2c2974878bb805bfded84580981d1a6e31ca709f#2c2974878bb805bfded84580981d1a6e31ca709f"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -2491,7 +2491,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=2c2974878bb805bfded84580981d1a6e31ca709f#2c2974878bb805bfded84580981d1a6e31ca709f"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -2513,7 +2513,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=2c2974878bb805bfded84580981d1a6e31ca709f#2c2974878bb805bfded84580981d1a6e31ca709f"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2524,7 +2524,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=2c2974878bb805bfded84580981d1a6e31ca709f#2c2974878bb805bfded84580981d1a6e31ca709f"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -2555,7 +2555,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=2c2974878bb805bfded84580981d1a6e31ca709f#2c2974878bb805bfded84580981d1a6e31ca709f"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2575,7 +2575,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=2c2974878bb805bfded84580981d1a6e31ca709f#2c2974878bb805bfded84580981d1a6e31ca709f"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2599,7 +2599,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=2c2974878bb805bfded84580981d1a6e31ca709f#2c2974878bb805bfded84580981d1a6e31ca709f"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -2623,7 +2623,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=2c2974878bb805bfded84580981d1a6e31ca709f#2c2974878bb805bfded84580981d1a6e31ca709f"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=2c2974878bb805bfded84580981d1a6e31ca709f#2c2974878bb805bfded84580981d1a6e31ca709f"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2654,7 +2654,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=2c2974878bb805bfded84580981d1a6e31ca709f#2c2974878bb805bfded84580981d1a6e31ca709f"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -2663,7 +2663,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=2c2974878bb805bfded84580981d1a6e31ca709f#2c2974878bb805bfded84580981d1a6e31ca709f"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -2673,7 +2673,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=2c2974878bb805bfded84580981d1a6e31ca709f#2c2974878bb805bfded84580981d1a6e31ca709f"
 dependencies = [
  "arrow",
  "chrono",
@@ -2706,7 +2706,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=2c2974878bb805bfded84580981d1a6e31ca709f#2c2974878bb805bfded84580981d1a6e31ca709f"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2727,7 +2727,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-adapter"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=2c2974878bb805bfded84580981d1a6e31ca709f#2c2974878bb805bfded84580981d1a6e31ca709f"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2741,7 +2741,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=2c2974878bb805bfded84580981d1a6e31ca709f#2c2974878bb805bfded84580981d1a6e31ca709f"
 dependencies = [
  "arrow",
  "chrono",
@@ -2757,7 +2757,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=2c2974878bb805bfded84580981d1a6e31ca709f#2c2974878bb805bfded84580981d1a6e31ca709f"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2775,7 +2775,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=2c2974878bb805bfded84580981d1a6e31ca709f#2c2974878bb805bfded84580981d1a6e31ca709f"
 dependencies = [
  "arrow",
  "arrow-data",
@@ -2830,7 +2830,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=2c2974878bb805bfded84580981d1a6e31ca709f#2c2974878bb805bfded84580981d1a6e31ca709f"
 dependencies = [
  "arrow",
  "chrono",
@@ -2856,7 +2856,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-common"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=2c2974878bb805bfded84580981d1a6e31ca709f#2c2974878bb805bfded84580981d1a6e31ca709f"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2866,7 +2866,7 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=2c2974878bb805bfded84580981d1a6e31ca709f#2c2974878bb805bfded84580981d1a6e31ca709f"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2881,7 +2881,7 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=2c2974878bb805bfded84580981d1a6e31ca709f#2c2974878bb805bfded84580981d1a6e31ca709f"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -2894,7 +2894,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "54.1.0"
-source = "git+https://github.com/tonyalaribe/datafusion.git?rev=158e8405f8bdfcc144468ad8940d6dfcda22b623#158e8405f8bdfcc144468ad8940d6dfcda22b623"
+source = "git+https://github.com/tonyalaribe/datafusion.git?rev=2c2974878bb805bfded84580981d1a6e31ca709f#2c2974878bb805bfded84580981d1a6e31ca709f"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -2963,7 +2963,7 @@ dependencies = [
 [[package]]
 name = "deltalake"
 version = "1.0.0"
-source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=8724b0c3b59bad831e87840edb450e4cc80ada73#8724b0c3b59bad831e87840edb450e4cc80ada73"
+source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=6c291c5e7b324c83e77912ff9572f06f8fb4f223#6c291c5e7b324c83e77912ff9572f06f8fb4f223"
 dependencies = [
  "buoyant_kernel 0.24.0",
  "ctor",
@@ -2974,7 +2974,7 @@ dependencies = [
 [[package]]
 name = "deltalake-aws"
 version = "1.0.0"
-source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=8724b0c3b59bad831e87840edb450e4cc80ada73#8724b0c3b59bad831e87840edb450e4cc80ada73"
+source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=6c291c5e7b324c83e77912ff9572f06f8fb4f223#6c291c5e7b324c83e77912ff9572f06f8fb4f223"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -2997,7 +2997,7 @@ dependencies = [
 [[package]]
 name = "deltalake-core"
 version = "1.0.0"
-source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=8724b0c3b59bad831e87840edb450e4cc80ada73#8724b0c3b59bad831e87840edb450e4cc80ada73"
+source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=6c291c5e7b324c83e77912ff9572f06f8fb4f223#6c291c5e7b324c83e77912ff9572f06f8fb4f223"
 dependencies = [
  "alloc-stdlib",
  "arrow",
@@ -3055,7 +3055,7 @@ dependencies = [
 [[package]]
 name = "deltalake-derive"
 version = "1.0.0"
-source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=8724b0c3b59bad831e87840edb450e4cc80ada73#8724b0c3b59bad831e87840edb450e4cc80ada73"
+source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=6c291c5e7b324c83e77912ff9572f06f8fb4f223#6c291c5e7b324c83e77912ff9572f06f8fb4f223"
 dependencies = [
  "convert_case 0.9.0",
  "itertools 0.14.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2963,7 +2963,7 @@ dependencies = [
 [[package]]
 name = "deltalake"
 version = "1.0.0"
-source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=6c291c5e7b324c83e77912ff9572f06f8fb4f223#6c291c5e7b324c83e77912ff9572f06f8fb4f223"
+source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=011769b39752ae13f4c4c3758d2254f598326465#011769b39752ae13f4c4c3758d2254f598326465"
 dependencies = [
  "buoyant_kernel 0.24.0",
  "ctor",
@@ -2974,7 +2974,7 @@ dependencies = [
 [[package]]
 name = "deltalake-aws"
 version = "1.0.0"
-source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=6c291c5e7b324c83e77912ff9572f06f8fb4f223#6c291c5e7b324c83e77912ff9572f06f8fb4f223"
+source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=011769b39752ae13f4c4c3758d2254f598326465#011769b39752ae13f4c4c3758d2254f598326465"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -2997,7 +2997,7 @@ dependencies = [
 [[package]]
 name = "deltalake-core"
 version = "1.0.0"
-source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=6c291c5e7b324c83e77912ff9572f06f8fb4f223#6c291c5e7b324c83e77912ff9572f06f8fb4f223"
+source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=011769b39752ae13f4c4c3758d2254f598326465#011769b39752ae13f4c4c3758d2254f598326465"
 dependencies = [
  "alloc-stdlib",
  "arrow",
@@ -3055,7 +3055,7 @@ dependencies = [
 [[package]]
 name = "deltalake-derive"
 version = "1.0.0"
-source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=6c291c5e7b324c83e77912ff9572f06f8fb4f223#6c291c5e7b324c83e77912ff9572f06f8fb4f223"
+source = "git+https://github.com/tonyalaribe/delta-rs-timefusion.git?rev=011769b39752ae13f4c4c3758d2254f598326465#011769b39752ae13f4c4c3758d2254f598326465"
 dependencies = [
  "convert_case 0.9.0",
  "itertools 0.14.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ regex = "1.11.1"
 # push, which busts cargo-chef's recipe.json and forces a full dependency
 # recompile in CI. Bump deliberately to pick up fork changes:
 #   cargo update -p deltalake --precise <new-sha>   (then update this rev)
-deltalake = { git = "https://github.com/tonyalaribe/delta-rs-timefusion.git", rev = "011769b39752ae13f4c4c3758d2254f598326465", features = [
+deltalake = { git = "https://github.com/tonyalaribe/delta-rs-timefusion.git", rev = "12847eb612ad49a7d43850081639b4647c42d3ec", features = [
   "datafusion",
   "s3",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ regex = "1.11.1"
 # push, which busts cargo-chef's recipe.json and forces a full dependency
 # recompile in CI. Bump deliberately to pick up fork changes:
 #   cargo update -p deltalake --precise <new-sha>   (then update this rev)
-deltalake = { git = "https://github.com/tonyalaribe/delta-rs-timefusion.git", rev = "8724b0c3b59bad831e87840edb450e4cc80ada73", features = [
+deltalake = { git = "https://github.com/tonyalaribe/delta-rs-timefusion.git", rev = "6c291c5e7b324c83e77912ff9572f06f8fb4f223", features = [
   "datafusion",
   "s3",
 ] }
@@ -260,39 +260,39 @@ datafusion-postgres = { git = "https://github.com/apitoolkit/datafusion-postgres
 # DataFusion 54.1 with shared sort-buffer reservations, positional Parquet scan protection, SQL DEALLOCATE ALL,
 # and the existing UPDATE FROM support.
 # Keep the workspace crates on one source so their public Rust types agree.
-datafusion = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
-datafusion-catalog = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
-datafusion-catalog-listing = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
-datafusion-common = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
-datafusion-common-runtime = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
-datafusion-datasource = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
-datafusion-datasource-arrow = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
-datafusion-datasource-csv = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
-datafusion-datasource-json = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
-datafusion-datasource-parquet = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
-datafusion-doc = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
-datafusion-execution = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
-datafusion-expr = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
-datafusion-expr-common = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
-datafusion-functions = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
-datafusion-functions-aggregate = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
-datafusion-functions-aggregate-common = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
-datafusion-functions-nested = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
-datafusion-functions-table = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
-datafusion-functions-window = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
-datafusion-functions-window-common = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
-datafusion-macros = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
-datafusion-optimizer = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
-datafusion-physical-expr = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
-datafusion-physical-expr-adapter = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
-datafusion-physical-expr-common = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
-datafusion-physical-optimizer = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
-datafusion-physical-plan = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
-datafusion-proto = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
-datafusion-proto-common = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
-datafusion-pruning = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
-datafusion-session = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
-datafusion-sql = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "158e8405f8bdfcc144468ad8940d6dfcda22b623" }
+datafusion = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "2c2974878bb805bfded84580981d1a6e31ca709f" }
+datafusion-catalog = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "2c2974878bb805bfded84580981d1a6e31ca709f" }
+datafusion-catalog-listing = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "2c2974878bb805bfded84580981d1a6e31ca709f" }
+datafusion-common = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "2c2974878bb805bfded84580981d1a6e31ca709f" }
+datafusion-common-runtime = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "2c2974878bb805bfded84580981d1a6e31ca709f" }
+datafusion-datasource = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "2c2974878bb805bfded84580981d1a6e31ca709f" }
+datafusion-datasource-arrow = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "2c2974878bb805bfded84580981d1a6e31ca709f" }
+datafusion-datasource-csv = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "2c2974878bb805bfded84580981d1a6e31ca709f" }
+datafusion-datasource-json = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "2c2974878bb805bfded84580981d1a6e31ca709f" }
+datafusion-datasource-parquet = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "2c2974878bb805bfded84580981d1a6e31ca709f" }
+datafusion-doc = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "2c2974878bb805bfded84580981d1a6e31ca709f" }
+datafusion-execution = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "2c2974878bb805bfded84580981d1a6e31ca709f" }
+datafusion-expr = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "2c2974878bb805bfded84580981d1a6e31ca709f" }
+datafusion-expr-common = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "2c2974878bb805bfded84580981d1a6e31ca709f" }
+datafusion-functions = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "2c2974878bb805bfded84580981d1a6e31ca709f" }
+datafusion-functions-aggregate = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "2c2974878bb805bfded84580981d1a6e31ca709f" }
+datafusion-functions-aggregate-common = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "2c2974878bb805bfded84580981d1a6e31ca709f" }
+datafusion-functions-nested = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "2c2974878bb805bfded84580981d1a6e31ca709f" }
+datafusion-functions-table = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "2c2974878bb805bfded84580981d1a6e31ca709f" }
+datafusion-functions-window = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "2c2974878bb805bfded84580981d1a6e31ca709f" }
+datafusion-functions-window-common = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "2c2974878bb805bfded84580981d1a6e31ca709f" }
+datafusion-macros = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "2c2974878bb805bfded84580981d1a6e31ca709f" }
+datafusion-optimizer = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "2c2974878bb805bfded84580981d1a6e31ca709f" }
+datafusion-physical-expr = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "2c2974878bb805bfded84580981d1a6e31ca709f" }
+datafusion-physical-expr-adapter = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "2c2974878bb805bfded84580981d1a6e31ca709f" }
+datafusion-physical-expr-common = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "2c2974878bb805bfded84580981d1a6e31ca709f" }
+datafusion-physical-optimizer = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "2c2974878bb805bfded84580981d1a6e31ca709f" }
+datafusion-physical-plan = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "2c2974878bb805bfded84580981d1a6e31ca709f" }
+datafusion-proto = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "2c2974878bb805bfded84580981d1a6e31ca709f" }
+datafusion-proto-common = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "2c2974878bb805bfded84580981d1a6e31ca709f" }
+datafusion-pruning = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "2c2974878bb805bfded84580981d1a6e31ca709f" }
+datafusion-session = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "2c2974878bb805bfded84580981d1a6e31ca709f" }
+datafusion-sql = { git = "https://github.com/tonyalaribe/datafusion.git", rev = "2c2974878bb805bfded84580981d1a6e31ca709f" }
 # tikv-jemalloc-sys 0.6.1 vendored with a single build.rs delta: honour
 # `JEMALLOC_SYS_PROF_BACKTRACE` so the heap profiler can be built with a working
 # unwinder (`--enable-prof-libunwind`). Upstream passes `--enable-prof` alone and

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ regex = "1.11.1"
 # push, which busts cargo-chef's recipe.json and forces a full dependency
 # recompile in CI. Bump deliberately to pick up fork changes:
 #   cargo update -p deltalake --precise <new-sha>   (then update this rev)
-deltalake = { git = "https://github.com/tonyalaribe/delta-rs-timefusion.git", rev = "6c291c5e7b324c83e77912ff9572f06f8fb4f223", features = [
+deltalake = { git = "https://github.com/tonyalaribe/delta-rs-timefusion.git", rev = "011769b39752ae13f4c4c3758d2254f598326465", features = [
   "datafusion",
   "s3",
 ] }

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -19479,15 +19479,25 @@ mod tests {
         // ENTIRELY — not downgraded to a merge, removed. That is the whole
         // remaining cost of a dedup rewrite (the bench put the sort at 81% of
         // one), so this assertion is guarding the win, not a detail.
-        let declared = rendered.split("output_ordering=[").nth(1).and_then(|rest| rest.split(']').next()).unwrap_or("").to_owned();
-        for column in &schema.sorting_columns {
-            assert!(
-                declared.contains(column.name.as_str()),
-                "`{}` is missing from the declared ordering, so the footer index no longer resolves to the column it names — \
-                 the rewrite is paying a full sort again. declared=[{declared}]",
-                column.name
-            );
+        let mut pending = vec![Arc::clone(&plan)];
+        let mut scans = 0;
+        while let Some(node) = pending.pop() {
+            if node.downcast_ref::<DataSourceExec>().is_some() {
+                let declared = node.properties().output_ordering().expect("the Parquet scan retains its footer ordering");
+                let actual: Vec<_> = declared
+                    .iter()
+                    .map(|expr| {
+                        let column = expr.expr.downcast_ref::<datafusion::physical_expr::expressions::Column>().expect("plain sort column");
+                        (column.name(), expr.options.descending, expr.options.nulls_first)
+                    })
+                    .collect();
+                let expected: Vec<_> = schema.sorting_columns.iter().map(|column| (column.name.as_str(), column.descending, column.nulls_first)).collect();
+                assert_eq!(actual, expected, "the scan must retain all footer keys in order, including direction and null placement");
+                scans += 1;
+            }
+            pending.extend(node.children().into_iter().cloned());
         }
+        assert!(scans > 0, "must inspect the actual Parquet scan");
         assert!(!rendered.contains("SortExec"), "the declared ordering satisfies the schema sort, so nothing should sort:\n{rendered}");
         Ok(())
     }

--- a/tests/e2e/ordering_pushdown.rs
+++ b/tests/e2e/ordering_pushdown.rs
@@ -17,8 +17,8 @@ use super::harness::{E2eEnv, FROZEN_START_MICROS, insert_at};
 
 /// monoscope's ACTUAL log-explorer listing must stream, not materialise.
 ///
-/// `order_by_ts_desc_limit_merges_mem_and_delta` pins the same window and limit
-/// with a two-column projection and passes. Prod 2026-09-04 shows the real query
+/// `order_by_ts_desc_limit_merges_mem_and_delta` checks rows from both stores
+/// with a two-column projection. Prod 2026-09-04 shows the real query
 /// failing: from 09:58 a listing on one project retried every ~15 s, each attempt
 /// dying in `ExternalSorterMerge` at 5.5 GB, with **`scan.has_limit=false
 /// scan.limit=0`** in the span — the LIMIT never reached the scan, so the sort
@@ -84,23 +84,24 @@ async fn order_by_ts_desc_limit_merges_mem_and_delta() -> anyhow::Result<()> {
     let client = env.pg_client().await?;
 
     let sec = 1_000_000i64;
-    // 5 older rows → flushed to Delta (physically DESC-sorted, honest footer).
-    for i in 0..5 {
-        insert_at(&client, &format!("old-{i}"), FROZEN_START_MICROS + i * sec).await?;
+    // Two separate flushes exercise ordered readers across multiple Delta files.
+    for batch in 0..2 {
+        let base = FROZEN_START_MICROS + batch * (bucket_secs as i64) * 3 * sec;
+        for i in 0..5 {
+            insert_at(&client, &format!("old-{}", batch * 5 + i), base + i * sec).await?;
+        }
+        env.advance(Duration::from_secs(bucket_secs * 3));
+        env.force_flush().await?;
     }
-    // Advance well past the bucket boundary so the old bucket is completed, then
-    // flush it out to Delta and drain MemBuffer.
-    env.advance(Duration::from_secs(bucket_secs * 3));
-    env.force_flush().await?;
 
     // 5 newer rows stay in MemBuffer (current, open bucket).
-    let new_base = FROZEN_START_MICROS + (bucket_secs as i64) * 3 * sec;
+    let new_base = FROZEN_START_MICROS + (bucket_secs as i64) * 6 * sec;
     for i in 0..5 {
         insert_at(&client, &format!("new-{i}"), new_base + i * sec).await?;
     }
 
     // The query has no lower time bound, so it spans MemBuffer ∪ Delta.
-    let sql = "SELECT id, timestamp FROM otel_logs_and_spans WHERE project_id = 'e2e_project' ORDER BY timestamp DESC LIMIT 3";
+    let sql = "SELECT id, timestamp FROM otel_logs_and_spans WHERE project_id = 'e2e_project' ORDER BY timestamp DESC LIMIT 12";
 
     // Plan shape: the union became order-preserving → a streaming merge, not a
     // blocking sort over the full window.
@@ -113,10 +114,14 @@ async fn order_by_ts_desc_limit_merges_mem_and_delta() -> anyhow::Result<()> {
         .join("\n");
     assert!(plan.contains("SortPreservingMergeExec"), "expected a streaming SortPreservingMergeExec (ordering pushdown fired); plan was:\n{plan}");
 
-    // Correctness: true top-3 newest, strictly descending, drawn from MemBuffer.
+    // The result must cross memory and both Delta files, with no omissions or duplicates.
     let rows = client.query(sql, &[]).await?;
     let ids: Vec<String> = rows.iter().map(|r| r.get::<_, String>(0)).collect();
-    assert_eq!(ids, vec!["new-4", "new-3", "new-2"], "wrong top-n or wrong order; plan:\n{plan}");
+    assert_eq!(
+        ids,
+        vec!["new-4", "new-3", "new-2", "new-1", "new-0", "old-9", "old-8", "old-7", "old-6", "old-5", "old-4", "old-3"],
+        "wrong top-n or wrong order; plan:\n{plan}"
+    );
 
     let ts: Vec<i64> = rows.iter().map(|r| r.get::<_, chrono::DateTime<chrono::Utc>>(1).timestamp_micros()).collect();
     assert!(ts.windows(2).all(|w| w[0] > w[1]), "timestamps not strictly descending: {ts:?}");


### PR DESCRIPTION
Production positional Delta scans lose existing file ordering when partitions are combined, forcing a blocking timestamp sort above the scan. Log explorer and health queries have exhausted the shared sort memory pool.

Pin Delta 12847eb612ad49a7d43850081639b4647c42d3ec and DataFusion 2c2974878bb805bfded84580981d1a6e31ca709f. The combined fix retains ordered partition merges and prevents newly inserted sorts from moving below positional deletion masks and row ordinals.

Regression evidence lives at the affected scan/optimizer boundary: the baseline lost the ordered merge, and an intermediate fix produced wrong visible rows after opposite-order sort pushdown. Delta now checks 24 combinations of masks, ordinals, reader ordering, and optimizer settings. The real-storage top-K test now flushes two separate Delta batches and requires the exact 12 newest rows across memory and both files, retaining its streaming-plan assertion. This integration candidate must pass the full TimeFusion suite as well as dependency PR validation before deployment.

Local validation: locked offline Cargo metadata resolution, formatting, and diff checks pass. Cargo.lock changes only the two fork sources. Full builds run in CI because prior local builds exhausted available disk. Production verification will compare exact row/count oracles and query plans, then monitor sort failures; a single successful query will not establish that shared-memory exhaustion is resolved.

Dependencies: merged https://github.com/tonyalaribe/datafusion/pull/2 and https://github.com/tonyalaribe/delta-rs-timefusion/pull/3, plus https://github.com/tonyalaribe/delta-rs-timefusion/pull/4. The two-file test exposed discarded timestamp statistics when a secondary sort column was all null; the follow-up collector fix retains available column bounds, and its focused real-Parquet regression failed before the correction. Draft; no deployment yet.

The existing maintenance ordering test also reproduced loss of secondary sort keys for a singleton file group. Delta now retains the full footer ordering as a separately validated candidate alongside the stats-backed prefix. The maintenance test inspects physical plan properties directly and checks every key, direction, and null placement, while still requiring the sort operator to disappear. This avoids depending on the display format for one versus multiple ordering candidates.

Current validation: E2E passed on the latest head. Full unit, security, and dependency validation remains pending. The previous fixture failure showed a complete ordered scan with no sort; its remaining failure was the old text parser, which has been replaced by the stricter property checks described above.
