### PR TITLE
Enable production hash indexing automatically and preserve local CI errors

### DIFF
--- a/docs/local-ci.md
+++ b/docs/local-ci.md
@@ -92,6 +92,13 @@ Two differences worth knowing:
   Docker and is capped at two threads. It is the slowest check by far; `make ci
   CHECKS="fmt clippy test"` is the usual pre-push sweep.
 
+## PostgreSQL smoke networking
+
+The PostgreSQL 18 client runs in Docker against the local native server.
+It uses `host.docker.internal` with Docker’s `host-gateway` mapping on Linux
+and macOS. No environment setting is needed. Both platforms run the same
+smoke assertions.
+
 ## macOS: root certificates
 
 `make ci` exports `SSL_CERT_FILE=/etc/ssl/cert.pem` when it is unset and that

--- a/docs/plans/2026-09-08-indexed-hash-histogram-plan.md
+++ b/docs/plans/2026-09-08-indexed-hash-histogram-plan.md
@@ -635,3 +635,75 @@ end-to-end tests passed. All four requested checks were attested for the final
 source, including the 32 MiB streaming regression. Final gate status requires
 only canonical `pg-smoke` on GitHub due to the documented macOS networking
 limitation. No failed check was attested.
+
+
+### Goal audit — 2026-09-09 06:19 UTC
+
+Integration is merged to master at `97235f16`. Local fmt, Clippy, full tests,
+doctests, and e2e passed. GitHub reused those attestations and passed canonical
+PostgreSQL smoke. Build/deploy run `34317126834` is still building the image.
+The live service remains on `ed6e56b`; production deployment is not yet proven.
+
+The user rejected manual hash-index activation and reiterated local signoff.
+The production schema now declares exact hash elements by default, without a
+new environment variable or runtime switch. Existing coverage checks reject
+legacy manifests that lack these elements, so maintenance backfills them.
+Correct captured-row fallback remains available during incomplete coverage.
+Full local signoff for this schema change is running. This instruction
+supersedes the earlier plan to leave activation off until a separate rollout.
+Reviews, complete-path benchmarks, production validation, and subsequent
+CPU/memory profiles remain required. Next goal audit: 06:49 UTC.
+
+
+Local validation follow-up: the first full run failed, but a pre-existing TCP
+probe redirected subsequent stderr to `/dev/null`. A before/after probe
+against local MinIO reproduced the loss and verified the fix. Keep the socket
+open/close inside the subshell so caller stderr remains intact.
+
+The visible rerun executed 1,474 tests: 1,457 passed and 17 search-service tests
+failed because their shared fixture omitted `hashes`. The index builder's
+missing-element-column guard remains unchanged. The fixture now includes a
+nullable string-list column, matching the newly indexed production schema.
+Targeted search-service tests and canonical local pg-smoke are running.
+No failed check was attested as passing; fmt and Clippy passed independently.
+
+
+The corrected shared fixture passed all 20 search-service tests in 3.357s
+(nextest `e2d0160e-0117-4a39-94d8-7f1d41aedd91`). Canonical `make ci-signoff
+CHECKS="pg-smoke"` passed on macOS and published its attestation, using the
+same SELECT 1 and five PostgreSQL 18 catalog assertions as Linux. No remote
+smoke fallback is needed for the current source. Full signoff is still running.
+
+Production service inspection now reports image `97235f1` with 1/1 replicas.
+A read-only pgwire `SELECT 1` returned 1 in 27.18ms after that observation.
+This confirms basic connectivity for the streaming integration deployment;
+it does not prove indexed histogram latency. The always-on production schema
+change is still local pending final signoff.
+
+
+### 30-minute goal audit — 2026-09-09 06:49 UTC
+
+The streaming integration deployed successfully at `97235f1`; service state,
+pgwire connectivity, and the deployment readiness soak passed. Production
+hash indexing still awaits the local schema change. That change requires no
+user switch and automatically invalidates legacy element coverage.
+
+All 1,474 main tests and eight doctests passed. Canonical PostgreSQL smoke
+passed locally after fixing Docker Desktop networking. All 63 e2e tests are
+running. The first failed suite exposed a fixture that lacked the now-indexed
+hashes column; its correction passed all 20 search-service tests. The runner's
+stderr redirection bug was also reproduced and fixed without suppressing any
+failure or weakening the index builder's missing-column guard.
+
+Master advanced to `90d314f4` with a separate Rust refactor and attestation GC
+workflow. Incorporate those changes, then validate the combined source locally
+before pushing. Production histogram correctness and latency, complete-path
+benchmarks, remaining full-feature reviews, and subsequent CPU/memory profiles
+remain open. Next goal audit: 07:19 UTC.
+
+
+Before rebasing onto the concurrent master refactor, full local validation
+passed: 1,474 tests, eight doctests, 63 e2e tests, fmt, Clippy, and canonical
+PostgreSQL smoke. Both signoff commands exited 0. The final gate marked all
+five checks proven locally, with none left for GitHub. These attestations
+cover this source only; combined-source validation follows the rebase.

