### PR TITLE
test: freeze the open-bucket flush clock

### DIFF
--- a/src/write/mod.rs
+++ b/src/write/mod.rs
@@ -6755,6 +6755,8 @@ mod tests {
     #[serial]
     #[tokio::test]
     async fn force_flush_current_bucket_drains_open_window() {
+        let now = crate::support::set_micros(chrono::Utc::now().timestamp_micros());
+        let _clock = scopeguard::guard((), |_| crate::support::unfreeze());
         let dir = tempdir().unwrap();
         let cfg = create_test_config(dir.path().to_path_buf());
 
@@ -6766,8 +6768,9 @@ mod tests {
         layer.delta_write_callback = Some(Arc::new(move |_p, _t, _b, _wm| Box::pin(async move { Ok(Vec::new()) })));
         let layer = Arc::new(layer);
 
-        // create_test_batch uses now() timestamps → the current (open) bucket.
-        layer.insert(&project, &table, vec![create_test_batch(&project)]).await.unwrap();
+        // Row and flush clocks must stay in the same bucket even at a wall-clock boundary.
+        let batch = json_to_batch(vec![crate::support::test_helpers::test_span_ts("open", "span", &project, now)]).unwrap();
+        layer.insert(&project, &table, vec![batch]).await.unwrap();
 
         // Normal completed-bucket flush must NOT touch the open bucket.
         layer.flush_completed_buckets().await.unwrap();


### PR DESCRIPTION
The open-bucket force-flush regression can fail when wall time crosses a bucket boundary between inserting its fixture and flushing completed buckets. CI job102022757538 reproduced this at10:20:00 UTC: the completed-bucket flush legitimately drained the newly sealed bucket; retry passed.

Freeze the existing test clock, give the fixture an explicit matching timestamp, and restore wall time with the existing scopeguard dependency even on panic. Both original assertions remain: normal flushing leaves the open bucket, and forced flushing drains it. Production behavior is unchanged.

Validation: formatting and diff checks pass. Full CI is pending; the captured baseline failure is in timefusion-typed-ordering-shard2-passed.log.