--- a/docs/plans/2026-09-08-indexed-hash-histogram-plan.md
+++ b/docs/plans/2026-09-08-indexed-hash-histogram-plan.md
@@ -707,3 +707,18 @@ passed: 1,474 tests, eight doctests, 63 e2e tests, fmt, Clippy, and canonical
 PostgreSQL smoke. Both signoff commands exited 0. The final gate marked all
 five checks proven locally, with none left for GitHub. These attestations
 cover this source only; combined-source validation follows the rebase.
+
+
+Final signoff after pulling `74295465`: `make ci-signoff` exited 0 for
+`14eaddea`. All 1,474 main tests, eight doctests, 63 e2e tests, fmt, Clippy,
+and canonical PostgreSQL smoke passed locally. Every check is attested;
+the final gate leaves none for GitHub. Main nextest run:
+`d9c584c8-f237-470e-8cb8-aa9849e86b3b` (147.551s). E2E run:
+`a11bd581-cfbd-4ebe-872e-c2bce35ed2ae` (212.474s).
+
+The pull retained master's shared host-gateway smoke implementation and our
+TCP-probe stderr fix. The existing production baseline is saved in
+`evidence/2026-09-08-hashes/production-integration-bounded-probes.json`:
+image `7429546`, one matching event in a one-second hash histogram (754.13ms),
+confirmed by ID lookup (1246.52ms). These timings precede automatic indexing.
+Push, merge, and production verification of the schema change follow.

--- a/docs/plans/evidence/2026-09-08-hashes/production-integration-bounded-probes.json
+++ b/docs/plans/evidence/2026-09-08-hashes/production-integration-bounded-probes.json
@@ -1,0 +1,28 @@
+{
+  "recorded_at": "2026-09-09T07:08:29.388449+00:00",
+  "service_image": "ghcr.io/monoscope-tech/timefusion:7429546",
+  "note": "Read-only bounded probes before automatic hash indexing deploy; not a full-window performance measurement.",
+  "queries": [
+    {
+      "name": "hash_histogram_one_second",
+      "sql": "SELECT time_bucket('1 hour',timestamp), count(*) FROM otel_logs_and_spans WHERE project_id='00000000-0000-0000-0000-000000000000' AND timestamp >= TIMESTAMP '2026-09-02 08:04:30' AND timestamp < TIMESTAMP '2026-09-02 08:04:31' AND hashes @> ARRAY['err:e03848c6'] GROUP BY 1",
+      "rows": [
+        [
+          "2026-09-02 08:00:00+00:00",
+          1
+        ]
+      ],
+      "elapsed_ms": 754.13
+    },
+    {
+      "name": "known_event_control",
+      "sql": "SELECT id FROM otel_logs_and_spans WHERE project_id='00000000-0000-0000-0000-000000000000' AND timestamp >= TIMESTAMP '2026-09-02 08:04:30' AND timestamp < TIMESTAMP '2026-09-02 08:04:31' AND id='1da21fbb-1d78-555f-ae88-a10edfc3afdf' AND hashes @> ARRAY['err:e03848c6'] LIMIT 1",
+      "rows": [
+        [
+          "1da21fbb-1d78-555f-ae88-a10edfc3afdf"
+        ]
+      ],
+      "elapsed_ms": 1246.52
+    }
+  ]
+}

--- a/schemas/otel_logs_and_spans.yaml
+++ b/schemas/otel_logs_and_spans.yaml
@@ -95,6 +95,7 @@ fields:
   - name: hashes
     data_type: "List(Utf8)"
     nullable: true
+    tantivy: { indexed: true, tokenizer: raw, list_mode: elements }
     # The one column production UPDATEs on this table (monoscope's enrichment
     # appends tags). Columns are immutable by DEFAULT, because a filter on an
     # immutable column can be pushed below the merge-on-read dedup and pruned at

--- a/scripts/ci/ci.sh
+++ b/scripts/ci/ci.sh
@@ -131,7 +131,7 @@ fingerprint() { # <check>
 # ---------------------------------------------------------------- capabilities
 
 probe_tcp() { # host port
-  (exec 3<>"/dev/tcp/$1/$2") 2>/dev/null && exec 3<&- 2>/dev/null || return 1
+  (exec 3<>"/dev/tcp/$1/$2") 2>/dev/null
 }
 
 # Split a postgres URL into host/port for probing without needing psql.

--- a/tests/suite/tantivy_search_test.rs
+++ b/tests/suite/tantivy_search_test.rs
@@ -85,8 +85,10 @@ fn batch(rows: &[(i64, &str, &str)]) -> RecordBatch {
         Field::new("timestamp", DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())), false),
         Field::new("id", DataType::Utf8, false),
         Field::new("level", DataType::Utf8, true),
+        Field::new("hashes", DataType::List(Arc::new(Field::new("item", DataType::Utf8, true))), true),
     ]));
-    RecordBatch::try_new(schema, vec![ts, id, level]).unwrap()
+    let hashes = arrow::array::new_null_array(schema.field(3).data_type(), rows.len());
+    RecordBatch::try_new(schema, vec![ts, id, level, hashes]).unwrap()
 }
 
 #[tokio::test]


### PR DESCRIPTION
The built-in telemetry schema omitted exact hash-element indexing, leaving production hash histograms without the indexed path. Declare it in the schema so normal writes index hashes and maintenance rebuilds legacy files automatically. Users need no feature switch or environment setting; captured-row fallback preserves correctness while coverage catches up.

Update the shared search-service fixture with the newly indexed nullable hashes column. The existing missing-column guard stays intact. Keep the CI TCP probe inside its subshell so a successful probe cannot discard subsequent test stderr. Document the portable PostgreSQL smoke networking now provided by master.

Validation:

- `make ci-signoff`: exit 0 on the final source after pulling master. Fmt, Clippy, all 1,474 tests, eight doctests, PostgreSQL 18 smoke, and 63 e2e tests passed locally. Every check was attested; none remain for GitHub.
- Main nextest: `d9c584c8-f237-470e-8cb8-aa9849e86b3b`, 147.551s. E2E: `a11bd581-cfbd-4ebe-872e-c2bce35ed2ae`, 212.474s.
- All 20 targeted search-service tests passed after reproducing the missing-column failures. A direct before/after TCP probe reproduced and fixed lost stderr. No failed check was attested.

A read-only production baseline on `7429546` returned the known event in a one-second hash histogram in 754.13ms, confirmed by ID lookup. This precedes automatic indexing and does not establish long-window performance. Production coverage, correctness, and latency validation continue after deployment.
