### PR TITLE
Distill the read path and a second maintenance pass

### DIFF
--- a/src/database/compact.rs
+++ b/src/database/compact.rs
@@ -151,10 +151,7 @@ impl Database {
                     let new_uris: Vec<String> = file_uris(&new_table);
                     let new_sets = Self::filesets_for_dates(&new_uris, &kept_dates);
                     let mut guard = self.zorder_filesets.write().await;
-                    let entry = guard.entry(table_url.clone()).or_default();
-                    for d in &kept_dates {
-                        entry.insert(*d, new_sets.get(d).cloned().unwrap_or_default());
-                    }
+                    guard.entry(table_url.clone()).or_default().extend(kept_dates.iter().map(|d| (*d, new_sets.get(d).cloned().unwrap_or_default())));
                 }
                 crate::observability::record_optimize_partitions(kept_dates.len() as u64, skipped as u64);
 
@@ -238,24 +235,22 @@ impl Database {
                     }
                     // Whatever carry-forward covered needs no build.
                     let added: Vec<_> = added.into_iter().filter(|(_, _, uri)| !carried.contains(uri)).collect();
-                    let mut built = 0usize;
-                    let mut reindex_errs = 0usize;
                     let table_owned = table_name.to_string();
-                    let mut jobs = futures::stream::iter(added.into_iter().map(|(pid, rel, uri)| {
+                    let (built, reindex_errs) = futures::stream::iter(added.into_iter().map(|(pid, rel, uri)| {
                         let (svc, store, table) = (svc.clone(), delta_store.clone(), table_owned.clone());
                         async move { svc.build_index_for_file(&table, &pid, &rel, &uri, store).await }
                     }))
-                    .buffer_unordered(self.config.tantivy.timefusion_tantivy_build_concurrency.max(1));
-                    while let Some(r) = jobs.next().await {
+                    .buffer_unordered(self.config.tantivy.timefusion_tantivy_build_concurrency.max(1))
+                    .fold((0usize, 0usize), |(built, errs), r| async move {
                         match r {
-                            Ok(()) => built += 1,
+                            Ok(()) => (built + 1, errs),
                             Err(e) => {
-                                reindex_errs += 1;
                                 warn!("tantivy post-optimize reindex failed for table={}: {}", table_name, e);
+                                (built, errs + 1)
                             }
                         }
-                    }
-                    drop(jobs);
+                    })
+                    .await;
                     if built > 0 || reindex_errs > 0 || !carried.is_empty() {
                         info!("tantivy post-optimize reindex: table={} built={} carried_forward={} errors={}", table_name, built, carried.len(), reindex_errs);
                     }
@@ -328,9 +323,11 @@ impl Database {
             .counts();
         // Most-fragmented partition first: it's the one whose recent-window
         // queries open the most files, so it benefits most from an early tick.
-        let mut projects: Vec<_> = counts.into_iter().collect();
-        projects.sort_unstable_by(|(a, a_count), (b, b_count)| b_count.cmp(a_count).then_with(|| a.cmp(b)));
-        projects.into_iter().map(|(project_id, _)| project_id.to_owned()).collect()
+        counts
+            .into_iter()
+            .sorted_by(|(a, a_count), (b, b_count)| b_count.cmp(a_count).then_with(|| a.cmp(b)))
+            .map(|(project_id, _)| project_id.to_owned())
+            .collect()
     }
 
     /// Select the specific files a light optimize should bin-pack.
@@ -402,7 +399,7 @@ impl Database {
                 ))
             })
             .into_group_map();
-        let mut planned: Vec<(String, Vec<String>, usize)> = per_project
+        let planned = per_project
             .into_iter()
             .map(|(project_id, adds)| {
                 let debt = adds.len();
@@ -422,7 +419,7 @@ impl Database {
                 )
             })
             .filter(|(_, bin, _)| !bin.is_empty())
-            .collect();
+            .collect_vec();
         // Packing goes MOST-fragmented first — that partition opens the most
         // files per query, so it is the most urgent. Repair inverts it:
         // SHORTEST-JOB-FIRST.
@@ -441,11 +438,17 @@ impl Database {
         // Widening the admission reach the same morning made it worse, by
         // promoting that project's 1.6-2.3 GB files from "ineligible" to
         // "eligible and first in line".
-        match policy.pass {
-            TailPass::Pack => planned.sort_unstable_by(|a, b| b.2.cmp(&a.2).then_with(|| a.0.cmp(&b.0))),
-            TailPass::Repair => planned.sort_unstable_by(|a, b| a.2.cmp(&b.2).then_with(|| a.0.cmp(&b.0))),
-        }
-        Ok(planned.into_iter().map(|(project_id, bin, _)| (project_id, bin)).collect())
+        Ok(planned
+            .into_iter()
+            .sorted_by(|a, b| {
+                match policy.pass {
+                    TailPass::Pack => b.2.cmp(&a.2),
+                    TailPass::Repair => a.2.cmp(&b.2),
+                }
+                .then_with(|| a.0.cmp(&b.0))
+            })
+            .map(|(project_id, bin, _)| (project_id, bin))
+            .collect())
     }
 
     /// `[min, max]` event time (micros) of a file from its raw Add stats JSON.
@@ -1065,18 +1068,16 @@ impl Database {
              (SELECT \"timestamp\", count(*) AS c FROM {DEDUP_SCAN_NAME} WHERE {filter} GROUP BY {keys_csv}) AS g \
              WHERE c > 1 GROUP BY 1 ORDER BY 1"
         );
-        crate::database::maintain::collect_watched(ctx, &probe).await?.into_iter().try_fold(Vec::new(), |mut starts, batch| {
-            let col = datafusion::arrow::compute::cast(batch.column(0), &datafusion::arrow::datatypes::DataType::Utf8)?;
-            let col = col.as_any().downcast_ref::<datafusion::arrow::array::StringArray>().expect("cast to Utf8");
-            starts.extend(col.iter().flatten().filter_map(|value| {
+        Ok(read_string_column(crate::database::maintain::collect_watched(ctx, &probe).await?)?
+            .iter()
+            .filter_map(|value| {
                 value.get(..19).and_then(|datetime| {
                     chrono::NaiveDateTime::parse_from_str(datetime, "%Y-%m-%dT%H:%M:%S")
                         .or_else(|_| chrono::NaiveDateTime::parse_from_str(datetime, "%Y-%m-%d %H:%M:%S"))
                         .ok()
                 })
-            }));
-            Ok::<_, anyhow::Error>(starts)
-        })
+            })
+            .collect())
     }
 
     /// Counts dedup keys whose versions disagree on a column declared IMMUTABLE,
@@ -1132,13 +1133,9 @@ impl Database {
     /// consumer. The old call-site claim, "one extra aggregate over a shard this
     /// rewrite is about to read in full anyway", was never true of either SQL
     /// formulation; it is true of the streaming one.
-    /// Columns an immutable-column audit compares — the single definition both
-    /// audit forms read, so the SQL and the streaming collapse cannot drift.
     ///
-    /// Dedup keys are excluded (they are the grouping), as are the tiebreak and
-    /// tombstone columns, which vary across versions by construction. Composite
-    /// types are excluded because ordering over them is neither cheap nor
-    /// meaningful.
+    /// This is the single definition of which columns an audit compares, so the
+    /// SQL and the streaming collapse cannot drift.
     fn immutable_audit_columns(schema: &crate::schema::TableSchema) -> Vec<String> {
         let excluded: HashSet<&str> =
             schema.dedup_keys.iter().map(String::as_str).chain(schema.dedup_tiebreak.as_deref()).chain(schema.tombstone_column.as_deref()).collect();
@@ -1252,7 +1249,7 @@ impl Database {
             // Ten-minute sealed bins bound materialization and avoid racing late
             // flushes; newer duplicates are retried later.
             let sealed_before = Utc::now().naive_utc() - chrono::Duration::hours(2);
-            let mut skipped_unsealed = 0usize;
+            let mut skipped_unsealed = false;
             // A one-minute whale cannot be split further in time. Bound the
             // key GROUP BY used by the duplicate probe with the same complete-
             // key hash partitioning as the rewrite. Each pass may reread the
@@ -1273,7 +1270,7 @@ impl Database {
                     let end = start + chrono::Duration::minutes(10);
                     if slice.is_none() && end > sealed_before {
                         debug!("dedup: skipping unsealed chunk starting {start} (cleared on a later sweep)");
-                        skipped_unsealed += 1;
+                        skipped_unsealed = true;
                         return None;
                     }
                     let (s, e) = (start.format("%Y-%m-%d %H:%M:%S"), end.format("%Y-%m-%d %H:%M:%S"));
@@ -1288,7 +1285,7 @@ impl Database {
                     ))
                 })
                 .collect();
-            (built, skipped_unsealed > 0)
+            (built, skipped_unsealed)
         } else {
             // No timestamp dedup key → can't chunk safely; whole-partition
             // rewrite, gated on the same any-dupes probe.
@@ -1303,7 +1300,6 @@ impl Database {
 
         // `buffer_unordered` bounds tasks in flight; the rewrite semaphore bounds
         // concurrent Arrow materialization.
-        use futures::stream::StreamExt;
         let permits = self.config.derived.rewrite_permits().max(1);
         let staged: Vec<Result<BinOutcome<StagedBin>>> = futures::stream::iter(chunks.into_iter().map(|(chunk_filter, label)| {
             let (partition_filter, key, date_str) = (&partition_filter, key.clone(), date_str.as_str());
@@ -1368,12 +1364,10 @@ impl Database {
             let dv_enabled =
                 table_ref.read().await.snapshot().ok().map(|s| s.snapshot().table_properties().enable_deletion_vectors == Some(true)).unwrap_or(false);
             if dv_enabled {
-                let _ = (partition_filter, scan_name);
                 return self.stage_dedup_chunk_dv(table_ref, table_name, project_id, schema, chunk_filter, label, date_str, key, limits).await;
             }
         }
         use deltalake::{kernel::Action, writer::DeltaWriter};
-        use futures::StreamExt;
         // Re-plan against a fresh snapshot when concurrent rewrites invalidate
         // file mappings; `commit_wave` guards the remaining commit window.
         const MAX_REPLANS: usize = 3;
@@ -1878,24 +1872,21 @@ impl Database {
                 .collect()
                 .await;
             drop(rewrite_permit);
-            // Fold: every shard hands back its adds even when it failed, so a
-            // mid-flight failure still leaks nothing.
-            let (mut before, mut after) = (0usize, 0usize);
-            let mut adds: Vec<Action> = Vec::new();
-            let mut first_err: Option<anyhow::Error> = None;
-            for (shard_adds, outcome) in staged_shards {
-                adds.extend(shard_adds);
-                match outcome {
-                    Ok((shard_before, shard_after)) => (before, after) = (before + shard_before, after + shard_after),
-                    Err(error) => {
-                        first_err.get_or_insert(error);
-                    }
+            // Every shard hands back its adds even when it failed, so collect
+            // them all BEFORE folding the outcomes: a mid-flight failure still
+            // leaks nothing.
+            let (shard_adds, outcomes): (Vec<Vec<Action>>, Vec<_>) = staged_shards.into_iter().unzip();
+            let adds: Vec<Action> = shard_adds.concat();
+            let (before, after) = match outcomes
+                .into_iter()
+                .try_fold((0usize, 0usize), |(before, after), outcome| outcome.map(|(shard_before, shard_after)| (before + shard_before, after + shard_after)))
+            {
+                Ok(totals) => totals,
+                Err(e) => {
+                    Self::cleanup_orphaned_parquet(&stage_store, &adds).await;
+                    return Err(e);
                 }
-            }
-            if let Some(e) = first_err {
-                Self::cleanup_orphaned_parquet(&stage_store, &adds).await;
-                return Err(e);
-            }
+            };
             if !dedup_rewrite_counts_match(before as u64, expected_live_rows, after as u64, expected_logical_rows) {
                 Self::cleanup_orphaned_parquet(&stage_store, &adds).await;
                 anyhow::bail!(

--- a/src/database/maintain.rs
+++ b/src/database/maintain.rs
@@ -798,7 +798,6 @@ async fn staged_objects_complete(store: &dyn object_store::ObjectStore, adds: &[
 }
 
 impl Database {
-    /// Push a coordinator task's next attempt out by `delay`, journaled and checkpointed.
     /// The busy-pool backoff for `key`, with the journal guard confined to this
     /// body so no caller can hold it across `retry_task`.
     ///
@@ -814,6 +813,7 @@ impl Database {
         admission_backoff(self.journal().attempts(key))
     }
 
+    /// Push a coordinator task's next attempt out by `delay`, journaled and checkpointed.
     fn retry_task(&self, key: &crate::maintenance_coordinator::TaskKey, reason: String, delay: std::time::Duration) -> Result<()> {
         let delay_micros = i64::try_from(delay.as_micros()).unwrap_or(i64::MAX);
         let mut journal = self.journal();
@@ -827,10 +827,6 @@ impl Database {
         journal.checkpoint()
     }
 
-    /// Exclusive upper bound the coverage was built to. `i64::MAX` means whole-partition.
-    ///
-    /// Must be the bound stored with the coverage, never one recomputed here — for a day still
-    /// being written the two would differ and invalidate good coverage every query.
     /// The partition fingerprint the ticket re-check compares against
     /// `coverage.source_fp`.
     ///
@@ -2504,19 +2500,21 @@ impl Database {
                 return Ok(true);
             }
         };
-        let mut required_columns: HashSet<&str> = ["project_id", "date", "timestamp"].into_iter().collect();
-        required_columns.extend(source_schema.dedup_keys.iter().map(String::as_str));
-        required_columns.extend(source_schema.dedup_tiebreak.iter().map(String::as_str));
-        required_columns.extend(source_schema.tombstone_column.iter().map(String::as_str));
-        required_columns.extend(spec.dimensions.iter().map(String::as_str));
-        required_columns.extend(spec.measures.iter().filter_map(|measure| measure.column.as_deref()));
-        required_columns.extend(
-            spec.measures
-                .iter()
-                .filter_map(|measure| measure.filter.as_deref())
-                .flat_map(|filter| filter.split(|character: char| !(character.is_ascii_alphanumeric() || character == '_')))
-                .filter(|token| source_schema.fields.iter().any(|field| field.name == *token)),
-        );
+        let required_columns: HashSet<&str> = ["project_id", "date", "timestamp"]
+            .into_iter()
+            .chain(source_schema.dedup_keys.iter().map(String::as_str))
+            .chain(source_schema.dedup_tiebreak.iter().map(String::as_str))
+            .chain(source_schema.tombstone_column.iter().map(String::as_str))
+            .chain(spec.dimensions.iter().map(String::as_str))
+            .chain(spec.measures.iter().filter_map(|measure| measure.column.as_deref()))
+            .chain(
+                spec.measures
+                    .iter()
+                    .filter_map(|measure| measure.filter.as_deref())
+                    .flat_map(|filter| filter.split(|character: char| !(character.is_ascii_alphanumeric() || character == '_')))
+                    .filter(|token| source_schema.fields.iter().any(|field| field.name == *token)),
+            )
+            .collect();
         let projected_numerator = u64::try_from(required_columns.len()).unwrap_or(u64::MAX);
         let projected_denominator = u64::try_from(source_schema.fields.len().max(1)).unwrap_or(u64::MAX);
         let mut untagged_inputs = 0u64;
@@ -3106,16 +3104,7 @@ impl Database {
         // partition's, so it reads as a backlog draining rather than a per-unit
         // blip; `retired` proves this unit actually removed one.
         let no_identity = |add: &deltalake::kernel::Add| slice_tag_range(add).is_none();
-        {
-            let stats = crate::observability::maintenance_stats();
-            // Record per TABLE and export the SUM. One shared slot was
-            // overwritten by whichever tier published last, so a publish to an
-            // already-clean tier reported 0 while another still held 67 untagged
-            // files — a gauge reading clean over live damage is the exact
-            // failure it exists to catch.
-            self.rollup_tier_untagged.insert(key.physical_table.clone(), live_adds.iter().filter(|add| no_identity(add)).count() as u64);
-            stats.rollup_tier_untagged_found.store(self.rollup_tier_untagged.iter().map(|entry| *entry.value()).sum(), Relaxed);
-        }
+        self.publish_tier_untagged(&key.physical_table, live_adds.iter().filter(|add| no_identity(add)).count() as u64);
         // Deferred to AFTER the commit. Counted here, this read 21 retired
         // within an hour on prod 2026-08-22 while a fresh Delta-log replay said
         // the live count had not moved at all — two deploys had killed the units
@@ -3169,12 +3158,8 @@ impl Database {
             crate::observability::maintenance_stats().rollup_skipped_covered_by_wider.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             let mut journal = self.journal();
             if let Ok(covering) = crate::maintenance_coordinator::TimeSlice::new(covering_start, covering_end) {
-                journal.enqueue(
-                    crate::maintenance_coordinator::TaskKey { slice: covering, ..key.clone() },
-                    crate::support::now_micros(),
-                    MAX_DECODED_BYTES,
-                    unix_ms(crate::support::now_micros()),
-                );
+                let now = crate::support::now_micros();
+                journal.enqueue(crate::maintenance_coordinator::TaskKey { slice: covering, ..key.clone() }, now, MAX_DECODED_BYTES, unix_ms(now));
             }
             journal.complete(&key);
             journal.checkpoint()?;
@@ -3593,7 +3578,6 @@ impl Database {
         // Only when the unit will do NOTHING, so this cannot become chatter: a
         // selection of one file is a 1:1 rewrite and retires no files either.
         if selected.len() < 2 {
-            let unsorted = unsorted_candidates;
             info!(
                 operation = ?key.operation,
                 project_id = %key.project_id,
@@ -3603,7 +3587,7 @@ impl Database {
                 after_date_filter = after_date,
                 after_project_filter = after_project,
                 after_range_filter = after_range,
-                unsorted_candidates = unsorted,
+                unsorted_candidates,
                 under_target = under_target_candidates,
                 selected = selected.len(),
                 target,
@@ -3956,7 +3940,9 @@ impl Database {
             let progress = Arc::new(std::sync::atomic::AtomicU64::new(0));
             // Scoped here, at the one place the operation is known, so every
             // query a unit runs can be attributed without threading a label
-            // through three rewrite paths.
+            // through three rewrite paths. It is also the ONE spelling of the
+            // operation's name: the work counters below read it rather than
+            // re-deriving it via `{operation:?}`, so the two cannot drift.
             let label: &'static str = match operation {
                 Operation::Dedup => "Dedup",
                 Operation::BaseRollup => "BaseRollup",
@@ -3987,9 +3973,8 @@ impl Database {
                     let elapsed = started.elapsed();
                     // Before `result?`: a unit that errors after 800s spent that
                     // capacity just as surely as one that succeeded.
-                    let op = format!("{operation:?}");
-                    crate::observability::count_maintenance_work(&op, "worker_secs", elapsed.as_secs());
-                    crate::observability::count_maintenance_work(&op, "progress_rows", progress.load(std::sync::atomic::Ordering::Relaxed));
+                    crate::observability::count_maintenance_work(label, "worker_secs", elapsed.as_secs());
+                    crate::observability::count_maintenance_work(label, "progress_rows", progress.load(std::sync::atomic::Ordering::Relaxed));
                     // Only the slow tail: a unit finishing well inside its
                     // deadline says nothing, and this runs on every claim.
                     if elapsed.as_secs_f64() > timeout.as_secs_f64() / 4.0 {
@@ -4011,10 +3996,9 @@ impl Database {
                     warn!(?operation, timeout_seconds = timeout.as_secs(), event = "maintenance_coordinator_unit_timed_out");
                     // `killed_secs` is a strict subset of `worker_secs`: the
                     // share of the fleet's capacity that produced nothing.
-                    let op = format!("{operation:?}");
-                    crate::observability::count_maintenance_work(&op, "worker_secs", started.elapsed().as_secs());
-                    crate::observability::count_maintenance_work(&op, "killed_secs", started.elapsed().as_secs());
-                    crate::observability::count_maintenance_work(&op, "progress_rows", progress.load(std::sync::atomic::Ordering::Relaxed));
+                    crate::observability::count_maintenance_work(label, "worker_secs", started.elapsed().as_secs());
+                    crate::observability::count_maintenance_work(label, "killed_secs", started.elapsed().as_secs());
+                    crate::observability::count_maintenance_work(label, "progress_rows", progress.load(std::sync::atomic::Ordering::Relaxed));
                     return Ok(true);
                 }
             };
@@ -4172,10 +4156,6 @@ impl Database {
         Ok(Self::partition_stats_bounded(table, tiebreak, bound_for)?.into_iter().map(|(key, stats)| (key, stats.fingerprint)).collect())
     }
 
-    /// As [`Self::partition_fingerprints_bounded`], but also carrying the row
-    /// timestamps each partition's files span — one pass, since the fingerprint
-    /// already folds those in and the add-actions scan is the dominant cost of
-    /// planning a rollup route.
     /// Split a window's live Delta files into the ones that may skip
     /// `DedupExec` and the ones that may not.
     ///
@@ -4277,6 +4257,10 @@ impl Database {
             .collect())
     }
 
+    /// As [`Self::partition_fingerprints_bounded`], but also carrying the row
+    /// timestamps each partition's files span — one pass, since the fingerprint
+    /// already folds those in and the add-actions scan is the dominant cost of
+    /// planning a rollup route.
     pub(crate) fn partition_stats_bounded(
         table: &DeltaTable, tiebreak: Option<&str>, bound_for: &dyn Fn(&str, &str) -> i64,
     ) -> Result<HashMap<(String, String), PartitionStats>> {
@@ -4377,14 +4361,37 @@ impl Database {
             .collect())
     }
 
-    /// Re-adopt rollup coverage that previous processes durably wrote.
+    /// Record one tier's untagged-file count and re-export the FLEET sum.
     ///
-    /// `rollup_coverage` is in-memory, so restarts used to lose it; because reads filter on
-    /// `rollup_generation`, already-written rollup rows became unreadable. There is no sidecar
-    /// file: the rollup table is the record. Each stored `(date, generation)` is re-proved against
-    /// the current source partition's generation, so a moved source fails to match and the
-    /// partition is left uncovered. Unproved claims cost a raw scan; trusting one would make a
-    /// rewrite read zero rows.
+    /// Per TABLE, summed on export. One shared slot was overwritten by whichever
+    /// tier published last, so a publish to an already-clean tier reported 0
+    /// while another still held 67 untagged files — a gauge reading clean over
+    /// live damage is the exact failure it exists to catch. Shared by the
+    /// publish path and the hourly replay so the two cannot disagree.
+    fn publish_tier_untagged(&self, table_name: &str, untagged: u64) {
+        self.rollup_tier_untagged.insert(table_name.to_owned(), untagged);
+        crate::observability::maintenance_stats()
+            .rollup_tier_untagged_found
+            .store(self.rollup_tier_untagged.iter().map(|entry| *entry.value()).sum(), std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// Write the damage set through to its sidecar. Best-effort by design: a
+    /// lost or stale file costs one mis-ranked claim, never correctness, because
+    /// recovery replaces each tier's slice and a clean publish clears its cell.
+    fn persist_untagged_cells(&self) {
+        let cells = self
+            .journal()
+            .untagged_cells()
+            .map(|(source, project_id, table_name, date)| crate::storage::StoredUntaggedCell {
+                source: source.clone(),
+                project_id: project_id.clone(),
+                table_name: table_name.clone(),
+                date: date.clone(),
+            })
+            .collect::<Vec<_>>();
+        crate::storage::store_sidecar(&self.config.core.timefusion_data_dir, crate::storage::UNTAGGED_CELLS, &cells);
+    }
+
     /// Queue a day-wide rebuild for every partition still holding a tier file
     /// with no identity tags.
     ///
@@ -4404,23 +4411,6 @@ impl Database {
     /// Self-limiting — the set is read from the log each recovery, so it shrinks
     /// as partitions are repaired and reaches zero. `rollup_tier_untagged_found`
     /// is the gauge that says whether it is converging.
-    /// Write the damage set through to its sidecar. Best-effort by design: a
-    /// lost or stale file costs one mis-ranked claim, never correctness, because
-    /// recovery replaces each tier's slice and a clean publish clears its cell.
-    fn persist_untagged_cells(&self) {
-        let cells = self
-            .journal()
-            .untagged_cells()
-            .map(|(source, project_id, table_name, date)| crate::storage::StoredUntaggedCell {
-                source: source.clone(),
-                project_id: project_id.clone(),
-                table_name: table_name.clone(),
-                date: date.clone(),
-            })
-            .collect::<Vec<_>>();
-        crate::storage::store_sidecar(&self.config.core.timefusion_data_dir, crate::storage::UNTAGGED_CELLS, &cells);
-    }
-
     fn enqueue_untagged_rebuilds(&self, source: &str, spec: &crate::schema::RollupSpec, target: &str, partitions: &UntaggedPartitions) {
         use crate::maintenance_coordinator::{MAX_DECODED_BYTES, Operation, TaskKey, TimeSlice};
         // Published before the empty check, so a tier that has just converged
@@ -4757,6 +4747,14 @@ impl Database {
         retired
     }
 
+    /// Re-adopt rollup coverage that previous processes durably wrote.
+    ///
+    /// `rollup_coverage` is in-memory, so restarts used to lose it; because reads filter on
+    /// `rollup_generation`, already-written rollup rows became unreadable. There is no sidecar
+    /// file: the rollup table is the record. Each stored `(date, generation)` is re-proved against
+    /// the current source partition's generation, so a moved source fails to match and the
+    /// partition is left uncovered. Unproved claims cost a raw scan; trusting one would make a
+    /// rewrite read zero rows.
     pub async fn recover_rollup_coverage(&self, source: &str) -> Result<usize> {
         let Some(schema) = get_schema(source).filter(|schema| !schema.rollups.is_empty()) else { return Ok(0) };
         self.retire_aged_out_coverage();
@@ -4933,10 +4931,7 @@ impl Database {
             // live untagged files for the first 40 minutes of every boot. A
             // reading that cannot distinguish "none" from "unmeasured" is not a
             // measurement.
-            self.rollup_tier_untagged.insert(target.clone(), untagged_files);
-            crate::observability::maintenance_stats()
-                .rollup_tier_untagged_found
-                .store(self.rollup_tier_untagged.iter().map(|entry| *entry.value()).sum(), std::sync::atomic::Ordering::Relaxed);
+            self.publish_tier_untagged(&target, untagged_files);
             let untagged_partitions: UntaggedPartitions = untagged_spans
                 .drain()
                 .map(|(partition, untagged)| {
@@ -5131,18 +5126,14 @@ impl Database {
                     );
                     recovered += 1;
                 }
+                // Only from the FILTERED loop above: with no tagged files
+                // `readable` is empty, and recording an empty set would retire
+                // every ledger cell this tier has as an orphan.
                 self.record_readable_coverage(source, &target, readable);
-                self.enqueue_unverifiable_rebuilds(source, spec, &target, RollupRebuildReason::MissingRowWitness, &witnessless);
-                self.enqueue_unverifiable_rebuilds(source, spec, &target, RollupRebuildReason::ObsoleteGeneration, &obsolete_generations);
-                self.recover_date_coverage(source, &target).await;
-                continue;
             }
             self.enqueue_unverifiable_rebuilds(source, spec, &target, RollupRebuildReason::MissingRowWitness, &witnessless);
             self.enqueue_unverifiable_rebuilds(source, spec, &target, RollupRebuildReason::ObsoleteGeneration, &obsolete_generations);
             self.recover_date_coverage(source, &target).await;
-            if !published.is_empty() {
-                continue;
-            }
             // Untagged legacy generations cannot be recovered safely without
             // scanning rollup data.  A production restart showed that even a
             // single 230 MiB compatibility GROUP BY starved PGWire for 19s.
@@ -5943,12 +5934,6 @@ impl Database {
         Ok(())
     }
 
-    /// Snapshot `dedup_clean_fp` to the data dir. Called at the end of a sweep
-    /// rather than per certification: one write per tick instead of one per
-    /// partition, and the snapshot picks up invalidations in the same pass.
-    ///
-    /// Best-effort by design — this is a cache, and a lost write costs a cold
-    /// start, never a wrong answer.
     /// Mirror of `persist_certifications` for the accumulating half of the
     /// evidence. Same flag, same lock (one writer at a time across both
     /// sidecars), same newest-irrelevant cap semantics — coverage entries are
@@ -5977,6 +5962,12 @@ impl Database {
         crate::storage::store_sidecar(&self.config.core.timefusion_data_dir, crate::storage::SLICE_COVERAGE, &entries);
     }
 
+    /// Snapshot `dedup_clean_fp` to the data dir. Called at the end of a sweep
+    /// rather than per certification: one write per tick instead of one per
+    /// partition, and the snapshot picks up invalidations in the same pass.
+    ///
+    /// Best-effort by design — this is a cache, and a lost write costs a cold
+    /// start, never a wrong answer.
     fn persist_certifications(&self) {
         if !self.config.maintenance.timefusion_dedup_certification_persist {
             return;
@@ -8445,15 +8436,17 @@ impl Database {
         }
     }
 
-    /// Resume a repair bin that a previous attempt already wrote.
-    ///
-    /// Returns the staged output as a `StagedBin` instead of spending another 40+ minutes
-    /// rewriting the same file. Hooked at bin selection, keyed on an intent whose inputs exactly
-    /// match the bin we were about to stage. The restart case falls out for free because
-    /// selection is deterministic given the snapshot, and the same lookup covers a stage whose
-    /// commit lost an OCC race. `commit_wave` lands it with the same lock, flush priority, liveness
-    /// re-check and OCC ladder. `None` is always safe: the caller stages normally, and the
-    /// declined entry's parquet falls to boot-time reconcile / VACUUM.
+    /// Publish a resumed rollup and retire its intent — the bookkeeping both
+    /// success arms owe, and which the commit alone does not satisfy.
+    fn publish_resumed_rollup(&self, rollup: &crate::database::RollupResume, wave_id: &str) -> Result<()> {
+        let mut journal = self.journal();
+        journal.publish(&rollup.key, rollup.publication.clone());
+        journal.checkpoint()?;
+        drop(journal);
+        self.clear_staged_intent(&[wave_id]);
+        Ok(())
+    }
+
     /// Commit a rollup unit whose output was staged before a restart, instead of
     /// re-running its scan. `Ok(true)` means this unit is DONE and the caller
     /// must not build anything.
@@ -8467,17 +8460,6 @@ impl Database {
     /// orphan sweep already collects staged parquet that no longer belongs to
     /// anything, and deleting an entry here on a transient read failure would
     /// discard a perfectly good staged output.
-    /// Publish a resumed rollup and retire its intent — the bookkeeping both
-    /// success arms owe, and which the commit alone does not satisfy.
-    fn publish_resumed_rollup(&self, rollup: &crate::database::RollupResume, wave_id: &str) -> Result<()> {
-        let mut journal = self.journal();
-        journal.publish(&rollup.key, rollup.publication.clone());
-        journal.checkpoint()?;
-        drop(journal);
-        self.clear_staged_intent(&[wave_id]);
-        Ok(())
-    }
-
     pub(crate) async fn resume_rollup_unit(&self, key: &crate::maintenance_coordinator::TaskKey, current_source_rows: Option<u64>) -> Result<bool> {
         use deltalake::protocol::{DeltaOperation, SaveMode};
         use std::sync::atomic::Ordering::Relaxed;
@@ -8600,6 +8582,15 @@ impl Database {
         Ok(false)
     }
 
+    /// Resume a repair bin that a previous attempt already wrote.
+    ///
+    /// Returns the staged output as a `StagedBin` instead of spending another 40+ minutes
+    /// rewriting the same file. Hooked at bin selection, keyed on an intent whose inputs exactly
+    /// match the bin we were about to stage. The restart case falls out for free because
+    /// selection is deterministic given the snapshot, and the same lookup covers a stage whose
+    /// commit lost an OCC race. `commit_wave` lands it with the same lock, flush priority, liveness
+    /// re-check and OCC ladder. `None` is always safe: the caller stages normally, and the
+    /// declined entry's parquet falls to boot-time reconcile / VACUUM.
     async fn resumable_staged_bin(&self, table_ref: &Arc<RwLock<DeltaTable>>, table_name: &str, project_id: &str, files: &[String]) -> Option<StagedBin> {
         use deltalake::kernel::Action;
         use std::sync::atomic::Ordering::Relaxed;
@@ -8948,11 +8939,6 @@ impl Database {
         if !self.config.maintenance.timefusion_repair_mark_sorted_at_write {
             return (0, 0);
         }
-        // The object store is captured HERE, once per table, so the probe stage below takes NO
-        // table locks at all. Re-locking per file would put 16 concurrent readers against a lock
-        // that `refresh_table_snapshot` needs to WRITE — and a delayed refresh is a stale
-        // snapshot, i.e. committed rows a query cannot see. Background hygiene must never be
-        // able to do that to the foreground.
         // Grouped BY TABLE, and the store is taken once while the enumeration lock is already
         // held, so the probe stage below takes NO table locks at all. Re-locking per file would
         // put `REPAIR_VERIFY_CONCURRENCY` readers against a lock `refresh_table_snapshot` needs
@@ -9163,8 +9149,6 @@ impl Database {
         Ok(())
     }
 
-    /// Vacuum the Delta table to clean up old files that are no longer needed
-    /// This reduces storage costs and improves query performance
     /// On-demand vacuum of a single unified table (pgwire `VACUUM <table>`).
     /// `retention_hours = None` uses the configured default. Mirrors
     /// `compact_date`: resolves the table then delegates, keeping config private.

--- a/src/database/write.rs
+++ b/src/database/write.rs
@@ -227,7 +227,6 @@ impl Database {
                     if c.nulls_first { "FIRST" } else { "LAST" }
                 )
             })
-            .collect::<Vec<_>>()
             .join(", ");
         if order_by.is_empty() {
             return None;
@@ -499,10 +498,7 @@ impl Database {
         // accepts the schema.
         let batches: Vec<RecordBatch> = batches.into_iter().map(cast_variant_columns_to_binary).collect::<DFResult<Vec<_>>>()?;
 
-        // Get or create the table
         let table_ref = self.get_or_create_table(project_id, table_name).await?;
-
-        // Get the appropriate schema for this table
         let schema = schema_or_default(table_name);
 
         let dirty_bins: Vec<(String, i64)> = if schema.dedup_keys.is_empty() {
@@ -952,23 +948,27 @@ impl Database {
         // Schema-evolution units never reach here: they are split out to the solo
         // (locked WriteBuilder) path so one project's merge can't stall the rest.
         let mut solo: Vec<usize> = Vec::new();
-        let mut stageable: Vec<(usize, PreparedWrite, (String, String))> = Vec::new();
+        let mut stageable: Vec<(usize, PreparedWrite, deltalake::writer::RecordBatchWriter, (String, String))> = Vec::new();
         for (i, prep) in prepared {
             match prep {
                 Err(e) => results[i] = Err(e),
-                Ok((p, _)) if p.staged_writer.is_none() => {
-                    debug!("coalesced flush: {}/{} needs schema evolution — splitting out of the shared commit", units[i].project_id, units[i].table_name);
-                    solo.push(i);
-                }
-                Ok((p, key)) => stageable.push((i, p, key)),
+                // `take()` here (not a `staged_writer.is_none()` peek + a later
+                // `.expect()`) so the writer's presence is carried in `stageable`'s
+                // type, not re-asserted at the point of use.
+                Ok((mut p, key)) => match p.staged_writer.take() {
+                    Some(writer) => stageable.push((i, p, writer, key)),
+                    None => {
+                        debug!("coalesced flush: {}/{} needs schema evolution — splitting out of the shared commit", units[i].project_id, units[i].table_name);
+                        solo.push(i);
+                    }
+                },
             }
         }
 
         let max_file_bytes = self.config.maintenance.timefusion_writer_max_file_bytes;
         let staged: Vec<(usize, (String, String), Result<StagedUnit>)> = stream::iter(stageable)
-            .map(|(i, prep, key)| async move {
-                let PreparedWrite { table_ref, schema, dirty_bins, batches, stage_store, staged_writer, sorted, .. } = prep;
-                let mut writer = staged_writer.expect("filtered above");
+            .map(|(i, prep, mut writer, key)| async move {
+                let PreparedWrite { table_ref, schema, dirty_bins, batches, stage_store, sorted, .. } = prep;
                 let adds: Result<Vec<Action>> =
                     Self::stage_batches(&mut writer, batches, max_file_bytes).await.map_err(|e| anyhow::anyhow!("staged parquet flush failed: {}", e));
                 (i, key, adds.map(|adds| StagedUnit { table_ref, schema, dirty_bins, adds, stage_store, sorted }))
@@ -1390,30 +1390,31 @@ impl Database {
         };
         drop(table);
 
-        let mut total_advanced = 0;
-        for (project_id, table_name) in topics {
-            // Same scan, second (independent) reading: the batch-set identities
-            // these commits contain. Feeds ONLY the flush-time decline — never
-            // the cursor advance below, which stays governed by the conservative
-            // watermark. See `LANDED_DIGESTS_KEY`.
-            if self.config.buffer.landed_skip_enabled()
-                && let Some(layer) = layer
-            {
-                let digests: Vec<crate::write::LandedDigest> =
-                    commits.iter().flat_map(|ci| parse_landed_digests_from_json(&ci.info, &project_id, &table_name)).collect();
-                if !digests.is_empty() {
-                    info!("Loaded {} landed-batch identities for {}.{}", digests.len(), project_id, table_name);
-                    layer.note_landed_digests(&project_id, &table_name, digests);
+        topics
+            .into_iter()
+            .map(|(project_id, table_name)| {
+                // Same scan, second (independent) reading: the batch-set identities
+                // these commits contain. Feeds ONLY the flush-time decline — never
+                // the cursor advance below, which stays governed by the conservative
+                // watermark. See `LANDED_DIGESTS_KEY`.
+                if self.config.buffer.landed_skip_enabled()
+                    && let Some(layer) = layer
+                {
+                    let digests: Vec<crate::write::LandedDigest> =
+                        commits.iter().flat_map(|ci| parse_landed_digests_from_json(&ci.info, &project_id, &table_name)).collect();
+                    if !digests.is_empty() {
+                        info!("Loaded {} landed-batch identities for {}.{}", digests.len(), project_id, table_name);
+                        layer.note_landed_digests(&project_id, &table_name, digests);
+                    }
                 }
-            }
-            let delta_max = max_watermark_across_commits(commits.iter().map(|ci| &ci.info), wal.shards_per_topic(), &project_id, &table_name);
-            let advanced = wal.merge_persisted_positions(&project_id, &table_name, &delta_max)?;
-            if advanced > 0 {
-                info!("Delta-derived cursor advance: project={}, table={}, shards_advanced={}", project_id, table_name, advanced);
-            }
-            total_advanced += advanced;
-        }
-        Ok(total_advanced)
+                let delta_max = max_watermark_across_commits(commits.iter().map(|ci| &ci.info), wal.shards_per_topic(), &project_id, &table_name);
+                let advanced = wal.merge_persisted_positions(&project_id, &table_name, &delta_max)?;
+                if advanced > 0 {
+                    info!("Delta-derived cursor advance: project={}, table={}, shards_advanced={}", project_id, table_name, advanced);
+                }
+                Ok(advanced)
+            })
+            .sum()
     }
 }
 

--- a/src/maintenance_coordinator.rs
+++ b/src/maintenance_coordinator.rs
@@ -15,6 +15,12 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 
+/// Lock without letting a poisoned mutex propagate: every mutex here guards
+/// plain data, so a panicking holder leaves it usable.
+fn lock<T>(mutex: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
+    mutex.lock().unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
 pub const NORMAL_SLICE_MICROS: i64 = 10 * 60 * 1_000_000;
 pub const DAY_MICROS: i64 = 24 * 60 * 60 * 1_000_000;
 /// Widths `coarsen_sealed_slices` fuses sealed units to, widest first. It takes
@@ -330,14 +336,9 @@ impl TimeSlice {
     fn fixed_units(start_micros: i64, end_micros: i64, width_micros: i64) -> anyhow::Result<Vec<Self>> {
         let whole = Self::new(start_micros, end_micros)?;
         anyhow::ensure!(width_micros > 0, "maintenance slice width must be positive");
-        let mut result = Vec::new();
-        let mut start = whole.start_micros;
-        while start < whole.end_micros {
-            let end = start.saturating_add(width_micros).min(whole.end_micros);
-            result.push(Self { start_micros: start, end_micros: end });
-            start = end;
-        }
-        Ok(result)
+        Ok(std::iter::successors(Some(whole.start_micros), |start| Some(start.saturating_add(width_micros)).filter(|next| *next < whole.end_micros))
+            .map(|start| Self { start_micros: start, end_micros: start.saturating_add(width_micros).min(whole.end_micros) })
+            .collect())
     }
 }
 
@@ -564,11 +565,20 @@ struct GroupPrice {
     /// Every member's own estimate, summed — what the old rule charged, kept
     /// only so a pass can report whether footprint pricing changed anything.
     summed_bytes: u64,
+    /// How many units this bucket holds, which is what `over_budget` reports.
+    members: usize,
+    /// The OLDEST member's creation time, because the fused unit inherits its
+    /// members' work and must inherit their age with it. `Option`, not a bare
+    /// `u64`: a `Default` of 0 would min-fold to the epoch and make every fused
+    /// unit permanently the oldest thing in the queue.
+    oldest: Option<u64>,
 }
 
 impl GroupPrice {
     fn add(&mut self, task: &MaintenanceTask) {
         self.summed_bytes = self.summed_bytes.saturating_add(task.estimated_decoded_bytes);
+        self.members += 1;
+        self.oldest = Some(self.oldest.unwrap_or(u64::MAX).min(task.created_unix_ms));
         match task.input {
             Some(input) => {
                 self.distinct.insert(input.fp, input);
@@ -653,9 +663,7 @@ pub fn split_sheds_enough_at(parent_measured_bytes: Option<u64>, observed_bytes:
 /// can observe the floor at the width where the floor starts to dominate.
 pub fn byte_bounded_units(task: &MaintenanceTask, observed_or_estimated_bytes: u64) -> Vec<MaintenanceTask> {
     if observed_or_estimated_bytes <= MAX_DECODED_BYTES {
-        let mut task = task.clone();
-        task.estimated_decoded_bytes = observed_or_estimated_bytes;
-        return vec![task];
+        return vec![MaintenanceTask { estimated_decoded_bytes: observed_or_estimated_bytes, ..task.clone() }];
     }
     if let Some(children) = bisect_time_unit(task, observed_or_estimated_bytes) {
         return children.into();
@@ -664,15 +672,7 @@ pub fn byte_bounded_units(task: &MaintenanceTask, observed_or_estimated_bytes: u
     let shards_u64 = observed_or_estimated_bytes.div_ceil(MAX_DECODED_BYTES).max(2);
     let shards = u32::try_from(shards_u64).unwrap_or(u32::MAX);
     let per_shard = observed_or_estimated_bytes.div_ceil(u64::from(shards));
-    (0..shards)
-        .map(|hash_shard| {
-            let mut shard = task.clone();
-            shard.hash_shard = hash_shard;
-            shard.hash_shards = shards;
-            shard.estimated_decoded_bytes = per_shard;
-            shard
-        })
-        .collect()
+    (0..shards).map(|hash_shard| MaintenanceTask { hash_shard, hash_shards: shards, estimated_decoded_bytes: per_shard, ..task.clone() }).collect()
 }
 
 /// Bisect time independently of whether a byte estimate exceeds the budget.
@@ -846,14 +846,14 @@ impl TaskLease {
 
     /// Annotate the error on its way out: `lease.note_failure(error)?`.
     pub fn note_failure<E: std::fmt::Display>(&self, error: E) -> E {
-        *self.failure.lock().unwrap_or_else(std::sync::PoisonError::into_inner) = Some(error.to_string());
+        *lock(&self.failure) = Some(error.to_string());
         error
     }
 }
 
 impl Drop for TaskLease {
     fn drop(&mut self) {
-        let mut journal = self.journal.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let mut journal = lock(&self.journal);
         // The ONLY place a unit's end is observable on every path. Prod
         // 2026-08-24, one container's whole 62-minute life: 244
         // `maintenance_task_started` and ZERO completion lines of any kind —
@@ -926,6 +926,20 @@ pub struct Invalidation<'a> {
     /// within one process while dedup was quiet). Every other caller passes
     /// true — fail toward minting.
     pub mint_rollup: bool,
+}
+
+/// Insert or replace a task by key, keeping `indices` in step with `tasks`.
+///
+/// A free function so WAL replay in [`TaskJournal::load`] — which runs before
+/// there is a `Self` — shares the one definition with every other insert site.
+fn insert_task(tasks: &mut Vec<MaintenanceTask>, indices: &mut HashMap<TaskKey, usize>, task: MaintenanceTask) {
+    match indices.get(&task.key).copied() {
+        Some(index) => tasks[index] = task,
+        None => {
+            indices.insert(task.key.clone(), tasks.len());
+            tasks.push(task);
+        }
+    }
 }
 
 impl TaskJournal {
@@ -1006,15 +1020,7 @@ impl TaskJournal {
                 }
                 let record = serde_json::from_slice::<JournalRecord>(&line[..line.len() - 1])?;
                 match record {
-                    JournalRecord::Task(task) => {
-                        if let Some(index) = task_indices.get(&task.key).copied() {
-                            snapshot.tasks[index] = task;
-                        } else {
-                            let index = snapshot.tasks.len();
-                            task_indices.insert(task.key.clone(), index);
-                            snapshot.tasks.push(task);
-                        }
-                    }
+                    JournalRecord::Task(task) => insert_task(&mut snapshot.tasks, &mut task_indices, task),
                     JournalRecord::SourceCursor { source, delta_version } => {
                         snapshot.source_cursors.entry(source).and_modify(|cursor| *cursor = (*cursor).max(delta_version)).or_insert(delta_version);
                     }
@@ -1221,11 +1227,13 @@ impl TaskJournal {
         if self.migration_done(Self::STALE_ESTIMATE_MIGRATION) {
             return None;
         }
-        let mut cleared = 0usize;
-        for task in self.snapshot.tasks.iter_mut().filter(|task| task.state != TaskState::Complete && task.estimated_decoded_bytes != 0) {
-            task.estimated_decoded_bytes = 0;
-            cleared += 1;
-        }
+        let cleared = self.snapshot.tasks.iter_mut().filter(|task| task.state != TaskState::Complete && task.estimated_decoded_bytes != 0).fold(
+            0usize,
+            |cleared, task| {
+                task.estimated_decoded_bytes = 0;
+                cleared + 1
+            },
+        );
         self.dirty_tasks.clear();
         self.mark_migration_done(Self::STALE_ESTIMATE_MIGRATION);
         Some(cleared)
@@ -1251,13 +1259,15 @@ impl TaskJournal {
         if self.migration_done(Self::REPAIR_SINGLE_PASS_MIGRATION) {
             return None;
         }
-        let mut reset = 0usize;
-        for task in self.snapshot.tasks.iter_mut().filter(|task| task.key.operation == Operation::Repair && task.state != TaskState::Complete) {
-            task.attempts = 0;
-            task.retry_reason = None;
-            task.deadline_micros = 0;
-            reset += 1;
-        }
+        let reset = self.snapshot.tasks.iter_mut().filter(|task| task.key.operation == Operation::Repair && task.state != TaskState::Complete).fold(
+            0usize,
+            |reset, task| {
+                task.attempts = 0;
+                task.retry_reason = None;
+                task.deadline_micros = 0;
+                reset + 1
+            },
+        );
         // A journal with no repair queue has nothing to forgive, so it must not
         // spend the one-shot cursor — or the migration would be consumed by a
         // boot that happened to precede the queue, and the caller would compact
@@ -1528,9 +1538,7 @@ impl TaskJournal {
         // deleted them first.
         let damaged = self.untagged_cells.clone();
         let is_damage = |task: &MaintenanceTask| {
-            chrono::DateTime::from_timestamp_micros(task.key.slice.start_micros).is_some_and(|time| {
-                damaged.contains(&(task.key.source.clone(), task.key.project_id.clone(), task.key.physical_table.clone(), time.date_naive().to_string()))
-            })
+            task_date(task).is_some_and(|date| damaged.contains(&(task.key.source.clone(), task.key.project_id.clone(), task.key.physical_table.clone(), date)))
         };
         self.retain_tasks(|task| {
             // A covering task does not carry this retry's failure history or deadline.
@@ -1588,14 +1596,8 @@ impl TaskJournal {
                 && task.state == TaskState::Pending
                 && !is_live_frontier(task.key.slice, now_micros)
                 && task.key.slice.width() < width
-                && !chrono::DateTime::from_timestamp_micros(task.key.slice.start_micros).is_some_and(|time| {
-                    untagged_cells.contains(&(
-                        task.key.source.clone(),
-                        task.key.project_id.clone(),
-                        task.key.physical_table.clone(),
-                        time.date_naive().to_string(),
-                    ))
-                })
+                && !task_date(task)
+                    .is_some_and(|date| untagged_cells.contains(&(task.key.source.clone(), task.key.project_id.clone(), task.key.physical_table.clone(), date)))
         };
         // Running and Retry units block every overlapping bucket. A retry
         // owns a deadline and failure history: fusing it would reset both on
@@ -1636,10 +1638,6 @@ impl TaskJournal {
 
         let mut report = CoarsenReport::default();
         let mut groups: HashMap<(String, String, String, Operation, i64), GroupPrice> = HashMap::new();
-        let mut members: HashMap<(String, String, String, Operation, i64), usize> = HashMap::new();
-        // The OLDEST member's creation time, because the fused unit inherits its
-        // members' work and must inherit their age with it.
-        let mut oldest: HashMap<(String, String, String, Operation, i64), u64> = HashMap::new();
         for task in self.snapshot.tasks.iter().filter(|task| coarsenable(task)) {
             report.candidates += 1;
             let group = (
@@ -1653,9 +1651,7 @@ impl TaskJournal {
                 report.blocked += 1;
                 continue;
             }
-            groups.entry(group.clone()).or_default().add(task);
-            *members.entry(group.clone()).or_default() += 1;
-            oldest.entry(group).and_modify(|at| *at = (*at).min(task.created_unix_ms)).or_insert(task.created_unix_ms);
+            groups.entry(group).or_default().add(task);
         }
         // Only fuse a span that will actually FIT. Coarsening is a win because
         // one unit does one scan where 144 slices each did the same scan — but a
@@ -1734,7 +1730,7 @@ impl TaskJournal {
             let fits = price.bytes() <= MAX_DECODED_BYTES || priced_by_partition.contains(group);
             report.priced_by_footprint += usize::from(fits && price.summed_bytes > MAX_DECODED_BYTES);
             if !fits {
-                report.over_budget += members.get(group).copied().unwrap_or(0);
+                report.over_budget += price.members;
             }
             fits
         });
@@ -1753,10 +1749,7 @@ impl TaskJournal {
         });
         for ((physical_table, source, project_id, operation, bucket), price) in groups {
             let Ok(slice) = TimeSlice::new(bucket, bucket.saturating_add(width)) else { continue };
-            let oldest_member = oldest
-                .get(&(physical_table.clone(), source.clone(), project_id.clone(), operation, bucket))
-                .copied()
-                .unwrap_or_else(|| u64::try_from(now_micros.div_euclid(1_000)).unwrap_or_default());
+            let oldest_member = price.oldest.unwrap_or_else(|| u64::try_from(now_micros.div_euclid(1_000)).unwrap_or_default());
             self.upsert(MaintenanceTask {
                 // Only when every member agreed. A fused unit over several file
                 // sets reads their union, which no scalar here can state, and
@@ -1978,14 +1971,14 @@ impl TaskJournal {
         }
         files.sort_unstable();
         let at = |q: f64| files[((files.len() - 1) as f64 * q) as usize];
-        let tied = files.iter().filter(|f| **f / BENEFIT_BUCKET_FILES == 0).count();
+        let tied = files.iter().filter(|f| **f < BENEFIT_BUCKET_FILES).count();
         let buckets = files.iter().map(|f| f / BENEFIT_BUCKET_FILES).collect::<std::collections::BTreeSet<_>>().len();
         Some(format!(
             "cells={} files_p50={} files_p90={} files_max={} tied_at_zero={} distinct_buckets={}",
             files.len(),
             at(0.5),
             at(0.9),
-            files[files.len() - 1],
+            at(1.0),
             tied,
             buckets
         ))
@@ -1994,9 +1987,7 @@ impl TaskJournal {
     pub fn most_indebted_unclaimed(&self, operation: Operation, now_micros: i64) -> Option<String> {
         let eligible =
             || self.snapshot.tasks.iter().filter(|task| task.key.operation == operation && matches!(task.state, TaskState::Pending | TaskState::Retry));
-        let date_of = |task: &MaintenanceTask| {
-            chrono::DateTime::from_timestamp_micros(task.key.slice.start_micros).map_or_else(|| "?".to_owned(), |time| time.date_naive().to_string())
-        };
+        let date_of = |task: &MaintenanceTask| task_date(task).unwrap_or_else(|| "?".to_owned());
         let worst = eligible().max_by_key(|task| task.input.map_or(0, |input| input.files))?;
         let files = worst.input.map_or(0, |input| input.files);
         // The reasons that live on the task itself, in the order `claim_next`
@@ -2049,18 +2040,18 @@ impl TaskJournal {
                 "CLAIMABLE"
             }
         };
-        let describe = |task: &MaintenanceTask| {
-            let date = chrono::DateTime::from_timestamp_micros(task.key.slice.start_micros)
-                .map(|time| time.date_naive().to_string())
-                .unwrap_or_else(|| "?".to_owned());
-            (task.key.project_id.clone(), date, why(task))
-        };
-        let mut sealed = self.snapshot.tasks.iter().filter(|task| {
-            task.key.operation == operation && matches!(task.state, TaskState::Pending | TaskState::Retry) && !is_frontier_task(task, now_micros)
-        });
+        let describe = |task: &MaintenanceTask| (task.key.project_id.clone(), task_date(task).unwrap_or_else(|| "?".to_owned()), why(task));
         // A claimable one is the interesting answer: it means eligibility is fine
         // and the refusal is in ordering. Otherwise report the first task's reason.
-        let sample: Vec<_> = sealed.by_ref().take(LIMIT).collect();
+        let sample: Vec<_> = self
+            .snapshot
+            .tasks
+            .iter()
+            .filter(|task| {
+                task.key.operation == operation && matches!(task.state, TaskState::Pending | TaskState::Retry) && !is_frontier_task(task, now_micros)
+            })
+            .take(LIMIT)
+            .collect();
         sample.iter().find(|task| why(task) == "CLAIMABLE").or_else(|| sample.first()).map(|task| describe(task))
     }
 
@@ -2156,7 +2147,7 @@ impl TaskJournal {
         if !matches!(task.key.operation, Operation::BaseRollup | Operation::DerivedRollup) {
             return 2;
         }
-        let Some(date) = chrono::DateTime::from_timestamp_micros(task.key.slice.start_micros).map(|time| time.date_naive().to_string()) else {
+        let Some(date) = task_date(task) else {
             return 2;
         };
         let cell = (task.key.source.clone(), task.key.project_id.clone(), task.key.physical_table.clone(), date);
@@ -2170,27 +2161,29 @@ impl TaskJournal {
     }
 
     pub fn prove_base_tier_for_day(&mut self, key: &TaskKey, day_start: i64, day_end: i64) -> usize {
-        let mut proven = 0;
-        for task in &mut self.snapshot.tasks {
+        // Disjoint field borrows, so the pipeline can mark tasks dirty as it goes.
+        let dirty = &mut self.dirty_tasks;
+        self.snapshot
+            .tasks
+            .iter_mut()
             // Only work that can still run. A completed task matches its own
-            // day and proving it is a no-op that would make `proven` read as
+            // day and proving it is a no-op that would make the count read as
             // progress when nothing became claimable.
-            if !matches!(task.state, TaskState::Pending | TaskState::Retry)
-                || task.base_tier_present
-                || task.key.operation != key.operation
-                || task.key.source != key.source
-                || task.key.project_id != key.project_id
-                || task.key.physical_table != key.physical_table
-                || task.key.slice.start_micros < day_start
-                || task.key.slice.end_micros > day_end
-            {
-                continue;
-            }
-            task.base_tier_present = true;
-            self.dirty_tasks.insert(task.key.clone());
-            proven += 1;
-        }
-        proven
+            .filter(|task| {
+                matches!(task.state, TaskState::Pending | TaskState::Retry)
+                    && !task.base_tier_present
+                    && task.key.operation == key.operation
+                    && task.key.source == key.source
+                    && task.key.project_id == key.project_id
+                    && task.key.physical_table == key.physical_table
+                    && task.key.slice.start_micros >= day_start
+                    && task.key.slice.end_micros <= day_end
+            })
+            .fold(0, |proven, task| {
+                task.base_tier_present = true;
+                dirty.insert(task.key.clone());
+                proven + 1
+            })
     }
 
     /// Remember what a unit reads, measured by the claim-time preflight.
@@ -2236,13 +2229,7 @@ impl TaskJournal {
         if task.state == TaskState::Complete {
             self.note_dedup_edges(&task.key);
         }
-        if let Some(index) = self.task_indices.get(&task.key).copied() {
-            self.snapshot.tasks[index] = task;
-        } else {
-            let index = self.snapshot.tasks.len();
-            self.task_indices.insert(task.key.clone(), index);
-            self.snapshot.tasks.push(task);
-        }
+        insert_task(&mut self.snapshot.tasks, &mut self.task_indices, task);
     }
 
     pub fn enqueue(&mut self, key: TaskKey, deadline_micros: i64, estimated_decoded_bytes: u64, created_unix_ms: u64) {
@@ -2394,13 +2381,11 @@ impl TaskJournal {
             return true;
         }
         self.dirty_tasks.insert(key.clone());
-        let index = self.snapshot.tasks.len();
-        self.task_indices.insert(key.clone(), index);
-        self.snapshot.tasks.push(MaintenanceTask {
-            base_tier_present,
-            input,
-            ..MaintenanceTask::pending(key, deadline_micros, estimated_decoded_bytes, created_unix_ms)
-        });
+        insert_task(
+            &mut self.snapshot.tasks,
+            &mut self.task_indices,
+            MaintenanceTask { base_tier_present, input, ..MaintenanceTask::pending(key, deadline_micros, estimated_decoded_bytes, created_unix_ms) },
+        );
         true
     }
 
@@ -2532,9 +2517,8 @@ impl TaskJournal {
                         self.dirty_tasks.insert(key);
                     }
                 } else {
-                    let index = self.snapshot.tasks.len();
-                    self.task_indices.insert(key.clone(), index);
-                    self.snapshot.tasks.push(MaintenanceTask::pending(key.clone(), deadline_micros, 0, created_unix_ms));
+                    let task = MaintenanceTask::pending(key.clone(), deadline_micros, 0, created_unix_ms);
+                    insert_task(&mut self.snapshot.tasks, &mut self.task_indices, task);
                     self.dirty_tasks.insert(key);
                 }
             }
@@ -2909,14 +2893,11 @@ impl TaskJournal {
     }
 
     fn dependencies_complete(&self, task: &MaintenanceTask) -> bool {
-        let required = match task.key.operation {
-            // Base publication performs its own bounded complete-key/tiebreak
-            // dedup before aggregation. Physical source consolidation is
-            // independent debt and must not block exact rollup coverage.
-            Operation::BaseRollup => None,
-            Operation::DerivedRollup => Some(Operation::BaseRollup),
-            _ => None,
-        };
+        // Only a DERIVED unit has a dependency at all. Base publication performs
+        // its own bounded complete-key/tiebreak dedup before aggregation, and
+        // physical source consolidation is independent debt that must not block
+        // exact rollup coverage.
+        let required = matches!(task.key.operation, Operation::DerivedRollup).then_some(Operation::BaseRollup);
         // Proven from real tier coverage, which is strictly better evidence than
         // the journal's own record of who built what. See the field's comment.
         //
@@ -2927,14 +2908,17 @@ impl TaskJournal {
         if task.base_tier_present {
             return true;
         }
-        if let Some(date) = chrono::DateTime::from_timestamp_micros(task.key.slice.start_micros).map(|time| time.date_naive().to_string())
+        if let Some(date) = task_date(task)
             && self.base_tier_ready.contains(&(task.key.source.clone(), task.key.project_id.clone(), date))
         {
             return true;
         }
+        // Contiguous coverage of the slice by COMPLETE units of the required
+        // operation: `scan` walks the sorted intervals and stops dead at the
+        // first gap, `any` stops at the first interval that reaches the end.
         required.is_none_or(|required| {
-            let mut intervals = self
-                .snapshot
+            use itertools::Itertools;
+            self.snapshot
                 .tasks
                 .iter()
                 .filter(|candidate| {
@@ -2945,19 +2929,14 @@ impl TaskJournal {
                         && task.key.slice.overlaps(candidate.key.slice.start_micros, candidate.key.slice.end_micros)
                 })
                 .map(|candidate| candidate.key.slice)
-                .collect::<Vec<_>>();
-            intervals.sort_unstable();
-            let mut covered_through = task.key.slice.start_micros;
-            for interval in intervals {
-                if interval.start_micros > covered_through {
-                    break;
-                }
-                covered_through = covered_through.max(interval.end_micros);
-                if covered_through >= task.key.slice.end_micros {
-                    return true;
-                }
-            }
-            false
+                .sorted_unstable()
+                .scan(task.key.slice.start_micros, |covered, interval| {
+                    (interval.start_micros <= *covered).then(|| {
+                        *covered = (*covered).max(interval.end_micros);
+                        *covered
+                    })
+                })
+                .any(|covered| covered >= task.key.slice.end_micros)
         })
     }
 
@@ -2979,21 +2958,23 @@ impl TaskJournal {
     }
 
     pub fn complete(&mut self, key: &TaskKey) -> bool {
-        let Some(index) = self.task_indices.get(key).copied() else { return false };
-        let task = &mut self.snapshot.tasks[index];
-        task.state = TaskState::Complete;
-        task.retry_reason = None;
-        self.dirty_tasks.insert(key.clone());
-        self.note_dedup_edges(key);
-        true
+        self.finish(key, None)
     }
 
     pub fn publish(&mut self, key: &TaskKey, publication: Publication) -> bool {
+        self.finish(key, Some(publication))
+    }
+
+    /// Mark a unit Complete. `None` leaves any existing publication untouched,
+    /// matching `complete`'s behaviour.
+    fn finish(&mut self, key: &TaskKey, publication: Option<Publication>) -> bool {
         let Some(index) = self.task_indices.get(key).copied() else { return false };
         let task = &mut self.snapshot.tasks[index];
         task.state = TaskState::Complete;
         task.retry_reason = None;
-        task.publication = Some(publication);
+        if let Some(publication) = publication {
+            task.publication = Some(publication);
+        }
         self.dirty_tasks.insert(key.clone());
         self.note_dedup_edges(key);
         true
@@ -3182,17 +3163,15 @@ impl TaskJournal {
     /// A process may die after selecting work. Running is not a durable lease;
     /// requeue it at boot so recovery produces redundant work, never a hole.
     pub fn requeue_running(&mut self, now_micros: i64) -> usize {
-        let mut count = 0;
-        for task in &mut self.snapshot.tasks {
-            if task.state == TaskState::Running {
-                task.state = TaskState::Retry;
-                task.deadline_micros = now_micros;
-                task.retry_reason = Some("coordinator_restart".to_owned());
-                self.dirty_tasks.insert(task.key.clone());
-                count += 1;
-            }
-        }
-        count
+        // Disjoint field borrows, so the pipeline can mark tasks dirty as it goes.
+        let dirty = &mut self.dirty_tasks;
+        self.snapshot.tasks.iter_mut().filter(|task| task.state == TaskState::Running).fold(0, |count, task| {
+            task.state = TaskState::Retry;
+            task.deadline_micros = now_micros;
+            task.retry_reason = Some("coordinator_restart".to_owned());
+            dirty.insert(task.key.clone());
+            count + 1
+        })
     }
 
     pub fn tasks(&self) -> impl Iterator<Item = &MaintenanceTask> {
@@ -3246,9 +3225,7 @@ impl TaskJournal {
         self.snapshot
             .tasks
             .iter()
-            .filter(|task| {
-                task.key.project_id == project_id && task.key.physical_table == target && task.key.slice.start_micros < end && task.key.slice.end_micros > start
-            })
+            .filter(|task| task.key.project_id == project_id && task.key.physical_table == target && task.key.slice.overlaps(start, end))
             .filter_map(|task| task.publication.as_ref().map(|publication| publication.rows))
             .sum()
     }
@@ -3275,27 +3252,28 @@ impl TaskJournal {
     /// Complete to Pending and mints no task, and a derived publish does not
     /// call it.
     pub fn reopen_derived_over(&mut self, project_id: &str, rollup_table: &str, start_micros: i64, end_micros: i64) -> usize {
-        let mut reopened = 0;
-        for task in &mut self.snapshot.tasks {
-            if task.state != TaskState::Complete
-                || task.key.operation != Operation::DerivedRollup
-                || task.key.project_id != project_id
-                || task.key.physical_table != rollup_table
-                || task.key.slice.start_micros >= end_micros
-                || task.key.slice.end_micros <= start_micros
-            {
-                continue;
-            }
-            task.state = TaskState::Pending;
-            task.retry_reason = None;
-            // Dropped with the state: `Publication` is what coverage is recovered
-            // from at boot, so leaving it would have the next process re-adopt
-            // the very cell this reopen exists to replace.
-            task.publication = None;
-            self.dirty_tasks.insert(task.key.clone());
-            reopened += 1;
-        }
-        reopened
+        // Disjoint field borrows, so the pipeline can mark tasks dirty as it goes.
+        let dirty = &mut self.dirty_tasks;
+        self.snapshot
+            .tasks
+            .iter_mut()
+            .filter(|task| {
+                task.state == TaskState::Complete
+                    && task.key.operation == Operation::DerivedRollup
+                    && task.key.project_id == project_id
+                    && task.key.physical_table == rollup_table
+                    && task.key.slice.overlaps(start_micros, end_micros)
+            })
+            .fold(0, |reopened, task| {
+                task.state = TaskState::Pending;
+                task.retry_reason = None;
+                // Dropped with the state: `Publication` is what coverage is recovered
+                // from at boot, so leaving it would have the next process re-adopt
+                // the very cell this reopen exists to replace.
+                task.publication = None;
+                dirty.insert(task.key.clone());
+                reopened + 1
+            })
     }
 
     pub fn source_cursor(&self, source: &str) -> Option<u64> {
@@ -3484,7 +3462,7 @@ impl TaskJournal {
             .maintenance_raw_tail_duration_secs
             .store(u64::try_from(FINALIZATION_DELAY_MICROS / 1_000_000).unwrap_or_default().saturating_add(eligible_lag_secs), Relaxed);
         let processed = stats.maintenance_processed_bytes.load(Relaxed);
-        let mut sample = THROUGHPUT_SAMPLE.get_or_init(|| Mutex::new((now_micros, processed))).lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let mut sample = lock(THROUGHPUT_SAMPLE.get_or_init(|| Mutex::new((now_micros, processed))));
         let elapsed = now_micros.saturating_sub(sample.0);
         if elapsed >= 1_000_000 {
             let rate = processed.saturating_sub(sample.1).saturating_mul(1_000_000) / u64::try_from(elapsed).unwrap_or(u64::MAX).max(1);
@@ -3498,8 +3476,8 @@ impl TaskJournal {
     }
 }
 
-/// `(class, operation priority, -width, -recency)` -> project -> that project's
-/// queue. Ordered so smaller tuples run first; see `scheduling_class`.
+/// `(class, starved, operation priority, -width, benefit, recency)` -> project ->
+/// that project's queue. Ordered so smaller tuples run first; see `scheduling_class`.
 type ReadyGroups<'a> = BTreeMap<(u8, u8, u8, i64, i64, i64), HashMap<&'a str, VecDeque<&'a MaintenanceTask>>>;
 
 /// Deadline ordering with round-robin selection among projects at the same
@@ -3839,6 +3817,11 @@ fn is_frontier_task(task: &MaintenanceTask, now_micros: i64) -> bool {
     task.key.operation != Operation::SealedConsolidation && is_live_frontier(task.key.slice, now_micros)
 }
 
+/// A task's slice as a calendar date, `None` if the start timestamp is out of `chrono`'s range.
+fn task_date(task: &MaintenanceTask) -> Option<String> {
+    chrono::DateTime::from_timestamp_micros(task.key.slice.start_micros).map(|time| time.date_naive().to_string())
+}
+
 fn track_latest_frontier_rollup<'a>(latest: &mut HashMap<(&'a str, &'a str, &'a str), &'a MaintenanceTask>, task: &'a MaintenanceTask, now_micros: i64) {
     if task.key.operation != Operation::BaseRollup || !is_live_frontier(task.key.slice, now_micros) {
         return;
@@ -3988,7 +3971,7 @@ impl AdmissionController {
         if request.decoded_bytes > MAX_DECODED_BYTES {
             return None;
         }
-        let mut state = self.0.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let mut state = lock(&self.0);
         if request.decoded_bytes > occupancy_scaled_ceiling(state.available.decoded_bytes, state.capacity.decoded_bytes) {
             return None;
         }
@@ -4001,7 +3984,7 @@ impl AdmissionController {
     }
 
     pub fn utilization(&self) -> Resources {
-        self.0.lock().unwrap_or_else(std::sync::PoisonError::into_inner).used()
+        lock(&self.0).used()
     }
 
     fn publish_utilization(state: &AdmissionState) {
@@ -4023,7 +4006,7 @@ pub struct AdmissionPermit {
 
 impl Drop for AdmissionPermit {
     fn drop(&mut self) {
-        let mut state = self.controller.0.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let mut state = lock(&self.controller.0);
         state.available = state.available.saturating_add(self.resources);
         debug_assert!(state.available.fits(state.capacity));
         AdmissionController::publish_utilization(&state);

--- a/src/maintenance_sim.rs
+++ b/src/maintenance_sim.rs
@@ -13,16 +13,16 @@ use anyhow::Context as _;
 use itertools::Itertools;
 use serde::Serialize;
 
+use crate::database::{coverage_is_short_for, median_contiguous_days};
 use crate::maintenance_coordinator::{
-    InputFootprint, Invalidation, MAX_DECODED_BYTES, MIN_SLICE_MICROS, MaintenanceTask, Operation, TaskJournal, TaskKey, TaskState, operation_cycle,
-    operation_deadline_secs,
+    DAY_MICROS, InputFootprint, Invalidation, LIVE_FRONTIER_WINDOW_MICROS, MAX_DECODED_BYTES, MIN_SLICE_MICROS, MaintenanceTask, NORMAL_SLICE_MICROS,
+    Operation, STARVATION_HORIZON_MICROS, TaskJournal, TaskKey, TaskState, TimeSlice, operation_cycle, operation_deadline_secs, split_sheds_enough_at,
 };
 
 const MICROS: i64 = 1_000_000;
-const DAY_MICROS: i64 = 86_400_000_000;
 const HOUR_MICROS: i64 = 3_600_000_000;
 /// Matches the write path's bucket cadence.
-const MINT_INTERVAL_MICROS: i64 = crate::maintenance_coordinator::NORMAL_SLICE_MICROS;
+const MINT_INTERVAL_MICROS: i64 = NORMAL_SLICE_MICROS;
 /// Lets idle workers notice newly mature deadlines.
 const IDLE_POLL_MICROS: i64 = 5 * MICROS;
 /// `run_maintenance_coordinator_once` coarsens on the same 60s cadence it plans
@@ -82,10 +82,7 @@ impl DayShape {
     pub fn bytes(&self, width_micros: i64, floored: bool) -> u64 {
         let width = width_micros.max(0) as u128;
         let proportional = (u128::from(self.decoded_bytes) * width / u128::from(DAY_MICROS as u64)) as u64;
-        if !floored {
-            return proportional;
-        }
-        proportional.saturating_add(self.files_overlapping(width_micros).saturating_mul(ROW_GROUP_BYTES))
+        if floored { proportional.saturating_add(self.files_overlapping(width_micros).saturating_mul(ROW_GROUP_BYTES)) } else { proportional }
     }
 
     fn files_overlapping(&self, width_micros: i64) -> u64 {
@@ -345,8 +342,11 @@ fn duration_range_secs(operation: Operation, width_micros: i64, rng: &mut Rng) -
 
 /// Debt work = file rewrites that cannot advance rollup coverage
 /// (`dependencies_complete`): the operations #176's occupancy cap applies to.
+/// Spelled as the COMPLEMENT of the rollup tiers, exactly like the server's own
+/// `_debt_slot` predicate — an operation added later is debt on both sides
+/// rather than silently exempt here.
 fn is_debt_op(operation: Operation) -> bool {
-    matches!(operation, Operation::Dedup | Operation::HotPacking | Operation::SealedConsolidation | Operation::Repair)
+    !matches!(operation, Operation::BaseRollup | Operation::DerivedRollup)
 }
 
 /// Deterministic SplitMix64 generator for simulation.
@@ -419,9 +419,9 @@ impl Coverage {
         };
         // A slice can straddle midnight after time-bisection; credit each day
         // it overlaps, clamped to that day.
+        let days = self.days.entry((key.source.clone(), key.project_id.clone())).or_default();
         for day in (day_start(key.slice.start_micros)..key.slice.end_micros).step_by(DAY_MICROS as usize) {
-            let overlap = (key.slice.end_micros.min(day + DAY_MICROS) - key.slice.start_micros.max(day)).max(0);
-            self.days.entry((key.source.clone(), key.project_id.clone())).or_default().entry(day).or_default()[tier] += overlap;
+            days.entry(day).or_default()[tier] += (key.slice.end_micros.min(day + DAY_MICROS) - key.slice.start_micros.max(day)).max(0);
         }
     }
 
@@ -470,8 +470,8 @@ impl Coverage {
     /// created tier production reads its median as provisional where the sim
     /// takes it at face value.
     fn coverage_is_short(&self, now_micros: i64) -> bool {
-        let fleet = self.per_sweep(now_micros).into_iter().map(|mut days| crate::database::median_contiguous_days(&mut days)).min().unwrap_or(0);
-        crate::database::coverage_is_short_for(fleet)
+        let fleet = self.per_sweep(now_micros).into_iter().map(|mut days| median_contiguous_days(&mut days)).min().unwrap_or(0);
+        coverage_is_short_for(fleet)
     }
 }
 
@@ -558,7 +558,7 @@ fn preflight(journal: &mut TaskJournal, model: &ByteModel, guard: SplitGuard, ta
             // inline transcription, which is a drift hazard by construction —
             // and is why the sim never reproduced the 2026-09-03
             // synthetic-observation defect.
-            let sheds = crate::maintenance_coordinator::split_sheds_enough_at(task.parent_measured_bytes, observed, numerator, denominator);
+            let sheds = split_sheds_enough_at(task.parent_measured_bytes, observed, numerator, denominator);
             if !sheds {
                 report.split_declined_at_floor += 1;
                 return Some(observed);
@@ -826,14 +826,15 @@ pub fn run(mut journal: TaskJournal, cfg: &SimConfig, start_micros: i64) -> anyh
                     // Bucketed on the SAME quantity `starved` ranks on: how long
                     // ago the slice's DATA ended, not when the record was made.
                     let waited = now.saturating_sub(task.key.slice.end_micros);
-                    if waited > crate::maintenance_coordinator::STARVATION_HORIZON_MICROS {
-                        report.claims_privileged += 1;
-                    } else if waited > 3 * crate::maintenance_coordinator::DAY_MICROS {
-                        report.claims_mid_band += 1;
+                    let band = if waited > STARVATION_HORIZON_MICROS {
+                        &mut report.claims_privileged
+                    } else if waited > 3 * DAY_MICROS {
+                        &mut report.claims_mid_band
                     } else {
-                        report.claims_frontier += 1;
-                    }
-                    if task.key.slice.width() >= crate::maintenance_coordinator::DAY_MICROS {
+                        &mut report.claims_frontier
+                    };
+                    *band += 1;
+                    if task.key.slice.width() >= DAY_MICROS {
                         report.claims_day_wide += 1;
                     }
                     if is_debt_op(operation) {
@@ -851,28 +852,24 @@ pub fn run(mut journal: TaskJournal, cfg: &SimConfig, start_micros: i64) -> anyh
             // prod runs it. A split leaves the worker free after the cost of
             // the measurement — no unit ran, so the debt slot goes back too.
             if let (Some(model), Some(task)) = (cfg.byte_model.as_ref(), claimed.as_ref()) {
-                match preflight(&mut journal, model, cfg.split_guard, task, &mut report) {
-                    Some(observed) => {
-                        let shards = observed.div_ceil(MAX_DECODED_BYTES).max(1);
-                        report.max_run_bytes = report.max_run_bytes.max(observed.div_ceil(shards));
-                        if shards > 1 {
-                            let width = task.key.slice.width();
-                            report.sharded_runs += 1;
-                            report.sharded_runs_above_min_slice += u64::from(width > MIN_SLICE_MICROS);
-                            report.narrowest_sharded_run_micros = match report.narrowest_sharded_run_micros {
-                                0 => width,
-                                current => current.min(width),
-                            };
-                        }
+                let Some(observed) = preflight(&mut journal, model, cfg.split_guard, task, &mut report) else {
+                    if is_debt_op(task.key.operation) {
+                        debt_busy -= 1;
                     }
-                    None => {
-                        if is_debt_op(task.key.operation) {
-                            debt_busy -= 1;
-                        }
-                        none_until = [0; 6];
-                        worker.busy_until = now + PREFLIGHT_COST_MICROS;
-                        continue;
-                    }
+                    none_until = [0; 6];
+                    worker.busy_until = now + PREFLIGHT_COST_MICROS;
+                    continue;
+                };
+                let shards = observed.div_ceil(MAX_DECODED_BYTES).max(1);
+                report.max_run_bytes = report.max_run_bytes.max(observed.div_ceil(shards));
+                if shards > 1 {
+                    let width = task.key.slice.width();
+                    report.sharded_runs += 1;
+                    report.sharded_runs_above_min_slice += u64::from(width > MIN_SLICE_MICROS);
+                    report.narrowest_sharded_run_micros = match report.narrowest_sharded_run_micros {
+                        0 => width,
+                        current => current.min(width),
+                    };
                 }
             }
             match claimed {
@@ -938,19 +935,21 @@ pub fn run(mut journal: TaskJournal, cfg: &SimConfig, start_micros: i64) -> anyh
             })
             .into_group_map();
         report.dedup_island_cells = by_cell.len();
-        for ((_, _, day), mut slices) in by_cell {
-            slices.sort_unstable();
-            let (runs, open_end) = slices.iter().fold((0usize, i64::MIN), |(runs, open), &(start, end)| (runs + usize::from(start > open), open.max(end)));
-            report.dedup_islands_total += runs;
-            // The grant-relevant outcome: ONE run covering the whole day. The
-            // island count is stock (dominated by pre-sim state); this is the
-            // conversion that certification actually pays on. `open_end` is the
-            // union's max end — with runs == 1 the union is one interval from
-            // the first start to `open_end`.
-            let day_start = day * DAY_MICROS;
-            report.dedup_cells_day_covered +=
-                usize::from(runs == 1 && slices.first().is_some_and(|&(s, _)| s <= day_start) && open_end >= day_start + DAY_MICROS);
-        }
+        (report.dedup_islands_total, report.dedup_cells_day_covered) = by_cell
+            .into_iter()
+            .map(|((_, _, day), mut slices)| {
+                slices.sort_unstable();
+                let (runs, open_end) = slices.iter().fold((0usize, i64::MIN), |(runs, open), &(start, end)| (runs + usize::from(start > open), open.max(end)));
+                // The grant-relevant outcome: ONE run covering the whole day.
+                // The island count is stock (dominated by pre-sim state); this
+                // is the conversion that certification actually pays on.
+                // `open_end` is the union's max end — with runs == 1 the union
+                // is one interval from the first start to `open_end`.
+                let day_start = day * DAY_MICROS;
+                let covered = runs == 1 && slices.first().is_some_and(|&(s, _)| s <= day_start) && open_end >= day_start + DAY_MICROS;
+                (runs, usize::from(covered))
+            })
+            .fold((0, 0), |(islands, covered), (runs, day_covered)| (islands + runs, covered + day_covered));
     }
     Ok(report)
 }
@@ -962,9 +961,7 @@ fn frontier_lag_secs(journal: &TaskJournal, now_micros: i64) -> u64 {
     journal
         .tasks()
         .filter(|task| {
-            is_open(task.state)
-                && task.deadline_micros <= now_micros
-                && task.key.slice.end_micros >= now_micros.saturating_sub(crate::maintenance_coordinator::LIVE_FRONTIER_WINDOW_MICROS)
+            is_open(task.state) && task.deadline_micros <= now_micros && task.key.slice.end_micros >= now_micros.saturating_sub(LIVE_FRONTIER_WINDOW_MICROS)
         })
         .map(|task| u64::try_from(now_micros.saturating_sub(task.deadline_micros).div_euclid(MICROS)).unwrap_or_default())
         .max()
@@ -1069,7 +1066,7 @@ fn rollup_key(project_id: &str, start_micros: i64, width_micros: i64) -> TaskKey
         physical_table: "otel_logs_and_spans_rollup_dashboard_1m_v3".to_owned(),
         source: "otel_logs_and_spans".to_owned(),
         project_id: project_id.to_owned(),
-        slice: crate::maintenance_coordinator::TimeSlice::new(start_micros, start_micros + width_micros).expect("fixture slice"),
+        slice: TimeSlice::new(start_micros, start_micros + width_micros).expect("fixture slice"),
         operation: Operation::BaseRollup,
     }
 }
@@ -1098,7 +1095,7 @@ pub fn load_sandboxed(input: &std::path::Path) -> anyhow::Result<(TaskJournal, t
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::maintenance_coordinator::{MAX_DECODED_BYTES, TimeSlice};
+    use crate::maintenance_coordinator::FRONTIER_LAG_BUDGET_SECS;
 
     fn key(project: &str, op: Operation, start: i64, width: i64) -> TaskKey {
         let table = match op {
@@ -1125,8 +1122,8 @@ mod tests {
     fn journal_with_streams(projects: usize) -> TaskJournal {
         let mut journal = empty_journal();
         for i in 0..projects {
-            let mut task = crate::maintenance_coordinator::MaintenanceTask {
-                key: key(&format!("p{i}"), Operation::BaseRollup, 60 * DAY_MICROS, crate::maintenance_coordinator::NORMAL_SLICE_MICROS),
+            let mut task = MaintenanceTask {
+                key: key(&format!("p{i}"), Operation::BaseRollup, 60 * DAY_MICROS, NORMAL_SLICE_MICROS),
                 state: TaskState::Complete,
                 deadline_micros: 0,
                 estimated_decoded_bytes: 0,
@@ -1183,7 +1180,7 @@ mod tests {
         let report_13 = run(journal_with_streams(13), &cfg(6), start).unwrap();
         let pending_13 = report_13.pending_end;
         assert!(
-            report_13.frontier_lag_secs_max > crate::maintenance_coordinator::FRONTIER_LAG_BUDGET_SECS,
+            report_13.frontier_lag_secs_max > FRONTIER_LAG_BUDGET_SECS,
             "13 projects already exceed the lag budget under measured durations, lag {}s",
             report_13.frontier_lag_secs_max
         );
@@ -1247,7 +1244,7 @@ mod tests {
         // with no ramping tier.
         let active = projects.iter().map(String::as_str).collect::<HashSet<_>>();
         let fleet = covered.iter().map(|covered| crate::database::min_contiguous_days(covered, &source, today, &active).2).min().unwrap();
-        let server = crate::database::coverage_is_short_for(fleet);
+        let server = coverage_is_short_for(fleet);
         assert_eq!(server, expected, "server decision at fleet median {fleet}");
         assert_eq!(coverage.coverage_is_short(now), server, "sim must decide as the server does (fleet median {fleet})");
     }
@@ -1321,10 +1318,10 @@ mod tests {
     /// The §3c run: `synth:whale`, 6 virtual hours, 16 workers, no minting —
     /// the queue under study is the fixture, not the frontier.
     fn synth_run(floored: bool, guard: SplitGuard) -> (SimReport, String, String) {
-        synth_run_at(floored, guard, 100)
+        synth_run_at(floored, guard, 100, 1.0)
     }
 
-    fn synth_run_at(floored: bool, guard: SplitGuard, whale_x_max: u64) -> (SimReport, String, String) {
+    fn synth_run_at(floored: bool, guard: SplitGuard, whale_x_max: u64, duration_scale: f64) -> (SimReport, String, String) {
         let start = 100 * DAY_MICROS;
         let queue = synthetic_whale_queue(start, floored, whale_x_max, 1);
         let cfg = SimConfig {
@@ -1333,6 +1330,7 @@ mod tests {
             horizon_micros: 6 * HOUR_MICROS,
             byte_model: Some(queue.model),
             split_guard: guard,
+            duration_scale,
             ..Default::default()
         };
         let report = run(queue.journal, &cfg, start).unwrap();
@@ -1399,22 +1397,11 @@ mod tests {
     #[test]
     fn a_floorless_whale_never_reaches_the_floor() {
         for guard in [SplitGuard::Off, SplitGuard::Shipped] {
-            let start = 100 * DAY_MICROS;
-            let queue = synthetic_whale_queue(start, false, 100, 1);
-            let whale = queue.whale_cell;
-            // The duration model is independent of bytes. Its random timeouts
-            // can legitimately split even a small task, so isolate byte physics
-            // here; timeout bisection is exercised by the failure tests.
-            let cfg = SimConfig {
-                mint_frontier: false,
-                workers: 16,
-                horizon_micros: 6 * HOUR_MICROS,
-                byte_model: Some(queue.model),
-                split_guard: guard,
-                duration_scale: 0.0,
-                ..Default::default()
-            };
-            let report = run(queue.journal, &cfg, start).unwrap();
+            // `duration_scale: 0.0` — the duration model is independent of
+            // bytes, and its random timeouts can legitimately split even a small
+            // task, so isolate byte physics here; timeout bisection is exercised
+            // by the failure tests.
+            let (report, whale, _) = synth_run_at(false, guard, 100, 0.0);
             assert_eq!(report.timeouts.values().sum::<u64>(), 0);
             // 255 units, not "tens": 100x MAX_DECODED_BYTES needs 128 leaves,
             // bisection only makes powers of two, and since bisection descends
@@ -1515,7 +1502,7 @@ mod tests {
     fn threshold_sweep() {
         for whale_x_max in [100, 20, 5] {
             for guard in [SplitGuard::Ratio(1, 2), SplitGuard::Ratio(2, 3), SplitGuard::Ratio(3, 4), SplitGuard::Ratio(4, 5), SplitGuard::Off] {
-                let (report, whale, _) = synth_run_at(true, guard, whale_x_max);
+                let (report, whale, _) = synth_run_at(true, guard, whale_x_max, 1.0);
                 println!(
                     "whale={whale_x_max:>3}x guard={guard:?} whale_units={:>5} at_min={:>5} declined={:>4} completed={:>5} sharded_above_min={} pending_end={}",
                     cell_units(&report, &whale),

--- a/src/read/bloom_prune.rs
+++ b/src/read/bloom_prune.rs
@@ -25,7 +25,7 @@ use std::{
 
 use anyhow::{Context, Result, anyhow};
 use bincode::{Decode, Encode};
-use dashmap::DashMap;
+use dashmap::{DashMap, DashSet};
 use datafusion::{
     logical_expr::{Expr, Operator, utils::split_conjunction},
     scalar::ScalarValue,
@@ -71,9 +71,7 @@ pub fn sidecar_path(table: &str, project_id: &str, date: &str) -> Path {
 }
 
 pub fn encode_sidecar(sidecar: &DateSidecar) -> Result<Vec<u8>> {
-    let mut out = vec![SIDECAR_VERSION];
-    out.extend(bincode::encode_to_vec(sidecar, BINCODE_CONFIG)?);
-    Ok(out)
+    Ok(std::iter::once(SIDECAR_VERSION).chain(bincode::encode_to_vec(sidecar, BINCODE_CONFIG)?).collect())
 }
 
 pub fn decode_sidecar(bytes: &[u8]) -> Result<DateSidecar> {
@@ -85,6 +83,12 @@ pub fn decode_sidecar(bytes: &[u8]) -> Result<DateSidecar> {
 }
 
 /// `project_id=<pid>/date=<d>/part-….parquet` → (pid, date).
+///
+/// ```
+/// use timefusion::read::bloom_prune::project_date_of_rel;
+/// assert_eq!(project_date_of_rel("project_id=abc/date=2026-08-22/part-0.parquet"), Some(("abc", "2026-08-22")));
+/// assert_eq!(project_date_of_rel("weird/path.parquet"), None);
+/// ```
 pub fn project_date_of_rel(rel: &str) -> Option<(&str, &str)> {
     let mut segs = rel.split('/');
     let pid = segs.next()?.strip_prefix("project_id=")?;
@@ -101,43 +105,70 @@ pub fn extract_needles(filters: &[Expr], schema: &crate::schema::TableSchema, mu
         Expr::Literal(ScalarValue::Utf8(Some(s)) | ScalarValue::LargeUtf8(Some(s)) | ScalarValue::Utf8View(Some(s)), _) => Some(s.clone()),
         _ => None,
     };
-    let mut by_col: HashMap<String, Vec<String>> = HashMap::new();
-    for conjunct in filters.iter().flat_map(|f| split_conjunction(f)) {
-        let (col, values) = match conjunct {
-            Expr::BinaryExpr(b) if b.op == Operator::Eq => match (&*b.left, &*b.right) {
-                (Expr::Column(c), rhs) => (c.name.clone(), lit_str(rhs).map(|v| vec![v])),
-                (lhs, Expr::Column(c)) => (c.name.clone(), lit_str(lhs).map(|v| vec![v])),
-                _ => continue,
-            },
-            Expr::InList(l) if !l.negated && l.list.len() <= MAX_NEEDLE_VALUES => match &*l.expr {
-                Expr::Column(c) => (c.name.clone(), l.list.iter().map(lit_str).collect::<Option<Vec<_>>>()),
-                _ => continue,
-            },
-            _ => continue,
-        };
-        if let Some(values) = values.filter(|_| eligible(&col)) {
+    filters
+        .iter()
+        .flat_map(|f| split_conjunction(f))
+        .filter_map(|conjunct| {
+            let (col, values) = match conjunct {
+                Expr::BinaryExpr(b) if b.op == Operator::Eq => match (&*b.left, &*b.right) {
+                    (Expr::Column(c), rhs) => (c.name.clone(), lit_str(rhs).map(|v| vec![v])),
+                    (lhs, Expr::Column(c)) => (c.name.clone(), lit_str(lhs).map(|v| vec![v])),
+                    _ => return None,
+                },
+                Expr::InList(l) if !l.negated && l.list.len() <= MAX_NEEDLE_VALUES => match &*l.expr {
+                    Expr::Column(c) => (c.name.clone(), l.list.iter().map(lit_str).collect::<Option<Vec<_>>>()),
+                    _ => return None,
+                },
+                _ => return None,
+            };
+            values.filter(|_| eligible(&col)).map(|values| (col, values))
+        })
+        .fold(HashMap::<String, Vec<String>>::new(), |mut by_col, (col, values)| {
             by_col.entry(col).or_default().extend(values);
-        }
-    }
-    by_col.into_iter().collect()
+            by_col
+        })
+        .into_iter()
+        .collect()
 }
 
 /// Dates (YYYY-MM-DD, UTC) covered by a micros time range; `None` when the
 /// range is unbounded or wider than `MAX_PRUNE_DATES`.
+///
+/// ```
+/// use timefusion::read::bloom_prune::dates_in_range;
+/// const DAY: i64 = 86_400_000_000;
+/// assert_eq!(dates_in_range((0, 0)).unwrap(), ["1970-01-01"]);
+/// assert_eq!(dates_in_range((0, 2 * DAY)).unwrap().len(), 3);
+/// assert!(dates_in_range((0, 400 * DAY)).is_none(), "over-wide windows skip pruning");
+/// assert!(dates_in_range((i64::MIN, 0)).is_none(), "unbounded windows skip pruning");
+/// ```
 pub fn dates_in_range(range: (i64, i64)) -> Option<Vec<String>> {
     let day = |micros: i64| chrono::DateTime::from_timestamp_micros(micros).map(|dt| dt.date_naive());
     let (lo, hi) = (day(range.0)?, day(range.1)?);
-    let span = (hi - lo).num_days();
-    if !(0..MAX_PRUNE_DATES as i64).contains(&span) {
-        return None;
-    }
-    Some(lo.iter_days().take(span as usize + 1).map(|d| d.format("%Y-%m-%d").to_string()).collect())
+    let span = usize::try_from((hi - lo).num_days()).ok().filter(|s| *s < MAX_PRUNE_DATES)?;
+    Some(lo.iter_days().take(span + 1).map(|d| d.format("%Y-%m-%d").to_string()).collect())
 }
 
 struct FileProbe {
     no_bloom: bool,
     columns: HashMap<String, Vec<Sbbf>>,
 }
+
+impl FileProbe {
+    /// True iff some needle column has complete blooms in this file and every
+    /// value of that needle misses in every row group — the file provably
+    /// contains no matching row (and, because updates and tombstones are
+    /// full-row copies, no other version of one either).
+    fn rejects(&self, needles: &[(String, Vec<String>)]) -> bool {
+        !self.no_bloom
+            && needles
+                .iter()
+                .any(|(col, values)| self.columns.get(col).is_some_and(|blooms| values.iter().all(|v| blooms.iter().all(|b| !b.check(v.as_str())))))
+    }
+}
+
+/// (table, project_id, date) — the resident-cache key.
+type DateKey = (String, String, String);
 
 pub struct DateBlooms {
     files: HashMap<String, FileProbe>,
@@ -162,20 +193,6 @@ impl DateBlooms {
             .collect();
         Self { files, bytes: raw_len, loaded_at: Instant::now() }
     }
-
-    /// True iff some needle column has complete blooms in this file and every
-    /// value of that needle misses in every row group — the file provably
-    /// contains no matching row (and, because updates and tombstones are
-    /// full-row copies, no other version of one either).
-    fn rejects(&self, rel: &str, needles: &[(String, Vec<String>)]) -> Option<bool> {
-        let probe = self.files.get(rel)?;
-        if probe.no_bloom {
-            return Some(false);
-        }
-        Some(
-            needles.iter().any(|(col, values)| probe.columns.get(col).is_some_and(|blooms| values.iter().all(|v| blooms.iter().all(|b| !b.check(v.as_str()))))),
-        )
-    }
 }
 
 #[derive(Default)]
@@ -196,8 +213,8 @@ pub struct BloomPruneStats {
 /// tasks, single-flighted per key.
 pub struct BloomPruneRegistry {
     store: Arc<dyn ObjectStore>,
-    entries: DashMap<(String, String, String), Arc<DateBlooms>>,
-    inflight: DashMap<(String, String, String), ()>,
+    entries: DashMap<DateKey, Arc<DateBlooms>>,
+    inflight: DashSet<DateKey>,
     bytes: AtomicUsize,
     cap_bytes: usize,
     refresh: Duration,
@@ -212,7 +229,7 @@ impl std::fmt::Debug for BloomPruneRegistry {
 
 impl BloomPruneRegistry {
     pub fn new(store: Arc<dyn ObjectStore>, cap_bytes: usize, refresh: Duration) -> Self {
-        Self { store, entries: DashMap::new(), inflight: DashMap::new(), bytes: AtomicUsize::new(0), cap_bytes, refresh, stats: BloomPruneStats::default() }
+        Self { store, entries: DashMap::new(), inflight: DashSet::new(), bytes: AtomicUsize::new(0), cap_bytes, refresh, stats: BloomPruneStats::default() }
     }
 
     /// Table-relative paths among the resident sidecars for `dates` that
@@ -220,6 +237,7 @@ impl BloomPruneRegistry {
     /// absent from the result — inclusion on unknown.
     pub fn rejected_rels(self: &Arc<Self>, table: &str, project_id: &str, dates: &[String], needles: &[(String, Vec<String>)]) -> HashSet<String> {
         let mut rejected = HashSet::new();
+        // Effectful loop: each date may spawn a load and bumps counters.
         for date in dates {
             let key = (table.to_string(), project_id.to_string(), date.clone());
             let Some(blooms) = self.entries.get(&key).map(|e| e.clone()) else {
@@ -231,13 +249,10 @@ impl BloomPruneRegistry {
             if blooms.loaded_at.elapsed() > self.refresh {
                 self.spawn_load(key);
             }
-            for rel in blooms.files.keys() {
-                self.stats.files_probed.fetch_add(1, Relaxed);
-                if blooms.rejects(rel, needles) == Some(true) {
-                    self.stats.files_rejected.fetch_add(1, Relaxed);
-                    rejected.insert(rel.clone());
-                }
-            }
+            let hits: Vec<_> = blooms.files.iter().filter(|(_, probe)| probe.rejects(needles)).map(|(rel, _)| rel.clone()).collect();
+            self.stats.files_probed.fetch_add(blooms.files.len() as u64, Relaxed);
+            self.stats.files_rejected.fetch_add(hits.len() as u64, Relaxed);
+            rejected.extend(hits);
         }
         if !rejected.is_empty() {
             self.stats.queries_pruned.fetch_add(1, Relaxed);
@@ -245,8 +260,8 @@ impl BloomPruneRegistry {
         rejected
     }
 
-    fn spawn_load(self: &Arc<Self>, key: (String, String, String)) {
-        if self.inflight.insert(key.clone(), ()).is_some() {
+    fn spawn_load(self: &Arc<Self>, key: DateKey) {
+        if !self.inflight.insert(key.clone()) {
             return; // single-flight: a load for this key is already running
         }
         let reg = self.clone();
@@ -257,7 +272,7 @@ impl BloomPruneRegistry {
                 // NotFound is the common cold case (date not built yet):
                 // cache an empty entry so we don't re-GET per query.
                 Err(e) if matches!(e.downcast_ref::<object_store::Error>(), Some(object_store::Error::NotFound { .. })) => {
-                    reg.insert(key.clone(), DateBlooms { files: HashMap::new(), bytes: 64, loaded_at: Instant::now() });
+                    reg.insert(key.clone(), DateBlooms::from_sidecar(DateSidecar::default(), 64));
                 }
                 Err(e) => {
                     reg.stats.load_errors.fetch_add(1, Relaxed);
@@ -268,12 +283,12 @@ impl BloomPruneRegistry {
         });
     }
 
-    async fn load(&self, (table, project_id, date): &(String, String, String)) -> Result<DateBlooms> {
+    async fn load(&self, (table, project_id, date): &DateKey) -> Result<DateBlooms> {
         let bytes = self.store.get(&sidecar_path(table, project_id, date)).await?.bytes().await?;
         Ok(DateBlooms::from_sidecar(decode_sidecar(&bytes)?, bytes.len()))
     }
 
-    fn insert(&self, key: (String, String, String), entry: DateBlooms) {
+    fn insert(&self, key: DateKey, entry: DateBlooms) {
         let added = entry.bytes;
         if let Some(old) = self.entries.insert(key, Arc::new(entry)) {
             self.bytes.fetch_sub(old.bytes, Relaxed);
@@ -316,11 +331,13 @@ pub async fn build_file_blooms(store: Arc<dyn ObjectStore>, rel: &str, file_size
     let reader = ParquetObjectReader::new(store, Path::from(rel)).with_file_size(file_size);
     let mut builder = ParquetRecordBatchStreamBuilder::new(reader).await.context("parquet footer")?;
     let n_rg = builder.metadata().num_row_groups();
+    // Leaf indices are resolved up front because reading a bloom borrows the builder mutably.
     let leaves: Vec<Option<usize>> = cols.iter().map(|col| builder.parquet_schema().columns().iter().position(|c| c.path().string() == *col)).collect();
-    let mut columns = Vec::new();
+    // Imperative: each bloom is an await, and both the labeled per-column exit
+    // and the cap's early return escape a stream pipeline.
+    let mut columns = Vec::with_capacity(cols.len());
     let mut total = 0u64;
-    'col: for (col, leaf) in cols.iter().zip(leaves) {
-        let Some(leaf) = leaf else { continue };
+    'col: for (col, leaf) in cols.iter().zip(leaves).filter_map(|(col, leaf)| Some((col, leaf?))) {
         let mut blooms = Vec::with_capacity(n_rg);
         for rg in 0..n_rg {
             // A column qualifies only with a bloom in EVERY row group — a
@@ -341,10 +358,14 @@ pub async fn build_file_blooms(store: Arc<dyn ObjectStore>, rel: &str, file_size
 
 #[cfg(test)]
 mod tests {
+    use test_case::test_case;
+
     use super::*;
 
-    #[test]
-    fn sidecar_roundtrip_and_probe_semantics() {
+    /// `f1` blooms `context___trace_id` over {present-a, present-b}; `f2` is
+    /// `no_bloom`. Built through encode/decode so every case also exercises the
+    /// sidecar round trip (a serialize/parse fault would show as a false negative).
+    fn fixture() -> DateBlooms {
         let mut bloom = Sbbf::new_with_ndv_fpp(100, 0.01).unwrap();
         for v in ["present-a", "present-b"] {
             bloom.insert(v);
@@ -361,36 +382,18 @@ mod tests {
                 FileBlooms { rel: "project_id=p/date=2026-08-22/f2.parquet".into(), no_bloom: true, columns: vec![] },
             ],
         };
-        let decoded = decode_sidecar(&encode_sidecar(&sidecar).unwrap()).unwrap();
-        let blooms = DateBlooms::from_sidecar(decoded, 0);
-
-        let needle = |v: &str| vec![("context___trace_id".to_string(), vec![v.to_string()])];
-        // No false negatives through the serialize/parse round trip.
-        assert_eq!(blooms.rejects("project_id=p/date=2026-08-22/f1.parquet", &needle("present-a")), Some(false));
-        assert_eq!(blooms.rejects("project_id=p/date=2026-08-22/f1.parquet", &needle("absent-value")), Some(true));
-        // IN-list: any present value keeps the file.
-        let in_list = vec![("context___trace_id".to_string(), vec!["absent".to_string(), "present-b".to_string()])];
-        assert_eq!(blooms.rejects("project_id=p/date=2026-08-22/f1.parquet", &in_list), Some(false));
-        // no_bloom and unknown files are never rejected.
-        assert_eq!(blooms.rejects("project_id=p/date=2026-08-22/f2.parquet", &needle("absent")), Some(false));
-        assert_eq!(blooms.rejects("project_id=p/date=2026-08-22/unknown.parquet", &needle("absent")), None);
-        // A needle on a column the file has no bloom for keeps the file.
-        let other_col = vec![("id".to_string(), vec!["absent".to_string()])];
-        assert_eq!(blooms.rejects("project_id=p/date=2026-08-22/f1.parquet", &other_col), Some(false));
+        DateBlooms::from_sidecar(decode_sidecar(&encode_sidecar(&sidecar).unwrap()).unwrap(), 0)
     }
 
-    #[test]
-    fn dates_in_range_bounds() {
-        let day = 86_400_000_000i64;
-        assert_eq!(dates_in_range((0, 0)).unwrap(), vec!["1970-01-01"]);
-        assert_eq!(dates_in_range((0, 2 * day)).unwrap().len(), 3);
-        assert!(dates_in_range((0, 400 * day)).is_none(), "over-wide windows skip pruning");
-        assert!(dates_in_range((i64::MIN, 0)).is_none(), "unbounded windows skip pruning");
-    }
-
-    #[test]
-    fn rel_parse() {
-        assert_eq!(project_date_of_rel("project_id=abc/date=2026-08-22/part-0.parquet"), Some(("abc", "2026-08-22")));
-        assert_eq!(project_date_of_rel("weird/path.parquet"), None);
+    /// `None` = the file is unknown to the sidecar, i.e. included on unknown.
+    #[test_case("f1", "context___trace_id", &["present-a"] => Some(false) ; "present needle keeps the file")]
+    #[test_case("f1", "context___trace_id", &["absent-value"] => Some(true) ; "absent needle rejects the file")]
+    #[test_case("f1", "context___trace_id", &["absent", "present-b"] => Some(false) ; "IN-list: any present value keeps")]
+    #[test_case("f1", "id", &["absent"] => Some(false) ; "needle on an unbloomed column keeps")]
+    #[test_case("f2", "context___trace_id", &["absent"] => Some(false) ; "no_bloom file is never rejected")]
+    #[test_case("unknown", "context___trace_id", &["absent"] => None ; "unknown file is unknown")]
+    fn probe_semantics(file: &str, col: &str, values: &[&str]) -> Option<bool> {
+        let needles: Vec<(String, Vec<String>)> = vec![(col.to_string(), values.iter().map(|v| v.to_string()).collect())];
+        fixture().files.get(&format!("project_id=p/date=2026-08-22/{file}.parquet")).map(|probe| probe.rejects(&needles))
     }
 }

--- a/src/read/functions.rs
+++ b/src/read/functions.rs
@@ -50,7 +50,7 @@ fn as_array(v: &ColumnarValue) -> datafusion::error::Result<ArrayRef> {
     }
 }
 
-macro_rules! scalar_udf_boilerplate {
+macro_rules! udf_boilerplate {
     ($name:literal) => {
         fn name(&self) -> &str {
             $name
@@ -59,6 +59,46 @@ macro_rules! scalar_udf_boilerplate {
             &self.signature
         }
     };
+}
+
+/// Declare a UDF struct whose only state is its `Signature` (plus, optionally,
+/// its `aliases()` list), plus the `Default` that builds it — the shape every
+/// stateless `ScalarUDFImpl`/`AggregateUDFImpl` here repeats.
+macro_rules! udf_struct {
+    ($(#[$m:meta])* $ty:ident, $sig:expr) => {
+        $(#[$m])*
+        #[derive(Debug, Hash, Eq, PartialEq)]
+        struct $ty {
+            signature: Signature,
+        }
+        impl Default for $ty {
+            fn default() -> Self {
+                Self { signature: $sig }
+            }
+        }
+    };
+    ($(#[$m:meta])* $ty:ident, $sig:expr, aliases: $aliases:expr) => {
+        $(#[$m])*
+        #[derive(Debug, Hash, Eq, PartialEq)]
+        struct $ty {
+            signature: Signature,
+            aliases: Vec<String>,
+        }
+        impl Default for $ty {
+            fn default() -> Self {
+                Self { signature: $sig, aliases: $aliases }
+            }
+        }
+    };
+}
+
+/// A cast around a path/format literal cannot change what it addresses, so every
+/// literal extractor below looks through one.
+fn uncast(expr: &Expr) -> &Expr {
+    match expr {
+        Expr::Cast(cast) => cast.expr.as_ref(),
+        expr => expr,
+    }
 }
 
 /// Resolves PostgreSQL types that DataFusion does not model natively as text.
@@ -130,11 +170,11 @@ impl ExprPlanner for VariantAwareExprPlanner {
             }));
         }
 
-        let (base_expr, mut path_parts) = if path_is_array { (unalias(&expr.left), vec![]) } else { collect_arrow_chain(&expr.left) };
+        let (base_expr, prefix) = if path_is_array { (unalias(&expr.left), vec![]) } else { collect_arrow_chain(&expr.left) };
         let Some(components) = (if path_is_array { extract_path_array(&expr.right) } else { extract_path_component(&expr.right).map(|c| vec![c]) }) else {
             return Ok(PlannerResult::Original(expr));
         };
-        path_parts.extend(components);
+        let path_parts: Vec<_> = prefix.into_iter().chain(components).collect();
 
         if !is_variant_column(&base_expr, schema) {
             return Ok(PlannerResult::Original(expr)); // Let JSON planner handle
@@ -196,11 +236,7 @@ fn unalias(expr: &Expr) -> Expr {
 /// 'extract_path_array' can keep rejecting it instead of returning a path that
 /// would silently address nothing.
 fn is_empty_path_array(expr: &Expr) -> bool {
-    let expr = match expr {
-        Expr::Cast(cast) => cast.expr.as_ref(),
-        expr => expr,
-    };
-    matches!(expr, Expr::Literal(v, _) if extract_utf8_string(v).is_some_and(|raw| raw.trim() == "{}"))
+    matches!(uncast(expr), Expr::Literal(v, _) if extract_utf8_string(v).is_some_and(|raw| raw.trim() == "{}"))
 }
 
 /// Path operand of `#>`/`#>>`. Postgres spells it `text[]`, which reaches the
@@ -209,11 +245,7 @@ fn is_empty_path_array(expr: &Expr) -> bool {
 /// parsing; an empty path is rejected here and handled by the whole-document arm
 /// in the planner instead.
 fn extract_path_array(expr: &Expr) -> Option<Vec<PathComponent>> {
-    let expr = match expr {
-        Expr::Cast(cast) => cast.expr.as_ref(),
-        expr => expr,
-    };
-    let parts: Vec<PathComponent> = match expr {
+    let parts: Vec<PathComponent> = match uncast(expr) {
         Expr::Literal(v, _) => {
             let raw = extract_utf8_string(v)?;
             let inner = raw.strip_prefix('{')?.strip_suffix('}')?;
@@ -256,11 +288,7 @@ pub(super) fn extract_path_component(expr: &Expr) -> Option<PathComponent> {
     // value])". Prod 2026-08-25: 17 of those in 90 minutes, one per chart load —
     // the panel errors outright rather than rendering slowly. A cast around a
     // path literal cannot change which field is addressed, so unwrap it.
-    let expr = match expr {
-        Expr::Cast(cast) => cast.expr.as_ref(),
-        expr => expr,
-    };
-    let Expr::Literal(v, _) = expr else { return None };
+    let Expr::Literal(v, _) = uncast(expr) else { return None };
     extract_utf8_string(v).map(PathComponent::Field).or_else(|| {
         Some(PathComponent::Index(match v {
             ScalarValue::Int64(Some(i)) => *i,
@@ -285,13 +313,10 @@ fn is_variant_column(expr: &Expr, schema: &DFSchema) -> bool {
         Expr::Column(col) => {
             schema.field_from_column(col).is_ok_and(|f| is_variant_type(f.data_type()) || f.metadata().get("tf.pg_type").is_some_and(|v| v == "jsonb"))
         }
-        // Unwrap aliases
         Expr::Alias(alias) => is_variant_column(&alias.expr, schema),
-        // Check if it's a call to a variant-producing function
         Expr::ScalarFunction(func) => {
-            let name = func.func.name();
             matches!(
-                name,
+                func.func.name(),
                 "json_to_variant"
                     | "variant_get"
                     | "cast_to_variant"
@@ -347,28 +372,22 @@ fn path_repr(parts: &[PathComponent]) -> String {
         .join("->")
 }
 
-/// `json_to_pg_text(utf8) → utf8`: convert JSON-encoded text to Postgres `->>` text.
-///
-/// - JSON string `"Alice"` → `Alice` (parsed, so escape sequences resolve correctly)
-/// - JSON null → SQL NULL
-/// - JSON number / boolean → its literal text (`42`, `true`)
-/// - JSON object / array → returned as-is (Postgres `->>` does the same)
-///
-/// Bridges `parquet_variant_compute::variant_get`'s NULL-on-non-string-cast
-/// behavior to the Postgres `->>` contract.
-#[derive(Debug, PartialEq, Eq, Hash)]
-struct JsonToPgTextUdf {
-    signature: Signature,
-}
-
-impl Default for JsonToPgTextUdf {
-    fn default() -> Self {
-        Self { signature: Signature::uniform(1, vec![DataType::Utf8, DataType::Utf8View, DataType::LargeUtf8], Volatility::Immutable) }
-    }
-}
+udf_struct!(
+    /// `json_to_pg_text(utf8) → utf8`: convert JSON-encoded text to Postgres `->>` text.
+    ///
+    /// - JSON string `"Alice"` → `Alice` (parsed, so escape sequences resolve correctly)
+    /// - JSON null → SQL NULL
+    /// - JSON number / boolean → its literal text (`42`, `true`)
+    /// - JSON object / array → returned as-is (Postgres `->>` does the same)
+    ///
+    /// Bridges `parquet_variant_compute::variant_get`'s NULL-on-non-string-cast
+    /// behavior to the Postgres `->>` contract.
+    JsonToPgTextUdf,
+    Signature::uniform(1, vec![DataType::Utf8, DataType::Utf8View, DataType::LargeUtf8], Volatility::Immutable)
+);
 
 impl ScalarUDFImpl for JsonToPgTextUdf {
-    scalar_udf_boilerplate!("json_to_pg_text");
+    udf_boilerplate!("json_to_pg_text");
     fn return_type(&self, _arg_types: &[DataType]) -> datafusion::error::Result<DataType> {
         Ok(DataType::Utf8)
     }
@@ -524,13 +543,13 @@ pub fn register_custom_functions(ctx: &mut datafusion::execution::context::Sessi
     reg_from!(
         ctx,
         crate::read::optimizers::PgCoalesceUdf::default(),
-        ToCharUDF::new(),
-        AtTimeZoneUDF::new(),
-        JsonBuildArrayUDF::new(),
-        JsonbBuildArrayUDF::new(),
-        ToJsonbUDF::new(),
-        ToJsonUDF::new(),
-        ExtractEpochUDF::new(),
+        ToCharUDF::default(),
+        AtTimeZoneUDF::default(),
+        JsonBuildArrayUDF::default(),
+        JsonbBuildArrayUDF::default(),
+        ToJsonbUDF::default(),
+        ToJsonUDF::default(),
+        ExtractEpochUDF::default(),
         JsonToPgTextUdf::default(),
         datafusion_variant::JsonToVariantUdf::default(),
         VariantToJsonExtUdf::default(),
@@ -542,18 +561,26 @@ pub fn register_custom_functions(ctx: &mut datafusion::execution::context::Sessi
         datafusion_variant::VariantListInsert::default(),
         datafusion_variant::VariantObjectConstruct::default(),
         datafusion_variant::VariantObjectInsert::default(),
-        JsonbPathExistsUDF::new(),
-        JsonbPathQueryFirstUDF::new(),
-        ApproxPercentileUDF::new(),
+        JsonbPathExistsUDF::default(),
+        JsonbPathQueryFirstUDF::default(),
+        ApproxPercentileUDF::default(),
     );
 
     // create_udf-based UDFs that carry construction logic.
     ctx.register_udf(create_jsonb_array_elements_udf());
-    ctx.register_udf(ScalarUDF::from(TimeBucketUDF::new()));
-    ctx.register_udaf(create_percentile_agg_udaf());
-    ctx.register_udaf(create_tdigest_merge_udaf());
+    ctx.register_udf(ScalarUDF::from(TimeBucketUDF::default()));
+    ctx.register_udaf(binary_state_udaf("percentile_agg", DataType::Float64, Arc::new(|_| Ok(Box::<PercentileAccumulator>::default()))));
+    ctx.register_udaf(binary_state_udaf(
+        "tdigest_merge",
+        DataType::Binary,
+        Arc::new(|_| Ok(Box::new(PercentileAccumulator { merging: true, ..Default::default() }) as Box<dyn Accumulator>)),
+    ));
     ctx.register_udaf(AggregateUDF::from(HllAggUDF::default()));
-    ctx.register_udaf(create_hll_merge_udaf());
+    ctx.register_udaf(binary_state_udaf(
+        "hll_merge",
+        DataType::Binary,
+        Arc::new(|_| Ok(Box::new(HllAccumulator { merging: true, ..Default::default() }) as Box<dyn Accumulator>)),
+    ));
     ctx.register_udf(create_hll_count_udf());
     ctx.register_udf(hash_bucket_udf());
 
@@ -634,19 +661,10 @@ fn create_now_micros_udf() -> ScalarUDF {
     create_udf("timefusion_now_micros", vec![], DataType::Int64, Volatility::Volatile, fun)
 }
 
-#[derive(Debug, Hash, Eq, PartialEq)]
-struct ToCharUDF {
-    signature: Signature,
-}
-
-impl ToCharUDF {
-    fn new() -> Self {
-        Self { signature: Signature::any(2, Volatility::Immutable) }
-    }
-}
+udf_struct!(ToCharUDF, Signature::any(2, Volatility::Immutable));
 
 impl ScalarUDFImpl for ToCharUDF {
-    scalar_udf_boilerplate!("to_char");
+    udf_boilerplate!("to_char");
 
     fn return_type(&self, _arg_types: &[DataType]) -> datafusion::error::Result<DataType> {
         Ok(DataType::Utf8View)
@@ -874,19 +892,10 @@ fn parse_pg_format(pg_format: &str) -> Vec<FmtPart> {
     parts
 }
 
-#[derive(Debug, Hash, Eq, PartialEq)]
-struct AtTimeZoneUDF {
-    signature: Signature,
-}
-
-impl AtTimeZoneUDF {
-    fn new() -> Self {
-        Self { signature: Signature::any(2, Volatility::Immutable) }
-    }
-}
+udf_struct!(AtTimeZoneUDF, Signature::any(2, Volatility::Immutable));
 
 impl ScalarUDFImpl for AtTimeZoneUDF {
-    scalar_udf_boilerplate!("at_time_zone");
+    udf_boilerplate!("at_time_zone");
 
     fn return_type(&self, arg_types: &[DataType]) -> datafusion::error::Result<DataType> {
         match &arg_types[0] {
@@ -926,19 +935,10 @@ fn create_jsonb_array_elements_udf() -> ScalarUDF {
     create_udf("jsonb_array_elements", vec![DataType::Utf8View], DataType::Utf8View, Volatility::Immutable, stub)
 }
 
-#[derive(Debug, Hash, Eq, PartialEq)]
-struct JsonBuildArrayUDF {
-    signature: Signature,
-}
-
-impl JsonBuildArrayUDF {
-    fn new() -> Self {
-        Self { signature: Signature::variadic_any(Volatility::Immutable) }
-    }
-}
+udf_struct!(JsonBuildArrayUDF, Signature::variadic_any(Volatility::Immutable));
 
 impl ScalarUDFImpl for JsonBuildArrayUDF {
-    scalar_udf_boilerplate!("json_build_array");
+    udf_boilerplate!("json_build_array");
 
     fn return_type(&self, _arg_types: &[DataType]) -> datafusion::error::Result<DataType> {
         Ok(DataType::Utf8View)
@@ -968,22 +968,16 @@ impl ScalarUDFImpl for JsonBuildArrayUDF {
     }
 }
 
-#[derive(Debug, Hash, Eq, PartialEq)]
-struct ToJsonUDF {
-    signature: Signature,
-    aliases: Vec<String>,
-}
-
-impl ToJsonUDF {
-    fn new() -> Self {
-        // PG's `row_to_json(record)` is `to_json` over a row. pgAdmin's
-        // dashboard polls `row_to_json(t)` over a subquery alias every 5s.
-        Self { signature: Signature::any(1, Volatility::Immutable), aliases: vec!["row_to_json".to_string()] }
-    }
-}
+udf_struct!(
+    /// PG's `row_to_json(record)` is `to_json` over a row. pgAdmin's
+    /// dashboard polls `row_to_json(t)` over a subquery alias every 5s.
+    ToJsonUDF,
+    Signature::any(1, Volatility::Immutable),
+    aliases: vec!["row_to_json".to_string()]
+);
 
 impl ScalarUDFImpl for ToJsonUDF {
-    scalar_udf_boilerplate!("to_json");
+    udf_boilerplate!("to_json");
 
     fn aliases(&self) -> &[String] {
         &self.aliases
@@ -1012,14 +1006,9 @@ fn jsonb_tagged_field() -> FieldRef {
 
 macro_rules! jsonb_wrapper {
     ($wrap:ident, $inner:ident, $pg_name:expr) => {
-        #[derive(Debug, Hash, Eq, PartialEq)]
+        #[derive(Debug, Hash, Eq, PartialEq, Default)]
         struct $wrap {
             inner: $inner,
-        }
-        impl $wrap {
-            fn new() -> Self {
-                Self { inner: $inner::new() }
-            }
         }
         impl ScalarUDFImpl for $wrap {
             fn name(&self) -> &str {
@@ -1043,19 +1032,10 @@ macro_rules! jsonb_wrapper {
 jsonb_wrapper!(JsonbBuildArrayUDF, JsonBuildArrayUDF, "jsonb_build_array");
 jsonb_wrapper!(ToJsonbUDF, ToJsonUDF, "to_jsonb");
 
-#[derive(Debug, Hash, Eq, PartialEq)]
-struct ExtractEpochUDF {
-    signature: Signature,
-}
-
-impl ExtractEpochUDF {
-    fn new() -> Self {
-        Self { signature: Signature::any(1, Volatility::Immutable) }
-    }
-}
+udf_struct!(ExtractEpochUDF, Signature::any(1, Volatility::Immutable));
 
 impl ScalarUDFImpl for ExtractEpochUDF {
-    scalar_udf_boilerplate!("extract_epoch");
+    udf_boilerplate!("extract_epoch");
 
     fn return_type(&self, _arg_types: &[DataType]) -> datafusion::error::Result<DataType> {
         Ok(DataType::Float64)
@@ -1117,9 +1097,6 @@ fn array_to_json_values_inner(array: &ArrayRef, sniff_json: bool) -> datafusion:
                 .as_any()
                 .downcast_ref::<StringViewArray>()
                 .ok_or_else(|| DataFusionError::Execution("Failed to downcast to StringViewArray".to_string()))?;
-            // Sniff JSON only at the top level: Variant/Utf8 columns holding JSON
-            // (attributes, events) must surface as real JSON. Inside List(Utf8)
-            // (e.g. summary text[]) PG keeps elements as JSON *strings*.
             let looks_json = |s: &str| (s.starts_with('{') && s.ends_with('}')) || (s.starts_with('[') && s.ends_with(']'));
             strs.iter()
                 .map(|v| match v {
@@ -1196,34 +1173,25 @@ fn list_to_json_values<O: datafusion::arrow::array::OffsetSizeTrait>(array: &Arr
         .collect()
 }
 
-/// TimescaleDB's `time_bucket`, and deliberately BOTH of its spellings for the
-/// bucket width: our own KQL emits a string (`time_bucket('5 minutes', ts)`),
-/// but real Timescale SQL — which is what a hand-written widget or a migrated
-/// dashboard contains — passes an INTERVAL. Accepting only the string form gave
-/// "Failed to coerce arguments … time_bucket(Interval(MonthDayNano),
-/// Timestamp)" and lost the whole query (issue 3812a29a, 2026-08-28).
-#[derive(Debug, Hash, Eq, PartialEq)]
-struct TimeBucketUDF {
-    signature: Signature,
-}
-
-impl TimeBucketUDF {
-    fn new() -> Self {
+udf_struct!(
+    /// TimescaleDB's `time_bucket`, and deliberately BOTH of its spellings for the
+    /// bucket width: our own KQL emits a string (`time_bucket('5 minutes', ts)`),
+    /// but real Timescale SQL — which is what a hand-written widget or a migrated
+    /// dashboard contains — passes an INTERVAL. Accepting only the string form gave
+    /// "Failed to coerce arguments … time_bucket(Interval(MonthDayNano),
+    /// Timestamp)" and lost the whole query (issue 3812a29a, 2026-08-28).
+    TimeBucketUDF,
+    {
         let ts = DataType::Timestamp(TimeUnit::Microsecond, Some(Arc::from("UTC")));
-        Self {
-            signature: Signature::one_of(
-                vec![
-                    TypeSignature::Exact(vec![DataType::Utf8View, ts.clone()]),
-                    TypeSignature::Exact(vec![DataType::Interval(IntervalUnit::MonthDayNano), ts]),
-                ],
-                Volatility::Immutable,
-            ),
-        }
+        Signature::one_of(
+            vec![TypeSignature::Exact(vec![DataType::Utf8View, ts.clone()]), TypeSignature::Exact(vec![DataType::Interval(IntervalUnit::MonthDayNano), ts])],
+            Volatility::Immutable,
+        )
     }
-}
+);
 
 impl ScalarUDFImpl for TimeBucketUDF {
-    scalar_udf_boilerplate!("time_bucket");
+    udf_boilerplate!("time_bucket");
 
     fn output_ordering(&self, inputs: &[ExprProperties]) -> datafusion::error::Result<SortProperties> {
         // Like date_bin, a constant positive width preserves timestamp ordering.
@@ -1309,27 +1277,10 @@ fn bucket_timestamps(timestamp_array: &ArrayRef, bucket_size_micros: i64) -> dat
     })
 }
 
-/// Create the percentile_agg UDAF for building t-digest summaries
-fn create_percentile_agg_udaf() -> AggregateUDF {
-    create_udaf(
-        "percentile_agg",
-        vec![DataType::Float64],
-        Arc::new(DataType::Binary),
-        Volatility::Immutable,
-        Arc::new(|_| Ok(Box::<PercentileAccumulator>::default())),
-        Arc::new(vec![DataType::Binary]),
-    )
-}
-
-fn create_tdigest_merge_udaf() -> AggregateUDF {
-    create_udaf(
-        "tdigest_merge",
-        vec![DataType::Binary],
-        Arc::new(DataType::Binary),
-        Volatility::Immutable,
-        Arc::new(|_| Ok(Box::<TDigestMergeAccumulator>::default())),
-        Arc::new(vec![DataType::Binary]),
-    )
+/// A UDAF whose partial state is exactly its output: one serialized Binary
+/// sketch/digest. Every sketch aggregate here has that shape.
+fn binary_state_udaf(name: &str, input: DataType, factory: datafusion::logical_expr::function::AccumulatorFactoryFunction) -> AggregateUDF {
+    create_udaf(name, vec![input], Arc::new(DataType::Binary), Volatility::Immutable, factory, Arc::new(vec![DataType::Binary]))
 }
 
 const TDIGEST_MAX_CENTROIDS: usize = 200;
@@ -1408,19 +1359,29 @@ fn merge_tdigest_batch(digest: &mut TDigestWrapper, arrays: &[ArrayRef]) -> data
     })
 }
 
-/// Accumulator for percentile_agg that builds a t-digest
+/// Shared by both t-digest UDAFs: they differ only in what `update_batch` feeds
+/// in — `percentile_agg` digests raw Float64 values, `tdigest_merge` folds
+/// already-serialized digests.
 #[derive(Debug, Default)]
 struct PercentileAccumulator {
     digest: TDigestWrapper,
+    merging: bool,
 }
 
 impl Accumulator for PercentileAccumulator {
     fn update_batch(&mut self, values: &[ArrayRef]) -> datafusion::error::Result<()> {
-        let Some(array) = values.first() else { return Ok(()) };
-        let floats =
-            array.as_any().downcast_ref::<Float64Array>().ok_or_else(|| DataFusionError::Execution("percentile_agg expects Float64 values".to_string()))?;
-        self.digest.insert_batch(floats.iter().flatten());
-        Ok(())
+        match values.first() {
+            Some(array) if !self.merging => {
+                let floats = array
+                    .as_any()
+                    .downcast_ref::<Float64Array>()
+                    .ok_or_else(|| DataFusionError::Execution("percentile_agg expects Float64 values".to_string()))?;
+                self.digest.insert_batch(floats.iter().flatten());
+                Ok(())
+            }
+            Some(_) => merge_tdigest_batch(&mut self.digest, values),
+            None => Ok(()),
+        }
     }
 
     fn evaluate(&mut self) -> datafusion::error::Result<ScalarValue> {
@@ -1440,47 +1401,14 @@ impl Accumulator for PercentileAccumulator {
     }
 }
 
-#[derive(Debug, Default)]
-struct TDigestMergeAccumulator {
-    digest: TDigestWrapper,
-}
-
-impl Accumulator for TDigestMergeAccumulator {
-    fn update_batch(&mut self, values: &[ArrayRef]) -> datafusion::error::Result<()> {
-        merge_tdigest_batch(&mut self.digest, values)
-    }
-
-    fn evaluate(&mut self) -> datafusion::error::Result<ScalarValue> {
-        Ok(ScalarValue::Binary(Some(self.digest.to_bytes()?)))
-    }
-
-    fn size(&self) -> usize {
-        self.digest.size()
-    }
-
-    fn state(&mut self) -> datafusion::error::Result<Vec<ScalarValue>> {
-        self.evaluate().map(|value| vec![value])
-    }
-
-    fn merge_batch(&mut self, states: &[ArrayRef]) -> datafusion::error::Result<()> {
-        merge_tdigest_batch(&mut self.digest, states)
-    }
-}
-
-/// UDF implementation for approx_percentile: extracts a percentile from a t-digest.
-#[derive(Debug, Hash, Eq, PartialEq)]
-struct ApproxPercentileUDF {
-    signature: Signature,
-}
-
-impl ApproxPercentileUDF {
-    fn new() -> Self {
-        Self { signature: Signature::new(TypeSignature::Exact(vec![DataType::Float64, DataType::Binary]), Volatility::Immutable) }
-    }
-}
+udf_struct!(
+    /// `approx_percentile(pct, digest)`: extracts a percentile from a t-digest.
+    ApproxPercentileUDF,
+    Signature::new(TypeSignature::Exact(vec![DataType::Float64, DataType::Binary]), Volatility::Immutable)
+);
 
 impl ScalarUDFImpl for ApproxPercentileUDF {
-    scalar_udf_boilerplate!("approx_percentile");
+    udf_boilerplate!("approx_percentile");
 
     fn return_type(&self, _arg_types: &[DataType]) -> datafusion::error::Result<DataType> {
         Ok(DataType::Float64)
@@ -1610,47 +1538,35 @@ impl Accumulator for HllAccumulator {
     }
 }
 
-/// `hll_agg(any) -> Binary`, also spelled `approx_count_distinct`.
-///
-/// Both names are Timescale Toolkit's: there, `approx_count_distinct(x)` builds
-/// a `hyperloglog` and `distinct_count(sketch)` reads the number out of it. TF
-/// mirrors that split exactly, so monoscope emits ONE
-/// `distinct_count(approx_count_distinct(x))` for both backends — the same trick
-/// `percentile_agg`/`approx_percentile` already play for percentiles. (Getting
-/// this wrong is easy: Toolkit's `approx_count_distinct` returns a SKETCH, not a
-/// count, and `approx_count_distinct(x)::float` is a type error there.)
-///
-/// The split is also what makes the rollup work: the aggregate's output IS the
-/// storable state, so a measure holds it and the scalar reads it back at query
-/// time.
-///
-/// A hand-written `AggregateUDFImpl` rather than `create_udaf` because the
-/// argument is deliberately untyped: a distinct count is meaningful over every
-/// column type, and an `Exact` signature would make `hll_agg(duration)` a
-/// planning error instead of a cast.
-#[derive(Debug, Hash, Eq, PartialEq)]
-struct HllAggUDF {
-    signature: Signature,
-    aliases: Vec<String>,
-}
-
-impl Default for HllAggUDF {
-    fn default() -> Self {
-        Self { signature: Signature::any(1, Volatility::Immutable), aliases: vec!["approx_count_distinct".to_string()] }
-    }
-}
+udf_struct!(
+    /// `hll_agg(any) -> Binary`, also spelled `approx_count_distinct`.
+    ///
+    /// Both names are Timescale Toolkit's: there, `approx_count_distinct(x)` builds
+    /// a `hyperloglog` and `distinct_count(sketch)` reads the number out of it. TF
+    /// mirrors that split exactly, so monoscope emits ONE
+    /// `distinct_count(approx_count_distinct(x))` for both backends — the same trick
+    /// `percentile_agg`/`approx_percentile` already play for percentiles. (Getting
+    /// this wrong is easy: Toolkit's `approx_count_distinct` returns a SKETCH, not a
+    /// count, and `approx_count_distinct(x)::float` is a type error there.)
+    ///
+    /// The split is also what makes the rollup work: the aggregate's output IS the
+    /// storable state, so a measure holds it and the scalar reads it back at query
+    /// time.
+    ///
+    /// A hand-written `AggregateUDFImpl` rather than `create_udaf` because the
+    /// argument is deliberately untyped: a distinct count is meaningful over every
+    /// column type, and an `Exact` signature would make `hll_agg(duration)` a
+    /// planning error instead of a cast.
+    HllAggUDF,
+    Signature::any(1, Volatility::Immutable),
+    aliases: vec!["approx_count_distinct".to_string()]
+);
 
 impl datafusion::logical_expr::AggregateUDFImpl for HllAggUDF {
-    fn name(&self) -> &str {
-        "hll_agg"
-    }
+    udf_boilerplate!("hll_agg");
 
     fn aliases(&self) -> &[String] {
         &self.aliases
-    }
-
-    fn signature(&self) -> &Signature {
-        &self.signature
     }
 
     fn return_type(&self, _arg_types: &[DataType]) -> datafusion::error::Result<DataType> {
@@ -1664,17 +1580,6 @@ impl datafusion::logical_expr::AggregateUDFImpl for HllAggUDF {
     fn accumulator(&self, _acc_args: datafusion::logical_expr::function::AccumulatorArgs) -> datafusion::error::Result<Box<dyn Accumulator>> {
         Ok(Box::new(HllAccumulator::default()))
     }
-}
-
-fn create_hll_merge_udaf() -> AggregateUDF {
-    create_udaf(
-        "hll_merge",
-        vec![DataType::Binary],
-        Arc::new(DataType::Binary),
-        Volatility::Immutable,
-        Arc::new(|_| Ok(Box::new(HllAccumulator { merging: true, ..Default::default() }) as Box<dyn Accumulator>)),
-        Arc::new(vec![DataType::Binary]),
-    )
 }
 
 /// `hll_count(Binary) -> Int64`, also spelled `distinct_count`. Int64 because
@@ -1726,14 +1631,15 @@ pub fn hash_bucket_udf() -> ScalarUDF {
             let [value, buckets] = args else {
                 return Err(DataFusionError::Execution("hash_bucket requires exactly 2 arguments: value and bucket count".to_string()));
             };
-            let buckets = match buckets {
-                ColumnarValue::Scalar(scalar) => i64::try_from(scalar.clone()).unwrap_or(0),
-                _ => return Err(DataFusionError::Execution("hash_bucket's bucket count must be a literal".to_string())),
+            let ColumnarValue::Scalar(count) = buckets else {
+                return Err(DataFusionError::Execution("hash_bucket's bucket count must be a literal".to_string()));
             };
-            let buckets = u64::try_from(buckets).ok().filter(|n| *n > 0).ok_or_else(|| {
-                // A zero count would divide by zero; a negative one is a caller bug.
-                DataFusionError::Execution("hash_bucket's bucket count must be positive".to_string())
-            })?;
+            // A zero count would divide by zero; a negative one is a caller bug.
+            let buckets = i64::try_from(count.clone())
+                .ok()
+                .and_then(|n| u64::try_from(n).ok())
+                .filter(|n| *n > 0)
+                .ok_or_else(|| DataFusionError::Execution("hash_bucket's bucket count must be positive".to_string()))?;
             let array = as_array(value)?;
             let strings = array
                 .as_any()
@@ -1900,37 +1806,18 @@ mod hll_tests {
 // jsonb_path_exists UDF for JSONPath queries on Variant/JSON columns
 // ============================================================================
 
-#[derive(Debug, Hash, Eq, PartialEq)]
-struct JsonbPathExistsUDF {
-    signature: Signature,
-}
-
-impl JsonbPathExistsUDF {
-    fn new() -> Self {
-        Self {
-            // Accept Variant struct or JSON string as first arg, path string as second
-            signature: Signature::any(2, Volatility::Immutable),
-        }
-    }
-}
+// Accept a Variant struct or a JSON string as first arg, a path string as second.
+udf_struct!(JsonbPathExistsUDF, Signature::any(2, Volatility::Immutable));
 
 impl ScalarUDFImpl for JsonbPathExistsUDF {
-    scalar_udf_boilerplate!("jsonb_path_exists");
+    udf_boilerplate!("jsonb_path_exists");
 
     fn return_type(&self, _arg_types: &[DataType]) -> datafusion::error::Result<DataType> {
         Ok(DataType::Boolean)
     }
 
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> datafusion::error::Result<ColumnarValue> {
-        let [json, path] = args.args.as_slice() else {
-            return Err(DataFusionError::Execution("jsonb_path_exists requires exactly 2 arguments: json/variant and jsonpath".to_string()));
-        };
-        let json_array = as_array(json)?;
-        let path_str = match path {
-            ColumnarValue::Scalar(scalar) => extract_utf8_string(scalar).ok_or_else(|| DataFusionError::Execution("JSONPath must be a string".to_string()))?,
-            ColumnarValue::Array(_) => return Err(DataFusionError::Execution("JSONPath must be a scalar string".to_string())),
-        };
-
+        let (json_array, path_str) = json_path_args(&args.args, "jsonb_path_exists")?;
         // PG SQL/JSON-path dialect.
         let json_path = sql_json_path::JsonPath::new(&path_str).map_err(|e| DataFusionError::Execution(format!("Invalid JSONPath: {e}")))?;
         let result = if is_variant_type(json_array.data_type()) {
@@ -1940,6 +1827,19 @@ impl ScalarUDFImpl for JsonbPathExistsUDF {
         };
         Ok(ColumnarValue::Array(result))
     }
+}
+
+/// `(json_array, jsonpath_text)` for the two `jsonb_path_*` UDFs: the path is a
+/// scalar because it compiles once per invocation, not once per row.
+fn json_path_args(args: &[ColumnarValue], name: &str) -> datafusion::error::Result<(ArrayRef, String)> {
+    let [json, path] = args else {
+        return Err(DataFusionError::Execution(format!("{name} requires exactly 2 arguments: json/variant and jsonpath")));
+    };
+    let ColumnarValue::Scalar(scalar) = path else {
+        return Err(DataFusionError::Execution("JSONPath must be a scalar string".to_string()));
+    };
+    let path_str = extract_utf8_string(scalar).ok_or_else(|| DataFusionError::Execution("JSONPath must be a string".to_string()))?;
+    Ok((as_array(json)?, path_str))
 }
 
 const MAX_VARIANT_DEPTH: usize = 100;
@@ -2048,25 +1948,28 @@ fn evaluate_jsonpath_on_variant(array: &ArrayRef, json_path: &sql_json_path::Jso
     // little for the dominant `$[*] ? (@ == x)` shape: the `[*]` prefix needs
     // the whole (small) column anyway, so only a JsonValue alloc is saved.
     // Revisit if a profile shows this materialization is a real hot spot.
-    use datafusion::arrow::array::StructArray;
-    use parquet_variant::Variant;
-    let struct_array = array.as_any().downcast_ref::<StructArray>().ok_or_else(|| DataFusionError::Execution("Expected Variant struct array".to_string()))?;
-    let metadata_col = struct_array.column_by_name("metadata").ok_or_else(|| DataFusionError::Execution("Variant missing metadata column".to_string()))?;
-    let value_col = struct_array.column_by_name("value").ok_or_else(|| DataFusionError::Execution("Variant missing value column".to_string()))?;
-    let metadata_binary = BinaryAccessor::try_new(metadata_col, "metadata")?;
-    let value_binary = BinaryAccessor::try_new(value_col, "value")?;
+    //
     // Lax mode (PG default): a data-dependent eval error is an empty match, not a query failure.
-    let out: BooleanArray = (0..struct_array.len())
-        .map(|i| {
-            if struct_array.is_null(i) {
-                Ok(None)
-            } else {
-                variant_to_serde_json(&Variant::new(metadata_binary.value(i), value_binary.value(i)), 0)
-                    .map(|json| Some(json_path.exists(&json).unwrap_or(false)))
-            }
-        })
-        .collect::<datafusion::error::Result<_>>()?;
+    let out: BooleanArray = map_variant_rows(array, |json| Some(json_path.exists(json).unwrap_or(false)))?;
     Ok(Arc::new(out))
+}
+
+/// Decode each row of a Variant struct array into a `JsonValue` and map it
+/// through `f`; NULL rows stay NULL without being decoded.
+fn map_variant_rows<T, A: FromIterator<Option<T>>>(array: &ArrayRef, f: impl Fn(&JsonValue) -> Option<T>) -> datafusion::error::Result<A> {
+    use datafusion::arrow::array::StructArray;
+    let struct_array = array.as_any().downcast_ref::<StructArray>().ok_or_else(|| DataFusionError::Execution("Expected Variant struct array".to_string()))?;
+    let missing = |name: &str| DataFusionError::Execution(format!("Variant missing {name} column"));
+    let metadata_binary = BinaryAccessor::try_new(struct_array.column_by_name("metadata").ok_or_else(|| missing("metadata"))?, "metadata")?;
+    let value_binary = BinaryAccessor::try_new(struct_array.column_by_name("value").ok_or_else(|| missing("value"))?, "value")?;
+    (0..struct_array.len())
+        .map(|i| {
+            (!struct_array.is_null(i))
+                .then(|| variant_to_serde_json(&parquet_variant::Variant::new(metadata_binary.value(i), value_binary.value(i)), 0).map(|json| f(&json)))
+                .transpose()
+                .map(Option::flatten)
+        })
+        .collect()
 }
 
 /// Convert a simple JSONPath (`$.a.b[0].c`) to a `parquet_variant::VariantPath`.
@@ -2117,7 +2020,6 @@ fn simple_path_to_variant_path(raw: &str) -> Option<parquet_variant::VariantPath
     Some(VariantPath::new(elements))
 }
 
-/// Evaluate JSONPath on a JSON string array
 // ============================================================================
 // jsonb_path_query_first: the matched VALUE, where jsonb_path_exists returns
 // only whether one existed.
@@ -2129,19 +2031,10 @@ fn simple_path_to_variant_path(raw: &str) -> Option<parquet_variant::VariantPath
 // RUM dashboard widgets — failed to plan with "Invalid function".
 // ============================================================================
 
-#[derive(Debug, Hash, Eq, PartialEq)]
-struct JsonbPathQueryFirstUDF {
-    signature: Signature,
-}
-
-impl JsonbPathQueryFirstUDF {
-    fn new() -> Self {
-        Self { signature: Signature::any(2, Volatility::Immutable) }
-    }
-}
+udf_struct!(JsonbPathQueryFirstUDF, Signature::any(2, Volatility::Immutable));
 
 impl ScalarUDFImpl for JsonbPathQueryFirstUDF {
-    scalar_udf_boilerplate!("jsonb_path_query_first");
+    udf_boilerplate!("jsonb_path_query_first");
 
     fn return_type(&self, _arg_types: &[DataType]) -> datafusion::error::Result<DataType> {
         Ok(DataType::Utf8View)
@@ -2154,14 +2047,7 @@ impl ScalarUDFImpl for JsonbPathQueryFirstUDF {
     }
 
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> datafusion::error::Result<ColumnarValue> {
-        let [json, path] = args.args.as_slice() else {
-            return Err(DataFusionError::Execution("jsonb_path_query_first requires exactly 2 arguments: json/variant and jsonpath".to_string()));
-        };
-        let json_array = as_array(json)?;
-        let path_str = match path {
-            ColumnarValue::Scalar(scalar) => extract_utf8_string(scalar).ok_or_else(|| DataFusionError::Execution("JSONPath must be a string".to_string()))?,
-            ColumnarValue::Array(_) => return Err(DataFusionError::Execution("JSONPath must be a scalar string".to_string())),
-        };
+        let (json_array, path_str) = json_path_args(&args.args, "jsonb_path_query_first")?;
         let json_path = sql_json_path::JsonPath::new(&path_str).map_err(|e| DataFusionError::Execution(format!("Invalid JSONPath: {e}")))?;
         let result = if is_variant_type(json_array.data_type()) {
             query_first_on_variant(&json_array, &json_path)?
@@ -2178,50 +2064,36 @@ impl ScalarUDFImpl for JsonbPathQueryFirstUDF {
 /// exists to serve — and writing one would duplicate the strict/lax hazard
 /// documented on `evaluate_jsonpath_on_variant`.
 fn query_first_on_variant(array: &ArrayRef, json_path: &sql_json_path::JsonPath) -> datafusion::error::Result<ArrayRef> {
-    use datafusion::arrow::array::StructArray;
-    use parquet_variant::Variant;
-    let struct_array = array.as_any().downcast_ref::<StructArray>().ok_or_else(|| DataFusionError::Execution("Expected Variant struct array".to_string()))?;
-    let metadata_col = struct_array.column_by_name("metadata").ok_or_else(|| DataFusionError::Execution("Variant missing metadata column".to_string()))?;
-    let value_col = struct_array.column_by_name("value").ok_or_else(|| DataFusionError::Execution("Variant missing value column".to_string()))?;
-    let metadata_binary = BinaryAccessor::try_new(metadata_col, "metadata")?;
-    let value_binary = BinaryAccessor::try_new(value_col, "value")?;
     // Lax mode (PG default): a data-dependent eval error is no match, not a query failure.
-    let out: StringViewArray = (0..struct_array.len())
-        .map(|i| {
-            if struct_array.is_null(i) {
-                Ok(None)
-            } else {
-                variant_to_serde_json(&Variant::new(metadata_binary.value(i), value_binary.value(i)), 0)
-                    .map(|json| json_path.query_first(&json).ok().flatten().map(|found| found.to_string()))
-            }
-        })
-        .collect::<datafusion::error::Result<_>>()?;
+    let out: StringViewArray = map_variant_rows(array, |json| json_path.query_first(json).ok().flatten().map(|found| found.to_string()))?;
     Ok(Arc::new(out))
 }
 
 fn query_first_on_json_string(array: &ArrayRef, json_path: &sql_json_path::JsonPath) -> datafusion::error::Result<ArrayRef> {
-    let eval = |s: &str| serde_json::from_str::<JsonValue>(s).ok().and_then(|v| json_path.query_first(&v).ok().flatten().map(|found| found.to_string()));
-    let iter: Box<dyn Iterator<Item = Option<&str>>> = if let Some(a) = array.as_any().downcast_ref::<StringViewArray>() {
-        Box::new(a.iter())
-    } else if let Some(a) = array.as_any().downcast_ref::<StringArray>() {
-        Box::new(a.iter())
-    } else {
-        return Err(DataFusionError::Execution("jsonb_path_query_first requires JSON string or Variant input".to_string()));
-    };
-    Ok(Arc::new(iter.map(|opt| opt.and_then(eval)).collect::<StringViewArray>()))
+    let out: StringViewArray = map_utf8_rows(array, "jsonb_path_query_first", |s| {
+        serde_json::from_str::<JsonValue>(s).ok().and_then(|v| json_path.query_first(&v).ok().flatten().map(|found| found.to_string()))
+    })?;
+    Ok(Arc::new(out))
 }
 
 fn evaluate_jsonpath_on_json_string(array: &ArrayRef, json_path: &sql_json_path::JsonPath) -> datafusion::error::Result<ArrayRef> {
     // Path exists per row; invalid JSON or a lax-mode eval error → false (PG parity).
-    let eval = |s: &str| serde_json::from_str::<JsonValue>(s).ok().and_then(|v| json_path.exists(&v).ok()).unwrap_or(false);
+    let out: BooleanArray = map_utf8_rows(array, "jsonb_path_exists", |s| {
+        Some(serde_json::from_str::<JsonValue>(s).ok().and_then(|v| json_path.exists(&v).ok()).unwrap_or(false))
+    })?;
+    Ok(Arc::new(out))
+}
+
+/// Map each non-NULL row of a Utf8/Utf8View array through `f`, keeping NULLs.
+fn map_utf8_rows<T, A: FromIterator<Option<T>>>(array: &ArrayRef, label: &str, f: impl Fn(&str) -> Option<T>) -> datafusion::error::Result<A> {
     let iter: Box<dyn Iterator<Item = Option<&str>>> = if let Some(a) = array.as_any().downcast_ref::<StringViewArray>() {
         Box::new(a.iter())
     } else if let Some(a) = array.as_any().downcast_ref::<StringArray>() {
         Box::new(a.iter())
     } else {
-        return Err(DataFusionError::Execution("jsonb_path_exists requires JSON string or Variant input".to_string()));
+        return Err(DataFusionError::Execution(format!("{label} requires JSON string or Variant input")));
     };
-    Ok(Arc::new(iter.map(|opt| opt.map(eval)).collect::<BooleanArray>()))
+    Ok(iter.map(|opt| opt.and_then(&f)).collect())
 }
 
 #[cfg(test)]
@@ -2460,7 +2332,7 @@ mod tests {
             config_options: Arc::new(datafusion::config::ConfigOptions::default()),
         };
         let start = std::time::Instant::now();
-        let ColumnarValue::Array(out) = JsonBuildArrayUDF::new().invoke_with_args(args).unwrap() else { panic!("expected array output") };
+        let ColumnarValue::Array(out) = JsonBuildArrayUDF::default().invoke_with_args(args).unwrap() else { panic!("expected array output") };
         assert!(start.elapsed() < std::time::Duration::from_secs(2), "quadratic regression: took {:?}", start.elapsed());
         let out = out.as_any().downcast_ref::<datafusion::arrow::array::StringViewArray>().unwrap();
         assert_eq!(out.len(), n);

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -81,31 +81,32 @@ struct Bound {
 }
 
 impl Bound {
-    /// Counts ordering violations for a specific union leg.
-    fn advance_counting(&mut self, t: i64, leg: LegKind) {
-        if let Some(l) = self.last
-            && if self.desc { t > l } else { t < l }
-        {
-            leg.counter().fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        }
-        if self.last.is_none_or(|l| if self.desc { t < l } else { t > l }) {
-            self.last = Some(t);
-        }
+    /// Is `a` strictly further along the declared direction than `b`?
+    const fn ahead(&self, a: i64, b: i64) -> bool {
+        if self.desc { a < b } else { a > b }
     }
 
-    fn advance(&mut self, t: i64) -> bool {
-        // A value moving AGAINST the declared direction proves this scan's
-        // advertised ordering is false — a parquet footer's `sorting_columns` is
-        // lying. Dedup stays sound either way (`dedup_key_idxs`), but this is the
-        // only direct signal that the hot-tail footer repair still has work to
-        // do; a zero here across prod would exonerate footers entirely and send
-        // the 2026-08-07 under-count investigation elsewhere.
-        if let Some(l) = self.last
-            && if self.desc { t > l } else { t < l }
-        {
-            ORDERING_VIOLATIONS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    /// Advance the run bound, counting violations into `violations`. Returns
+    /// true when this row OPENS a new run (i.e. it moved forward and was not the
+    /// very first row).
+    ///
+    /// A value moving AGAINST the declared direction proves this scan's
+    /// advertised ordering is false — a parquet footer's `sorting_columns` is
+    /// lying. Dedup stays sound either way (the bound column stays in the dedup
+    /// key — see `dedup_key_idxs`), but this is the only direct signal that the
+    /// hot-tail footer repair still has work to do; a zero here across prod
+    /// would exonerate footers entirely and send the 2026-08-07 under-count
+    /// investigation elsewhere.
+    fn step(&mut self, t: i64, violations: &AtomicU64) -> bool {
+        if self.last.is_some_and(|l| self.ahead(l, t)) {
+            violations.fetch_add(1, Ordering::Relaxed);
         }
-        self.last.is_none_or(|l| if self.desc { t < l } else { t > l }) && self.last.replace(t).is_some()
+        self.last.is_none_or(|l| self.ahead(t, l)) && self.last.replace(t).is_some()
+    }
+
+    /// Advance against the global counter, the one every dedup scan feeds.
+    fn advance(&mut self, t: i64) -> bool {
+        self.step(t, &ORDERING_VIOLATIONS)
     }
 }
 
@@ -131,7 +132,7 @@ impl LegKind {
         self.into()
     }
 
-    fn counter(self) -> &'static std::sync::atomic::AtomicU64 {
+    fn counter(self) -> &'static AtomicU64 {
         match self {
             LegKind::Mem => &ORDERING_VIOLATIONS_MEM,
             LegKind::Delta => &ORDERING_VIOLATIONS_DELTA,
@@ -139,11 +140,11 @@ impl LegKind {
     }
 }
 
-pub(crate) static ORDERING_VIOLATIONS_MEM: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
-pub(crate) static ORDERING_VIOLATIONS_DELTA: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+pub(crate) static ORDERING_VIOLATIONS_MEM: AtomicU64 = AtomicU64::new(0);
+pub(crate) static ORDERING_VIOLATIONS_DELTA: AtomicU64 = AtomicU64::new(0);
 
 pub fn ordering_violations_by_leg() -> [(&'static str, u64); 2] {
-    [LegKind::Mem, LegKind::Delta].map(|leg| (leg.label(), leg.counter().load(std::sync::atomic::Ordering::Relaxed)))
+    [LegKind::Mem, LegKind::Delta].map(|leg| (leg.label(), leg.counter().load(Ordering::Relaxed)))
 }
 
 /// Diagnostic wrapper that answers "which leg's declared ordering is false?".
@@ -266,53 +267,47 @@ impl ExecutionPlan for OrderingProbeExec {
     }
 
     fn execute(&self, partition: usize, context: Arc<TaskContext>) -> DFResult<SendableRecordBatchStream> {
-        use futures::StreamExt;
         let stream = self.inner.execute(partition, context)?;
         let schema = stream.schema();
-        // The leg's OWN claim — not the union's. `None` means this leg declares
-        // nothing, and a leg that promises nothing cannot break a promise.
-        let Some(mut bound) = detect_bound(&self.inner, &[], &schema, true).or_else(|| leading_bound(&self.inner, &schema)) else {
+        // The leg's OWN claim — not the union's, and ignoring whether the column
+        // is a dedup key: the probe cares only about "did this leg honour what it
+        // declared". `None` means this leg declares nothing, and a leg that
+        // promises nothing cannot break a promise.
+        let Some(mut bound) = leading_bound(&self.inner, &schema, |_| true) else {
             return Ok(stream);
         };
-        let leg = self.leg;
+        let counter = self.leg.counter();
         let out = stream.map(move |batch| {
             let batch = batch?;
-            if let Some(col) = batch.column(bound.idx).as_any().downcast_ref::<arrow::array::TimestampMicrosecondArray>() {
-                for i in 0..col.len() {
-                    if col.is_valid(i) {
-                        bound.advance_counting(col.value(i), leg);
-                    }
-                }
-            } else if let Some(col) = batch.column(bound.idx).as_any().downcast_ref::<arrow::array::Int64Array>() {
-                for i in 0..col.len() {
-                    if col.is_valid(i) {
-                        bound.advance_counting(col.value(i), leg);
-                    }
-                }
+            let col = batch.column(bound.idx);
+            if let Some(values) = bound_slice(col) {
+                (0..col.len()).filter(|&i| col.is_valid(i)).for_each(|i| {
+                    bound.step(values[i], counter);
+                });
             }
             Ok(batch)
         });
-        Ok(Box::pin(datafusion::physical_plan::stream::RecordBatchStreamAdapter::new(schema, out)))
+        Ok(Box::pin(RecordBatchStreamAdapter::new(schema, out)))
     }
 }
 
-/// The leg's leading sort column as a `Bound`, ignoring whether it is a dedup
-/// key — the probe cares only about "did this leg honour what it declared".
-fn leading_bound(input: &Arc<dyn ExecutionPlan>, in_schema: &SchemaRef) -> Option<Bound> {
+/// The input's leading sort column as a `Bound`, when `accept`s its name and it
+/// is i64-backed. The declared ordering is never verified — see `detect_bound`.
+fn leading_bound(input: &Arc<dyn ExecutionPlan>, in_schema: &SchemaRef, accept: impl Fn(&str) -> bool) -> Option<Bound> {
     let se = input.properties().output_ordering()?.iter().next()?;
     let col = sort_col(se)?;
-    matches!(in_schema.field(col.index()).data_type(), DataType::Int64 | DataType::Timestamp(..)).then(|| Bound {
+    (accept(col.name()) && matches!(in_schema.field(col.index()).data_type(), DataType::Int64 | DataType::Timestamp(..))).then(|| Bound {
         idx: col.index(),
         desc: se.options.descending,
         last: None,
     })
 }
 
-/// Rows observed out of the order their scan declared. See `Bound::advance`.
-pub(crate) static ORDERING_VIOLATIONS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+/// Rows observed out of the order their scan declared. See `Bound::step`.
+pub(crate) static ORDERING_VIOLATIONS: AtomicU64 = AtomicU64::new(0);
 
 pub fn ordering_violations() -> u64 {
-    ORDERING_VIOLATIONS.load(std::sync::atomic::Ordering::Relaxed)
+    ORDERING_VIOLATIONS.load(Ordering::Relaxed)
 }
 
 /// The i64-backed values of a bound column (timestamps / Int64), for cheap
@@ -369,9 +364,9 @@ pub fn set_bounded_dedup_enabled(enabled: bool) {
     let _ = BOUNDED_DEDUP_ENABLED.set(enabled);
 }
 
-/// The dedup key columns to hash, given the chosen bound.
+/// The dedup key columns to hash. The bound column is ALWAYS retained.
 ///
-/// The bound column is ALWAYS retained. It used to be filtered out here: within
+/// It used to be filtered out here: within
 /// a *genuinely* sorted run the bound is constant, so encoding it into every key
 /// is redundant, and dropping it saved one timestamp encoding per physical row.
 ///
@@ -386,8 +381,7 @@ pub fn set_bounded_dedup_enabled(enabled: bool) {
 ///
 /// Keeping the bound in the key makes bounded mode fail-SAFE: a false ordering
 /// can now only under-dedup (emit a duplicate), never drop a distinct row.
-fn dedup_key_idxs(bound: Option<&Bound>, key_idxs: &[usize]) -> Vec<usize> {
-    let _ = bound;
+fn dedup_key_idxs(key_idxs: &[usize]) -> Vec<usize> {
     key_idxs.to_vec()
 }
 
@@ -400,16 +394,7 @@ fn dedup_key_idxs(bound: Option<&Bound>, key_idxs: &[usize]) -> Vec<usize> {
 /// when it lies badly enough to matter, and defaults OFF until the footer repair
 /// has drained the poisoned files.
 fn detect_bound(input: &Arc<dyn ExecutionPlan>, keys: &[String], in_schema: &SchemaRef, enabled: bool) -> Option<Bound> {
-    if !enabled {
-        return None;
-    }
-    let se = input.properties().output_ordering()?.iter().next()?;
-    let col = sort_col(se)?;
-    (keys.iter().any(|k| k == col.name()) && matches!(in_schema.field(col.index()).data_type(), DataType::Int64 | DataType::Timestamp(..))).then(|| Bound {
-        idx: col.index(),
-        desc: se.options.descending,
-        last: None,
-    })
+    enabled.then(|| leading_bound(input, in_schema, |name| keys.iter().any(|k| k == name))).flatten()
 }
 
 /// The input's output ordering, remapped through `output_projection` onto the
@@ -590,7 +575,7 @@ impl ExecutionPlan for DedupExec {
             None => crate::database::scan_metric_names::DEDUP_FULL_SET_TOTAL,
         })
         .increment(1);
-        let key_idxs = dedup_key_idxs(bound.as_ref(), &self.key_idxs);
+        let key_idxs = dedup_key_idxs(&self.key_idxs);
         // A bound lets keep-greatest emit per run without buffering the stream,
         // so it is the preferred shape — but it is no longer REQUIRED. Refusing
         // to run unbounded is what forced `version_append` scans to manufacture
@@ -1022,20 +1007,18 @@ struct Dedup {
     direct_string_key: Option<usize>,
 }
 
-enum KeyRows {
+enum KeyRows<'a> {
     Encoded(datafusion::arrow::row::Rows),
-    Utf8(ArrayRef),
-    Utf8View(ArrayRef),
-    LargeUtf8(ArrayRef),
+    /// The `direct_string_key` fast path: a single non-nullable string column,
+    /// read in place rather than re-encoded through the row converter.
+    Direct(StringValues<'a>),
 }
 
-impl KeyRows {
+impl KeyRows<'_> {
     fn value(&self, row: usize) -> &[u8] {
         match self {
             Self::Encoded(rows) => rows.row(row).data(),
-            Self::Utf8(array) => array.as_any().downcast_ref::<StringArray>().expect("validated Utf8 key").value(row).as_bytes(),
-            Self::Utf8View(array) => array.as_any().downcast_ref::<StringViewArray>().expect("validated Utf8View key").value(row).as_bytes(),
-            Self::LargeUtf8(array) => array.as_any().downcast_ref::<LargeStringArray>().expect("validated LargeUtf8 key").value(row).as_bytes(),
+            Self::Direct(values) => values.value(row).expect("direct string key is non-nullable").as_bytes(),
         }
     }
 }
@@ -1047,13 +1030,8 @@ impl Dedup {
             let keys = self.conv.convert_columns(&key_arrays).map_err(arrow_err)?;
             return Ok(dedup_first(batch, &keys, &mut self.seen, self.output_projection.as_deref(), self.bound.as_mut())?.into_iter().collect());
         };
-        let keys = match self.direct_string_key {
-            Some(idx) => match batch.column(idx).data_type() {
-                DataType::Utf8 => KeyRows::Utf8(batch.column(idx).clone()),
-                DataType::Utf8View => KeyRows::Utf8View(batch.column(idx).clone()),
-                DataType::LargeUtf8 => KeyRows::LargeUtf8(batch.column(idx).clone()),
-                _ => unreachable!("direct string key type was validated at construction"),
-            },
+        let keys = match self.direct_string_key.and_then(|idx| StringValues::from_column(batch.column(idx))) {
+            Some(values) => KeyRows::Direct(values),
             None => {
                 let key_arrays: Vec<ArrayRef> = self.key_idxs.iter().map(|&i| batch.column(i).clone()).collect();
                 KeyRows::Encoded(self.conv.convert_columns(&key_arrays).map_err(arrow_err)?)
@@ -1202,8 +1180,6 @@ fn dedup_first(
 
 #[cfg(test)]
 mod tests {
-    use super::{FileSpan, skippable_certified_files};
-
     /// The soundness rule for additive, file-set certification. Getting this
     /// wrong silently over-counts every dashboard tile, so the cases that must
     /// DECLINE are enumerated as carefully as the ones that may skip.
@@ -1358,7 +1334,7 @@ mod tests {
 
         // `dedup_key_idxs` must therefore RETAIN the bound column, making the
         // operator fail-safe under a false ordering.
-        assert_eq!(dedup_key_idxs(Some(&Bound { idx: 1, desc: true, last: None }), &[0, 1]), vec![0, 1], "bound column must stay in the dedup key");
+        assert_eq!(dedup_key_idxs(&[0, 1]), vec![0, 1], "bound column must stay in the dedup key");
 
         let full = RowConverter::new(vec![SortField::new(DataType::Utf8), SortField::new(DataType::Int64)]).unwrap();
         let mut bound2 = Bound { idx: 1, desc: true, last: None };
@@ -2305,13 +2281,6 @@ pub async fn try_count_pushdown(plan: &LogicalPlan, database: &Arc<Database>) ->
     // Only tables served by ProjectRoutingTable qualify (system tables like
     // timefusion_stats share the session but not the storage model).
     let Some(schema) = crate::schema::get_schema(&q.table_name) else { return Ok(None) };
-    if schema.tombstones_possible()
-        && let Some(total) = try_logical_count(database, &q, schema).await
-    {
-        debug!("count_pushdown: answered {}/{} [{}, {}] = {} from logical-count index", q.project_id, q.table_name, q.lo, q.hi, total);
-        crate::observability::record_logical_count_pushdown_used();
-        return count_result(plan, total);
-    }
     // Tombstones make `stats.numRecords` an over-count in exactly the way
     // deletion vectors do (below), except invisibly: a merge-on-read DELETE is
     // an APPEND, so the file stats count both the tombstone version and the
@@ -2324,9 +2293,13 @@ pub async fn try_count_pushdown(plan: &LogicalPlan, database: &Arc<Database>) ->
     // would trade the whole stats fast path (the highest-frequency dashboard
     // tile) for an unbounded scan that buys nothing. See
     // `TableSchema::tombstones_possible` for the ordering invariant that makes
-    // this sound.
+    // this sound. The logical-count index is the one exact answer for such a
+    // table, so try it first and decline when it has no covering partition.
     if schema.tombstones_possible() {
-        return Ok(None);
+        let Some(total) = try_logical_count(database, &q, schema).await else { return Ok(None) };
+        debug!("count_pushdown: answered {}/{} [{}, {}] = {} from logical-count index", q.project_id, q.table_name, q.lo, q.hi, total);
+        crate::observability::record_logical_count_pushdown_used();
+        return count_result(plan, total);
     }
 
     // Gate: window fully flushed (no MemBuffer rows in range).
@@ -2440,22 +2413,17 @@ async fn try_logical_count(database: &Arc<Database>, q: &CountQuery, schema: &cr
         }
         return None;
     }
-    let authoritative_batches = mem_batches;
     let covered_ranges = crate::write::mem_buffer::merge_ranges(mem_ranges);
     let delta_batches = database.logical_count_overlay_batches(delta_snapshot, log_store, added_files, columns).await.ok()?;
     indexes.into_iter().try_fold(0u64, |total, (date, index)| {
         let day_lo = date.and_hms_opt(0, 0, 0)?.and_utc().timestamp_micros();
         let day_hi = date.succ_opt()?.and_hms_opt(0, 0, 0)?.and_utc().timestamp_micros();
-        let input =
-            crate::read::LogicalCountOverlay { authoritative_batches: &authoritative_batches, delta_batches: &delta_batches, covered_ranges: &covered_ranges };
+        let input = crate::read::LogicalCountOverlay { authoritative_batches: &mem_batches, delta_batches: &delta_batches, covered_ranges: &covered_ranges };
         let count = index.count_with_covered_overlay(input, q.lo.max(day_lo), hi.min(day_hi), columns).ok()?;
         total.checked_add(count)
     })
 }
 
-/// Extract `(min_ts, max_ts, numRecords)` for this project's files from the
-/// flattened add-actions batch and sum the fully-contained ones. `None` on
-/// any missing column/stat, DV presence, or boundary straddle.
 /// A timestamp stats column as microseconds, or `None` when it is absent or not
 /// a timestamp. Shared with the rollup coverage fingerprint, which reads the
 /// same per-file span this pushdown does.
@@ -2467,8 +2435,10 @@ pub(crate) fn ts_micros_column(b: &RecordBatch, name: &str) -> Option<Int64Array
     Some(c.as_any().downcast_ref::<TimestampMicrosecondArray>()?.reinterpret_cast())
 }
 
+/// Extract `(min_ts, max_ts, numRecords)` for this project's files from the
+/// flattened add-actions batch and sum the fully-contained ones. `None` on
+/// any missing column/stat, DV presence, or boundary straddle.
 fn sum_from_actions(actions: &RecordBatch, q: &CountQuery) -> Option<u64> {
-    let ts_micros_col = ts_micros_column;
     // Deletion vectors make numRecords an over-count — bail if ANY file has
     // one (column families vary by writer; check every dv-prefixed column).
     let any_dv = actions
@@ -2482,8 +2452,8 @@ fn sum_from_actions(actions: &RecordBatch, q: &CountQuery) -> Option<u64> {
     }
     let pid = actions.column_by_name("partition.project_id")?.as_any().downcast_ref::<StringArray>()?;
     let records = actions.column_by_name("stats.numRecords")?.as_any().downcast_ref::<Int64Array>()?;
-    let min_ts = ts_micros_col(actions, "stats.minValues.timestamp")?;
-    let max_ts = ts_micros_col(actions, "stats.maxValues.timestamp")?;
+    let min_ts = ts_micros_column(actions, "stats.minValues.timestamp")?;
+    let max_ts = ts_micros_column(actions, "stats.maxValues.timestamp")?;
     let rows = (0..actions.num_rows())
         .filter(|&i| pid.is_valid(i) && pid.value(i) == q.project_id)
         .map(|i| (min_ts.is_valid(i).then(|| min_ts.value(i)), max_ts.is_valid(i).then(|| max_ts.value(i)), records.is_valid(i).then(|| records.value(i))));
@@ -2540,7 +2510,7 @@ use std::{
 use anyhow::{Context, Result, bail};
 use arrow::{
     array::TimestampMicrosecondArray,
-    datatypes::{Field, Schema, TimeUnit},
+    datatypes::{Field, Schema},
 };
 use arrow_ipc::{reader::FileReader, writer::FileWriter};
 
@@ -2821,10 +2791,7 @@ const KEY_NULL: char = '\u{0}';
 /// `FORMAT_VERSION` bump, because a cached index encodes a shorter tail and
 /// mixing widths would over-count.
 fn key(timestamp: i64, id: &str) -> Box<[u8]> {
-    let mut out = Vec::with_capacity(8 + id.len());
-    out.extend_from_slice(&timestamp.to_be_bytes());
-    out.extend_from_slice(id.as_bytes());
-    out.into_boxed_slice()
+    [timestamp.to_be_bytes().as_slice(), id.as_bytes()].concat().into_boxed_slice()
 }
 
 /// The non-timestamp dedup-key columns of one batch, resolved once per batch.
@@ -2851,15 +2818,78 @@ impl<'a> KeyTail<'a> {
     }
 }
 
+/// The four narrow columns a logical-count batch carries, resolved once per
+/// batch: `timestamp`, the remaining dedup keys, the version tiebreak and the
+/// tombstone marker.
+struct CountColumns<'a> {
+    timestamps: &'a TimestampMicrosecondArray,
+    tiebreaks: &'a TimestampMicrosecondArray,
+    deleted: &'a BooleanArray,
+    tail: KeyTail<'a>,
+}
+
+impl<'a> CountColumns<'a> {
+    fn new(batch: &'a RecordBatch, columns: LogicalCountColumns<'_>) -> Result<Self> {
+        Ok(Self {
+            timestamps: column_as(batch, columns.timestamp)?,
+            tiebreaks: column_as(batch, columns.tiebreak)?,
+            deleted: column_as(batch, columns.deleted)?,
+            tail: KeyTail::new(batch, columns.keys)?,
+        })
+    }
+
+    /// `(timestamp, encoded key tail, winner)` for one row, reusing `buffer`.
+    ///
+    /// `None` when the timestamp is NULL: a bounded timestamp predicate never
+    /// matches one, so such a row contributes to no count index. A NULL in any
+    /// other key encodes as a distinct segment rather than erroring — it can
+    /// only split a group, never merge two.
+    fn row<'b>(&self, row: usize, buffer: &'b mut String) -> Option<(i64, &'b str, Winner)> {
+        if self.timestamps.is_null(row) {
+            return None;
+        }
+        let winner = Winner {
+            tiebreak: (!self.tiebreaks.is_null(row)).then(|| self.tiebreaks.value(row)),
+            deleted: !self.deleted.is_null(row) && self.deleted.value(row),
+        };
+        Some((self.timestamps.value(row), self.tail.encode(row, buffer), winner))
+    }
+}
+
 fn packed_id<'a>(ids: &'a [u8], winner: &PackedWinner) -> &'a [u8] {
     let start = winner.id_offset as usize;
     let end = start + usize::from(winner.id_len);
     &ids[start..end]
 }
 
+/// The timestamp prefix every index key carries (see [`key`]).
+fn key_timestamp(key: &[u8]) -> i64 {
+    i64::from_be_bytes(key[..8].try_into().expect("logical-count key always starts with timestamp"))
+}
+
+impl PackedWinner {
+    fn winner(&self) -> Winner {
+        Winner { tiebreak: (self.flags & FLAG_TIEBREAK_PRESENT != 0).then_some(self.tiebreak), deleted: self.flags & FLAG_DELETED != 0 }
+    }
+}
+
 impl LogicalCountIndex {
     pub fn new() -> Self {
-        Self { winners: HashMap::default(), packed: None, key_bytes: 0 }
+        Self::default()
+    }
+
+    /// Every stored winner, whichever representation is live: `(timestamp, id
+    /// bytes, winner)`. The one place the packed/build split is spelled out.
+    fn entries(&self) -> impl Iterator<Item = (i64, &[u8], Winner)> {
+        match &self.packed {
+            Some(packed) => itertools::Either::Left(packed.winners.iter().map(move |w| (w.timestamp, packed_id(&packed.ids, w), w.winner()))),
+            None => itertools::Either::Right(self.winners.iter().map(|(key, winner)| (key_timestamp(key), &key[8..], *winner))),
+        }
+    }
+
+    /// Live winners satisfying `keep`, over whichever representation is live.
+    fn count_where(&self, keep: impl Fn(i64, Winner) -> bool) -> u64 {
+        u64::try_from(self.entries().filter(|&(timestamp, _, winner)| keep(timestamp, winner)).count()).expect("logical-count partition length fits u64")
     }
 
     /// Apply one physical version. Returns whether it changed the logical row.
@@ -2894,7 +2924,7 @@ impl LogicalCountIndex {
             live_timestamps: Vec::with_capacity(winners.len()),
         };
         for (key, winner) in winners {
-            let timestamp = i64::from_be_bytes(key[..8].try_into().expect("logical-count key always starts with timestamp"));
+            let timestamp = key_timestamp(&key);
             let id = &key[8..];
             let id_offset = u32::try_from(packed.ids.len()).context("logical-count ID arena exceeds 4GiB")?;
             let id_len = u16::try_from(id.len()).context("logical-count ID exceeds 65535 bytes")?;
@@ -2924,8 +2954,7 @@ impl LogicalCountIndex {
                 .winners
                 .binary_search_by(|candidate| candidate.timestamp.cmp(&timestamp).then_with(|| packed_id(&packed.ids, candidate).cmp(id.as_bytes())))
                 .ok()?;
-            let winner = packed.winners[pos];
-            Some(Winner { tiebreak: (winner.flags & FLAG_TIEBREAK_PRESENT != 0).then_some(winner.tiebreak), deleted: winner.flags & FLAG_DELETED != 0 })
+            Some(packed.winners[pos].winner())
         } else {
             self.winners.get(key(timestamp, id).as_ref()).copied()
         }
@@ -2934,28 +2963,15 @@ impl LogicalCountIndex {
     /// Apply the four-column narrow form emitted by a count-index build:
     /// `timestamp`, `id`, version tiebreak, tombstone marker.
     pub fn apply_batch(&mut self, batch: &RecordBatch, columns: LogicalCountColumns<'_>) -> Result<usize> {
-        let timestamps = timestamp_values(batch, columns.timestamp)?;
-        let tail = KeyTail::new(batch, columns.keys)?;
-        let tiebreaks = timestamp_values(batch, columns.tiebreak)?;
-        let deleted = batch
-            .column_by_name(columns.deleted)
-            .with_context(|| format!("logical-count batch missing {}", columns.deleted))?
-            .as_any()
-            .downcast_ref::<BooleanArray>()
-            .with_context(|| format!("logical-count {} is not Boolean", columns.deleted))?;
-        let mut changed = 0;
+        let narrow = CountColumns::new(batch, columns)?;
         let mut buffer = String::new();
+        let mut changed = 0;
+        // Imperative: each row hands back a `&str` borrowed from the reused
+        // `buffer`, which no iterator chain can thread through a closure.
         for row in 0..batch.num_rows() {
-            // A bounded timestamp predicate never matches NULL, so such a row
-            // contributes to no count index. A NULL in any other key encodes as
-            // a distinct segment rather than erroring: it can only split a
-            // group, never merge two.
-            if timestamps.is_null(row) {
-                continue;
+            if let Some((timestamp, id, winner)) = narrow.row(row, &mut buffer) {
+                changed += usize::from(self.apply(timestamp, id, winner.tiebreak, winner.deleted));
             }
-            let tiebreak = (!tiebreaks.is_null(row)).then(|| tiebreaks.value(row));
-            let is_deleted = !deleted.is_null(row) && deleted.value(row);
-            changed += usize::from(self.apply(timestamps.value(row), tail.encode(row, &mut buffer), tiebreak, is_deleted));
         }
         Ok(changed)
     }
@@ -2973,6 +2989,7 @@ impl LogicalCountIndex {
     /// Delta rows; `delta_batches` are newly appended Delta files and remain
     /// subject to the same range gate as the indexed base.
     pub fn count_with_covered_overlay(&self, input: LogicalCountOverlay<'_>, lo: i64, hi: i64, columns: LogicalCountColumns<'_>) -> Result<u64> {
+        use std::collections::hash_map::Entry;
         let LogicalCountOverlay { authoritative_batches, delta_batches, covered_ranges } = input;
         #[derive(Clone, Copy)]
         struct Overlay {
@@ -2983,37 +3000,22 @@ impl LogicalCountIndex {
 
         let base_visible = |timestamp: i64| !covered_ranges.iter().any(|&(start, end)| (start..end).contains(&timestamp));
         let mut overlay: HashMap<Box<[u8]>, Overlay, ahash::RandomState> = HashMap::default();
+        let mut buffer = String::new();
         for (batches, authoritative) in [(authoritative_batches, true), (delta_batches, false)] {
             for batch in batches {
-                let timestamps = timestamp_values(batch, columns.timestamp)?;
-                let tail = KeyTail::new(batch, columns.keys)?;
-                let mut buffer = String::new();
-                let tiebreaks = timestamp_values(batch, columns.tiebreak)?;
-                let deleted = batch
-                    .column_by_name(columns.deleted)
-                    .with_context(|| format!("logical-count overlay missing {}", columns.deleted))?
-                    .as_any()
-                    .downcast_ref::<BooleanArray>()
-                    .with_context(|| format!("logical-count overlay {} is not Boolean", columns.deleted))?;
+                let narrow = CountColumns::new(batch, columns)?;
                 for row in 0..batch.num_rows() {
-                    if timestamps.is_null(row) {
-                        continue;
-                    }
-                    let timestamp = timestamps.value(row);
-                    let id = tail.encode(row, &mut buffer);
-                    let encoded = key(timestamp, id);
-                    let candidate =
-                        Winner { tiebreak: (!tiebreaks.is_null(row)).then(|| tiebreaks.value(row)), deleted: !deleted.is_null(row) && deleted.value(row) };
+                    let Some((timestamp, id, candidate)) = narrow.row(row, &mut buffer) else { continue };
                     if !authoritative && !base_visible(timestamp) {
                         continue;
                     }
-                    match overlay.entry(encoded) {
-                        std::collections::hash_map::Entry::Occupied(mut entry) => {
+                    match overlay.entry(key(timestamp, id)) {
+                        Entry::Occupied(mut entry) => {
                             if candidate.tiebreak > entry.get().current.tiebreak {
                                 entry.get_mut().current = candidate;
                             }
                         }
-                        std::collections::hash_map::Entry::Vacant(entry) => {
+                        Entry::Vacant(entry) => {
                             let base = self.winner(timestamp, id).filter(|_| base_visible(timestamp));
                             let current = base.filter(|winner| winner.tiebreak >= candidate.tiebreak).unwrap_or(candidate);
                             entry.insert(Overlay { base, current, timestamp });
@@ -3034,30 +3036,9 @@ impl LogicalCountIndex {
     }
 
     fn count_covered_live(&self, lo: i64, hi: i64, covered_ranges: &[(i64, i64)]) -> u64 {
-        let visible = |timestamp: i64, winner: Winner| {
+        self.count_where(|timestamp, winner| {
             !winner.deleted && (lo..hi).contains(&timestamp) && covered_ranges.iter().any(|&(start, end)| (start..end).contains(&timestamp))
-        };
-        let count = if let Some(packed) = &self.packed {
-            packed
-                .winners
-                .iter()
-                .filter(|winner| {
-                    visible(
-                        winner.timestamp,
-                        Winner { tiebreak: (winner.flags & FLAG_TIEBREAK_PRESENT != 0).then_some(winner.tiebreak), deleted: winner.flags & FLAG_DELETED != 0 },
-                    )
-                })
-                .count()
-        } else {
-            self.winners
-                .iter()
-                .filter(|(key, winner)| {
-                    let timestamp = i64::from_be_bytes(key[..8].try_into().expect("logical-count key always starts with timestamp"));
-                    visible(timestamp, **winner)
-                })
-                .count()
-        };
-        u64::try_from(count).expect("logical-count partition length fits u64")
+        })
     }
 
     /// Exact live row count in the half-open interval `[lo, hi)`.
@@ -3065,28 +3046,19 @@ impl LogicalCountIndex {
         if lo >= hi {
             return 0;
         }
+        // The packed form pays two binary searches instead of a full walk.
         if let Some(packed) = &self.packed {
             let start = packed.live_timestamps.partition_point(|timestamp| *timestamp < lo);
             let end = packed.live_timestamps.partition_point(|timestamp| *timestamp < hi);
             return u64::try_from(end - start).expect("logical-count partition length fits u64");
         }
-        u64::try_from(
-            self.winners
-                .iter()
-                .filter(|(key, winner)| {
-                    let timestamp = i64::from_be_bytes(key[..8].try_into().expect("logical-count key always starts with timestamp"));
-                    !winner.deleted && (lo..hi).contains(&timestamp)
-                })
-                .count(),
-        )
-        .expect("logical-count partition length fits u64")
+        self.count_where(|timestamp, winner| !winner.deleted && (lo..hi).contains(&timestamp))
     }
 
     pub fn logical_rows(&self) -> u64 {
-        if let Some(packed) = &self.packed {
-            u64::try_from(packed.live_timestamps.len()).expect("logical-count partition length fits u64")
-        } else {
-            u64::try_from(self.winners.values().filter(|winner| !winner.deleted).count()).expect("logical-count partition length fits u64")
+        match &self.packed {
+            Some(packed) => u64::try_from(packed.live_timestamps.len()).expect("logical-count partition length fits u64"),
+            None => self.count_where(|_, winner| !winner.deleted),
         }
     }
 
@@ -3159,26 +3131,10 @@ impl LogicalCountIndex {
                 rows.clear();
                 Ok(())
             };
-            if let Some(packed) = &self.packed {
-                for winner in &packed.winners {
-                    let id = std::str::from_utf8(packed_id(&packed.ids, winner)).context("logical-count key contains non-UTF8 id")?;
-                    rows.push((
-                        winner.timestamp,
-                        id,
-                        Winner { tiebreak: (winner.flags & FLAG_TIEBREAK_PRESENT != 0).then_some(winner.tiebreak), deleted: winner.flags & FLAG_DELETED != 0 },
-                    ));
-                    if rows.len() == WRITE_ROWS {
-                        write_rows(&mut rows)?;
-                    }
-                }
-            } else {
-                for (key, winner) in &self.winners {
-                    let timestamp = i64::from_be_bytes(key[..8].try_into().expect("logical-count key always starts with timestamp"));
-                    let id = std::str::from_utf8(&key[8..]).context("logical-count key contains non-UTF8 id")?;
-                    rows.push((timestamp, id, *winner));
-                    if rows.len() == WRITE_ROWS {
-                        write_rows(&mut rows)?;
-                    }
+            for (timestamp, id, winner) in self.entries() {
+                rows.push((timestamp, std::str::from_utf8(id).context("logical-count key contains non-UTF8 id")?, winner));
+                if rows.len() == WRITE_ROWS {
+                    write_rows(&mut rows)?;
                 }
             }
             write_rows(&mut rows)?;
@@ -3186,11 +3142,9 @@ impl LogicalCountIndex {
             std::fs::rename(&tmp, path).with_context(|| format!("publish logical-count cache {}", path.display()))?;
             Ok(())
         };
-        if let Err(error) = write() {
+        write().inspect_err(|_| {
             let _ = std::fs::remove_file(&tmp);
-            return Err(error);
-        }
-        Ok(())
+        })
     }
 
     /// Load only when the file belongs to the caller's exact snapshot.
@@ -3253,14 +3207,12 @@ impl LogicalCountIndex {
     }
 }
 
-fn timestamp_values<'a>(batch: &'a RecordBatch, name: &str) -> Result<&'a TimestampMicrosecondArray> {
+/// One named column of a logical-count batch as its concrete Arrow array type.
+/// The downcast IS the type check — a wrong timestamp unit or a non-Boolean
+/// tombstone column fails here rather than being read as something else.
+fn column_as<'a, A: 'static>(batch: &'a RecordBatch, name: &str) -> Result<&'a A> {
     let column = batch.column_by_name(name).with_context(|| format!("logical-count batch missing {name}"))?;
-    match column.data_type() {
-        DataType::Timestamp(TimeUnit::Microsecond, _) => {
-            column.as_any().downcast_ref::<TimestampMicrosecondArray>().with_context(|| format!("logical-count {name} is not TimestampMicrosecond"))
-        }
-        other => bail!("logical-count {name} has unsupported type {other}"),
-    }
+    column.as_any().downcast_ref::<A>().with_context(|| format!("logical-count {name} has unsupported type {}", column.data_type()))
 }
 
 enum StringValues<'a> {
@@ -3270,17 +3222,18 @@ enum StringValues<'a> {
 }
 
 impl<'a> StringValues<'a> {
+    /// `None` for any non-string column.
+    fn from_column(column: &'a ArrayRef) -> Option<Self> {
+        let any = column.as_any();
+        any.downcast_ref::<StringViewArray>()
+            .map(Self::View)
+            .or_else(|| any.downcast_ref::<StringArray>().map(Self::Utf8))
+            .or_else(|| any.downcast_ref::<LargeStringArray>().map(Self::Large))
+    }
+
     fn new(batch: &'a RecordBatch, name: &str) -> Result<Self> {
         let column = batch.column_by_name(name).with_context(|| format!("logical-count batch missing {name}"))?;
-        if let Some(values) = column.as_any().downcast_ref::<StringViewArray>() {
-            Ok(Self::View(values))
-        } else if let Some(values) = column.as_any().downcast_ref::<StringArray>() {
-            Ok(Self::Utf8(values))
-        } else if let Some(values) = column.as_any().downcast_ref::<LargeStringArray>() {
-            Ok(Self::Large(values))
-        } else {
-            bail!("logical-count {name} has unsupported type {}", column.data_type())
-        }
+        Self::from_column(column).with_context(|| format!("logical-count {name} has unsupported type {}", column.data_type()))
     }
 
     fn value(&self, row: usize) -> Option<&'a str> {
@@ -3294,10 +3247,13 @@ impl<'a> StringValues<'a> {
 
 #[cfg(test)]
 mod logical_count_index_tests {
+    use arrow::datatypes::TimeUnit;
+
+    use super::*;
+
     fn unmasked(paths: &[&str]) -> super::CountFiles {
         paths.iter().map(|path| ((*path).to_owned(), None)).collect()
     }
-    use super::*;
 
     fn versions(rows: &[(i64, &str, Option<i64>, Option<bool>)]) -> RecordBatch {
         let schema = Arc::new(Schema::new(vec![
@@ -3762,15 +3718,16 @@ pub enum Hll {
     Dense(Box<[u8; M]>),
 }
 
-/// Split a hash into its register index and the 1-based position of the first
-/// set bit in the remaining suffix.
+/// Raise the register this hash lands in. The hash's register index is its top
+/// `P` bits; the value is the 1-based position of the first set bit in the
+/// remaining suffix.
 #[inline]
-const fn register_of(hash: u64) -> (usize, u8) {
+fn set_register(registers: &mut [u8; M], hash: u64) {
     let index = (hash >> (64 - P)) as usize;
     // `| 1` bounds rho at 64-P+1 without a branch: the sentinel bit stops the
     // count when the whole suffix is zero.
     let rho = ((hash << P) | 1).leading_zeros() as u8 + 1;
-    (index, rho)
+    registers[index] = registers[index].max(rho);
 }
 
 impl Hll {
@@ -3783,20 +3740,14 @@ impl Hll {
                     self.densify();
                 }
             }
-            Self::Dense(registers) => {
-                let (index, rho) = register_of(hash);
-                registers[index] = registers[index].max(rho);
-            }
+            Self::Dense(registers) => set_register(registers, hash),
         }
     }
 
     fn densify(&mut self) {
         let Self::Sparse(hashes) = self else { return };
         let mut registers = Box::new([0u8; M]);
-        for &hash in hashes.iter() {
-            let (index, rho) = register_of(hash);
-            registers[index] = registers[index].max(rho);
-        }
+        hashes.iter().for_each(|&hash| set_register(&mut registers, hash));
         *self = Self::Dense(registers);
     }
 
@@ -3814,17 +3765,8 @@ impl Hll {
                 let mine = std::mem::replace(self, other.clone());
                 self.merge(&mine);
             }
-            (Self::Dense(mine), Self::Sparse(theirs)) => {
-                for &hash in theirs.iter() {
-                    let (index, rho) = register_of(hash);
-                    mine[index] = mine[index].max(rho);
-                }
-            }
-            (Self::Dense(mine), Self::Dense(theirs)) => {
-                for (slot, &their) in mine.iter_mut().zip(theirs.iter()) {
-                    *slot = (*slot).max(their);
-                }
-            }
+            (Self::Dense(mine), Self::Sparse(theirs)) => theirs.iter().for_each(|&hash| set_register(mine, hash)),
+            (Self::Dense(mine), Self::Dense(theirs)) => mine.iter_mut().zip(theirs.iter()).for_each(|(slot, &their)| *slot = (*slot).max(their)),
         }
     }
 

--- a/src/read/optimizers.rs
+++ b/src/read/optimizers.rs
@@ -12,12 +12,17 @@ pub fn downcast<T: 'static>(any: &dyn std::any::Any) -> Option<&T> {
     any.downcast_ref()
 }
 
-/// Extracts any UTF-8 scalar representation.
-pub fn extract_utf8_string(v: &ScalarValue) -> Option<String> {
+/// Borrows any UTF-8 scalar representation; `None` for NULL and non-string scalars.
+fn utf8_scalar(v: &ScalarValue) -> Option<&String> {
     match v {
-        ScalarValue::Utf8(Some(s)) | ScalarValue::Utf8View(Some(s)) | ScalarValue::LargeUtf8(Some(s)) => Some(s.clone()),
+        ScalarValue::Utf8(s) | ScalarValue::Utf8View(s) | ScalarValue::LargeUtf8(s) => s.as_ref(),
         _ => None,
     }
+}
+
+/// Extracts any UTF-8 scalar representation.
+pub fn extract_utf8_string(v: &ScalarValue) -> Option<String> {
+    utf8_scalar(v).cloned()
 }
 
 /// Matches a column through coercion casts.
@@ -388,7 +393,7 @@ fn wrap_variant_exprs(exprs: &[Expr], variant: &HashSet<usize>, udf: &Arc<Scalar
 fn is_utf8_expr(expr: &Expr) -> bool {
     match expr {
         // NULL literals must pass through: json_to_variant would try to parse "" and fail.
-        Expr::Literal(ScalarValue::Utf8(Some(_)) | ScalarValue::Utf8View(Some(_)) | ScalarValue::LargeUtf8(Some(_)), _) => true,
+        Expr::Literal(v, _) => utf8_scalar(v).is_some(),
         Expr::Cast(cast) => is_utf8_expr(&cast.expr),
         _ => false,
     }
@@ -421,7 +426,7 @@ fn is_utf8_expr(expr: &Expr) -> bool {
 use std::collections::HashMap;
 
 use datafusion::{
-    arrow::datatypes::{DataType, Field},
+    arrow::datatypes::{DataType, Field, TimeUnit},
     catalog::default_table_source::DefaultTableSource,
     common::{Column, DFSchema, DFSchemaRef},
     logical_expr::{
@@ -716,31 +721,25 @@ fn wrap_root_projection(plan: LogicalPlan) -> Result<LogicalPlan> {
         // Recurse into a node's single input in place, leaving the parent's own
         // fields (and cached schema) untouched.
         let down = |input: Arc<LogicalPlan>| -> Result<Arc<LogicalPlan>> { Ok(Arc::new(peel(Arc::unwrap_or_clone(input), d)?)) };
+        // Every peelable node is "rebuild me with my single `input` recursed
+        // into", differing only in the constructor.
+        macro_rules! descend {
+            ($rebuild:expr, $node:expr) => {{
+                let mut node = $node;
+                node.input = down(node.input)?;
+                Ok($rebuild(node))
+            }};
+        }
         match plan {
-            LogicalPlan::Sort(mut s) => {
-                s.input = down(s.input)?;
-                Ok(LogicalPlan::Sort(s))
-            }
-            LogicalPlan::Limit(mut l) => {
-                l.input = down(l.input)?;
-                Ok(LogicalPlan::Limit(l))
-            }
-            LogicalPlan::Distinct(Distinct::All(input)) => Ok(LogicalPlan::Distinct(Distinct::All(down(input)?))),
-            LogicalPlan::Distinct(Distinct::On(mut on)) => {
-                on.input = down(on.input)?;
-                Ok(LogicalPlan::Distinct(Distinct::On(on)))
-            }
-            LogicalPlan::SubqueryAlias(mut s) => {
-                s.input = down(s.input)?;
-                Ok(LogicalPlan::SubqueryAlias(s))
-            }
+            LogicalPlan::Sort(s) => descend!(LogicalPlan::Sort, s),
+            LogicalPlan::Limit(l) => descend!(LogicalPlan::Limit, l),
+            LogicalPlan::SubqueryAlias(s) => descend!(LogicalPlan::SubqueryAlias, s),
             // Some DataFusion rewrite passes promote a Filter above the
             // outermost Projection. Peel through it so Variant columns still
             // reach the wire wrapped, not as raw binary.
-            LogicalPlan::Filter(mut f) => {
-                f.input = down(f.input)?;
-                Ok(LogicalPlan::Filter(f))
-            }
+            LogicalPlan::Filter(f) => descend!(LogicalPlan::Filter, f),
+            LogicalPlan::Distinct(Distinct::All(input)) => Ok(LogicalPlan::Distinct(Distinct::All(down(input)?))),
+            LogicalPlan::Distinct(Distinct::On(on)) => descend!(|on| LogicalPlan::Distinct(Distinct::On(on)), on),
             LogicalPlan::Projection(proj) => wrap_projection(proj),
             // Union/Intersect/Except/Aggregate/Join/Window/etc. — anything we
             // can't peel through. We don't descend (would need branch-aware
@@ -931,6 +930,10 @@ mod variant_json_accessor_tests {
 
     use super::*;
 
+    fn json_call(udf: Arc<ScalarUDF>, args: Vec<Expr>) -> Expr {
+        Expr::ScalarFunction(ScalarFunction { func: udf, args })
+    }
+
     async fn run(sql: &str, with_rule: bool) -> (String, Vec<datafusion::arrow::record_batch::RecordBatch>) {
         let mut ctx = SessionContext::new();
         crate::read::functions::register_custom_functions(&mut ctx).expect("custom functions");
@@ -989,14 +992,12 @@ mod variant_json_accessor_tests {
     /// walks the descent loop — and it pins the path encoding while it is there.
     #[test]
     fn the_nested_json_get_tower_prod_emits_folds_into_one_path() {
-        use datafusion::{logical_expr::Cast, prelude::lit};
-        let json_call = |udf: Arc<ScalarUDF>, args: Vec<Expr>| Expr::ScalarFunction(ScalarFunction { func: udf, args });
         // Exactly what JsonExprPlanner emits, aliases and all; `::` binds tighter
         // than `->>`, so the last key arrives wrapped in a Cast.
         let level1 =
             json_call(datafusion_functions_json::udfs::json_get_udf(), vec![json_call(variant_to_json_udf(), vec![col("v")]), lit("a")]).alias("v -> 'a'");
         let level2 = json_call(datafusion_functions_json::udfs::json_get_udf(), vec![level1, lit(0i64)]).alias("v -> 'a' -> 0");
-        let cast_key = Expr::Cast(Cast::new(Box::new(lit("b")), datafusion::arrow::datatypes::DataType::Utf8));
+        let cast_key = Expr::Cast(Cast::new(Box::new(lit("b")), DataType::Utf8));
         let tower = json_call(datafusion_functions_json::udfs::json_as_text_udf(), vec![level2, cast_key]);
 
         let native = super::variant_native_extraction(&tower).expect("the nested tower is the shape this rule exists for");
@@ -1008,8 +1009,6 @@ mod variant_json_accessor_tests {
     /// rewriter normalizes them away first.
     #[test]
     fn an_excluded_shape_is_left_alone() {
-        use datafusion::prelude::lit;
-        let json_call = |udf: Arc<ScalarUDF>, args: Vec<Expr>| Expr::ScalarFunction(ScalarFunction { func: udf, args });
         let as_text = |args: Vec<Expr>| json_call(datafusion_functions_json::udfs::json_as_text_udf(), args);
         let variant = json_call(variant_to_json_udf(), vec![col("v")]);
         let rewrite = |e: Expr| super::variant_native_extraction(&e);
@@ -1369,7 +1368,7 @@ fn match_indexed_predicate(expr: &Expr, indexed_columns: &IndexedCols, allow_eq:
             // the prefilter and the preserved LIKE/ILIKE re-runs with correct
             // semantics on the Delta side.
             let route = match r.as_ref() {
-                Expr::Literal(s, _) => classify_like_pattern(&extract_utf8_string(s)?, *escape_char, tok == NGRAM3_TOKENIZER)
+                Expr::Literal(s, _) => classify_like_pattern(utf8_scalar(s)?, *escape_char, tok == NGRAM3_TOKENIZER)
                     // ngram3 needs a full trigram to match anything.
                     .filter(|q| tok != NGRAM3_TOKENIZER || q.chars().filter(|c| *c != '*').count() >= NGRAM_MIN_QUERY_LEN)
                     .map(Route::Ready)?,
@@ -1399,7 +1398,7 @@ fn match_indexed_predicate(expr: &Expr, indexed_columns: &IndexedCols, allow_eq:
             let (tok, text_typed) = *indexed_columns.get(&c.name)?;
             let Expr::Literal(s, _) = right.as_ref() else { return None };
             (tok == NGRAM3_TOKENIZER && text_typed)
-                .then(|| regex_literal_substring(&extract_utf8_string(s)?).filter(|q| q.chars().count() >= NGRAM_MIN_QUERY_LEN))
+                .then(|| regex_literal_substring(utf8_scalar(s)?).filter(|q| q.chars().count() >= NGRAM_MIN_QUERY_LEN))
                 .flatten()
                 .map(|q| (c.name.clone(), Route::Ready(q)))
         }
@@ -1412,15 +1411,9 @@ fn match_indexed_predicate(expr: &Expr, indexed_columns: &IndexedCols, allow_eq:
 /// Utf8-ish; the cast is value-preserving for string types, so seeing through
 /// it is safe (non-string sources are rejected by the `text_typed` gate).
 fn column_through_string_cast(e: &Expr) -> Option<&Column> {
-    use arrow::datatypes::DataType;
-    use datafusion::logical_expr::expr::{Cast, TryCast};
     match e {
         Expr::Column(c) => Some(c),
-        Expr::Cast(Cast { expr, field }) | Expr::TryCast(TryCast { expr, field })
-            if matches!(field.data_type(), DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View) =>
-        {
-            column_through_string_cast(expr)
-        }
+        Expr::Cast(Cast { expr, field }) | Expr::TryCast(TryCast { expr, field }) if is_text_type(field.data_type()) => column_through_string_cast(expr),
         _ => None,
     }
 }
@@ -1622,8 +1615,6 @@ mod tantivy_rewriter_tests {
     /// was built on ingest and never read.
     #[test]
     fn match_regex_imatch_through_cast_routes_on_ngram3() {
-        use arrow::datatypes::DataType;
-        use datafusion::logical_expr::expr::Cast;
         let cols = cols_of([("name", NGRAM3_TOKENIZER), ("tid", RAW_TOKENIZER)]);
         let re = |c: &str, op: Operator, pat: &str, cast: bool| {
             let lhs = if cast { Expr::Cast(Cast::new(Box::new(col(c)), DataType::Utf8)) } else { col(c) };
@@ -1790,10 +1781,7 @@ impl datafusion::logical_expr::ScalarUDFImpl for PgCoalesceUdf {
             // fails on the second list and the original error surfaces — no
             // silent mis-typing, just a planner-time error like today.
             let list_t = arg_types.iter().find(|t| matches!(t, DataType::List(_) | DataType::LargeList(_) | DataType::FixedSizeList(..))).ok_or(e)?.clone();
-            let patched: Vec<DataType> = arg_types
-                .iter()
-                .map(|t| if matches!(t, DataType::Utf8 | DataType::Utf8View | DataType::LargeUtf8) { list_t.clone() } else { t.clone() })
-                .collect();
+            let patched: Vec<DataType> = arg_types.iter().map(|t| if is_text_type(t) { list_t.clone() } else { t.clone() }).collect();
             self.inner.coerce_types(&patched)
         })
     }
@@ -1858,12 +1846,7 @@ fn rewrite_in_expr(expr: Expr, input_schemas: &[Arc<DFSchema>]) -> Result<Transf
     // reach TypeCoercion would NOT error: arrow-cast's blanket `(_, List)`
     // rule wraps each value in a single-element list — a silently wrong
     // result. Reject it like PG ("COALESCE types ... cannot be matched").
-    if let Some(bad) = new_args.iter().find_map(|a| {
-        input_schemas.iter().find_map(|s| match a.get_type(s.as_ref()) {
-            Ok(t @ (DataType::Utf8 | DataType::Utf8View | DataType::LargeUtf8)) => Some(t),
-            _ => None,
-        })
-    }) {
+    if let Some(bad) = new_args.iter().find_map(|a| input_schemas.iter().find_map(|s| a.get_type(s.as_ref()).ok().filter(is_text_type))) {
         return plan_err!("COALESCE types {bad} and List({elem_type}) cannot be matched");
     }
     Ok(Transformed::new_transformed(Expr::ScalarFunction(ScalarFunction { func, args: new_args }), transformed))
@@ -1877,10 +1860,8 @@ fn rewrite_in_expr(expr: Expr, input_schemas: &[Arc<DFSchema>]) -> Result<Transf
 /// then casts the literal (arrow supports List → Large/FixedSizeList), so no
 /// physical-planning mismatch — the variant only matters for element type.
 fn pg_list_literal(arg: &Expr, elem_type: &DataType) -> Option<ScalarValue> {
-    let Expr::Literal(ScalarValue::Utf8(Some(s)) | ScalarValue::Utf8View(Some(s)) | ScalarValue::LargeUtf8(Some(s)), _) = arg else {
-        return None;
-    };
-    let vals: Vec<ScalarValue> = parse_pg_string_array(s)?
+    let Expr::Literal(v, _) = arg else { return None };
+    let vals: Vec<ScalarValue> = parse_pg_string_array(utf8_scalar(v)?)?
         .into_iter()
         .map(|e| e.map_or_else(|| ScalarValue::try_from(elem_type).ok(), |s| ScalarValue::try_from_string(s, elem_type).ok()))
         .collect::<Option<_>>()?;
@@ -2751,29 +2732,22 @@ impl AnalyzerRule for ExistsInProjection {
 }
 
 fn rewrite_exprs(exprs: Vec<Expr>) -> Result<(Vec<Expr>, bool)> {
-    let mut any = false;
-    let rewritten = exprs
-        .into_iter()
-        .map(|expr| {
-            // `transform_up` so a nested EXISTS is rewritten before its parent
-            // is inspected; `Alias` nodes must survive untouched or the
-            // projection's output column names change.
-            expr.transform_up(|expr| match expr {
-                Expr::Exists(exists) => {
-                    any = true;
-                    Ok(Transformed::yes(match count_subquery(exists.subquery)? {
-                        Some(count) if exists.negated => count.eq(lit(0_i64)),
-                        Some(count) => count.gt(lit(0_i64)),
-                        // Provably empty subquery: EXISTS is a constant.
-                        None => lit(exists.negated),
-                    }))
-                }
-                other => Ok(Transformed::no(other)),
-            })
-            .map(|transformed| transformed.data)
+    // `transform_up` so a nested EXISTS is rewritten before its parent is
+    // inspected; `Alias` nodes must survive untouched or the projection's
+    // output column names change. The collected `transformed` flag is the
+    // "did anything change" answer — no separate accumulator.
+    let Transformed { data, transformed, .. } = exprs.into_iter().map_until_stop_and_collect(|expr| {
+        expr.transform_up(|expr| match expr {
+            Expr::Exists(exists) => Ok(Transformed::yes(match count_subquery(exists.subquery)? {
+                Some(count) if exists.negated => count.eq(lit(0_i64)),
+                Some(count) => count.gt(lit(0_i64)),
+                // Provably empty subquery: EXISTS is a constant.
+                None => lit(exists.negated),
+            })),
+            other => Ok(Transformed::no(other)),
         })
-        .collect::<Result<Vec<_>>>()?;
-    Ok((rewritten, any))
+    })?;
+    Ok((data, transformed))
 }
 
 /// `q` → scalar subquery `SELECT count(1) FROM q`, keeping the outer
@@ -2799,23 +2773,23 @@ fn count_subquery(subquery: Subquery) -> Result<Option<Expr>> {
 /// keeps its Limit and simply fails to plan, as it does today.
 ///
 /// Returns `None` for `LIMIT 0`, which can never produce a row.
-fn peel_row_caps(mut plan: LogicalPlan) -> Option<LogicalPlan> {
-    while let LogicalPlan::Limit(limit) = &plan {
-        if limit.skip.as_deref().is_some_and(|skip| literal_count(skip) != Some(0)) {
-            break;
+fn peel_row_caps(plan: LogicalPlan) -> Option<LogicalPlan> {
+    match plan {
+        // A non-zero OFFSET is not peelable, so it falls through to `other`.
+        LogicalPlan::Limit(limit) if limit.skip.as_deref().is_none_or(|skip| literal_count(skip) == Some(0)) => {
+            if limit.fetch.as_deref().and_then(literal_count) == Some(0) {
+                return None; // LIMIT 0 can never produce a row
+            }
+            peel_row_caps(Arc::unwrap_or_clone(limit.input))
         }
-        if limit.fetch.as_deref().and_then(literal_count) == Some(0) {
-            return None;
-        }
-        plan = Arc::unwrap_or_clone(limit.input.clone());
+        other => Some(other),
     }
-    Some(plan)
 }
 
 fn literal_count(expr: &Expr) -> Option<i64> {
     match expr {
-        Expr::Literal(value, ..) => value.cast_to(&datafusion::arrow::datatypes::DataType::Int64).ok().and_then(|value| match value {
-            datafusion::scalar::ScalarValue::Int64(count) => count,
+        Expr::Literal(value, ..) => value.cast_to(&DataType::Int64).ok().and_then(|value| match value {
+            ScalarValue::Int64(count) => count,
             _ => None,
         }),
         _ => None,
@@ -3398,7 +3372,7 @@ mod dedup_needs_ordered_input_tests {
 use datafusion::logical_expr::{Filter, SubqueryAlias, utils::split_conjunction};
 
 /// Branches a wide aggregate window is split into. `<2` disables the rule.
-static RANGE_SPLIT_BRANCHES: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+static RANGE_SPLIT_BRANCHES: OnceLock<usize> = OnceLock::new();
 
 pub fn range_split_branches() -> usize {
     *RANGE_SPLIT_BRANCHES.get_or_init(|| 4)
@@ -3592,7 +3566,7 @@ fn narrow_scan_window(plan: &LogicalPlan, lo: i64, hi: i64) -> Option<LogicalPla
             // A non-microsecond timestamp declines the whole rewrite.
             let field = scan.projected_schema.field_with_unqualified_name("timestamp").ok()?;
             let timezone = match field.data_type() {
-                arrow_schema::DataType::Timestamp(arrow_schema::TimeUnit::Microsecond, timezone) => timezone.clone(),
+                DataType::Timestamp(TimeUnit::Microsecond, timezone) => timezone.clone(),
                 _ => return None,
             };
             let literal = |micros| Expr::Literal(ScalarValue::TimestampMicrosecond(Some(micros), timezone.clone()), None);
@@ -3793,7 +3767,7 @@ impl PhysicalOptimizerRule for AggregateInputOrdering {
             if downcast::<SortExec>(plan.as_ref()).is_some() || downcast::<UnorderedAggregateInput>(plan.as_ref()).is_some() {
                 return false;
             }
-            downcast::<DedupExec>(plan.as_ref()).is_some() || plan.children().iter().any(|child| relies_on_storage_order(child))
+            downcast::<DedupExec>(plan.as_ref()).is_some() || plan.children().into_iter().any(relies_on_storage_order)
         }
         plan.transform_up(|node| {
             if downcast::<datafusion::physical_plan::aggregates::AggregateExec>(node.as_ref()).is_some() {

--- a/src/read/plan_cache.rs
+++ b/src/read/plan_cache.rs
@@ -6,11 +6,14 @@
 //! Cached plans embed schemas. This is safe while the compile-time schema
 //! registry is immutable; schema hot reload must invalidate this cache.
 
-use std::sync::{
-    Arc, OnceLock,
-    atomic::{
-        AtomicBool, AtomicU64, AtomicUsize,
-        Ordering::{AcqRel, Relaxed, Release},
+use std::{
+    cmp::Reverse,
+    sync::{
+        Arc, OnceLock,
+        atomic::{
+            AtomicBool, AtomicU64, AtomicUsize,
+            Ordering::{AcqRel, Relaxed, Release},
+        },
     },
 };
 
@@ -47,16 +50,10 @@ use datafusion_postgres::{
         types::format::FormatOptions,
     },
 };
+use itertools::Itertools;
 use tracing::{debug, warn};
 
 use crate::observability::{api_err, arrow_err};
-
-/// Randomly halves a map once it reaches its soft cap.
-fn soft_cap<K: Eq + std::hash::Hash, V>(map: &DashMap<K, V>, cap: usize) {
-    if map.len() >= cap {
-        map.retain(|_, _| fastrand::bool());
-    }
-}
 
 /// Approximate retained bytes per expression, calibrated against production.
 const PLAN_BYTES_PER_EXPR: usize = 384;
@@ -135,7 +132,7 @@ impl<V: Clone> WeighedMap<V> {
 
     /// Evict HEAVIEST-FIRST down to the low-water mark.
     ///
-    /// Heaviest-first, not `soft_cap`'s random half: the bytes are owed by a
+    /// Heaviest-first, not a random half: the bytes are owed by a
     /// handful of bulk INSERTs while the population is mostly small dashboard
     /// SELECTs, so a random half would keep paying the pressure AND throw away
     /// the hot templates that make the cache worth having. Dropping the biggest
@@ -155,8 +152,10 @@ impl<V: Clone> WeighedMap<V> {
             low_water,
             "plan_cache over budget — evicting heaviest-first down to the low-water mark. If this fires steadily, the workload's plan-template variety has grown past the cache budget."
         );
-        let mut by_weight: Vec<(usize, String)> = self.map.iter().map(|e| (e.value().1, e.key().clone())).collect();
-        by_weight.sort_unstable_by(|a, b| b.0.cmp(&a.0));
+        // `sorted_unstable_by_key` is EAGER (it collects, then sorts): every
+        // DashMap shard guard is released before the loop below calls `remove`.
+        // A lazy sort would hold a guard across `remove` and deadlock.
+        let by_weight = self.map.iter().map(|e| (e.value().1, e.key().clone())).sorted_unstable_by_key(|&(weight, _)| Reverse(weight));
         // Both bounds are swept in one pass: drop while EITHER is exceeded.
         let mut held = self.bytes();
         let mut len = self.map.len();
@@ -320,7 +319,7 @@ async fn try_fast_path_insert(plan: &LogicalPlan, session_context: &SessionConte
     // constant array for projection cells the optimizer folded to a literal.
     let (final_schema, columns) = match column_plan {
         Some(plan) => {
-            let (fields, cols): (Vec<Arc<Field>>, Vec<ArrayRef>) = plan
+            let (fields, cols) = plan
                 .iter()
                 .map(|(src, name)| match src {
                     ColumnSource::Values(idx) => {
@@ -332,9 +331,7 @@ async fn try_fast_path_insert(plan: &LogicalPlan, session_context: &SessionConte
                         Ok((Arc::new(Field::new(name, arr.data_type().clone(), true)), arr))
                     }
                 })
-                .collect::<DfResult<Vec<_>>>()?
-                .into_iter()
-                .unzip();
+                .collect::<DfResult<(Vec<Arc<Field>>, Vec<ArrayRef>)>>()?;
             (Arc::new(Schema::new(fields)), cols)
         }
         None => (values_schema, values_columns),
@@ -653,16 +650,13 @@ fn parameterize_statement(stmt: &Statement, base: usize, include_strings: bool) 
     // cached path, and uncached means the literal survives to the planner where
     // `VariantAwareExprPlanner::plan_substring` rewrites it correctly.
     // The offset forms carry `Value::Number` and are unaffected.
-    let mut has_regex_substring = false;
-    let _: ControlFlow<()> = visit_expressions(stmt, |e: &SqlExpr| {
-        if let SqlExpr::Substring { substring_from: Some(from), .. } = e
-            && let SqlExpr::Value(vs) = &**from
-            && matches!(vs.value, Value::SingleQuotedString(_))
-        {
-            has_regex_substring = true;
+    let has_regex_substring = visit_expressions(stmt, |e: &SqlExpr| match e {
+        SqlExpr::Substring { substring_from: Some(from), .. } if matches!(&**from, SqlExpr::Value(vs) if matches!(vs.value, Value::SingleQuotedString(_))) => {
+            ControlFlow::Break(())
         }
-        ControlFlow::Continue(())
-    });
+        _ => ControlFlow::Continue(()),
+    })
+    .is_break();
     if has_regex_substring {
         return None;
     }
@@ -725,9 +719,8 @@ fn parameterize_statement(stmt: &Statement, base: usize, include_strings: bool) 
             // Expr::Literal — a `$N` placeholder slips past it and gets mis-cast to a
             // single-element list (COALESCE(list_col, '{a,b}') → ['{a,b}'] instead of
             // ['a','b']). Cheap to skip: array-literal COALESCE is not a hot cached path.
-            SqlExpr::Value(vs) => {
-                if include_strings
-                    && let Value::SingleQuotedString(s) = &vs.value
+            SqlExpr::Value(vs) if include_strings => {
+                if let Value::SingleQuotedString(s) = &vs.value
                     && !s.trim_start().starts_with('{')
                 {
                     vs.value = placeholder_for(&mut values, base, ScalarValue::Utf8(Some(s.clone())));
@@ -757,22 +750,24 @@ fn parameterize_statement(stmt: &Statement, base: usize, include_strings: bool) 
             // standalone Number (ordinals / LIMIT / OFFSET). Gated on
             // `include_strings`: the mixed now()+`$N` execute path calls with
             // `false` and binds only time-fn placeholders positionally, so it must
-            // not gain extra numeric placeholders.
-            SqlExpr::BinaryOp { left, right, .. } if include_strings => {
+            // not gain extra numeric placeholders. EVERY arm below this sentinel
+            // requires `include_strings` — the time-fn arm above deliberately does not.
+            _ if !include_strings => {}
+            SqlExpr::BinaryOp { left, right, .. } => {
                 take_number(left, base, &mut values);
                 take_number(right, base, &mut values);
             }
-            SqlExpr::UnaryOp { expr, .. } | SqlExpr::Nested(expr) | SqlExpr::Cast { expr, .. } if include_strings => take_number(expr, base, &mut values),
-            SqlExpr::Between { expr, low, high, .. } if include_strings => {
+            SqlExpr::UnaryOp { expr, .. } | SqlExpr::Nested(expr) | SqlExpr::Cast { expr, .. } => take_number(expr, base, &mut values),
+            SqlExpr::Between { expr, low, high, .. } => {
                 take_number(expr, base, &mut values);
                 take_number(low, base, &mut values);
                 take_number(high, base, &mut values);
             }
-            SqlExpr::InList { expr, list, .. } if include_strings => {
+            SqlExpr::InList { expr, list, .. } => {
                 take_number(expr, base, &mut values);
                 list.iter_mut().for_each(|e| take_number(e, base, &mut values));
             }
-            SqlExpr::Case { operand, conditions, else_result, .. } if include_strings => {
+            SqlExpr::Case { operand, conditions, else_result, .. } => {
                 // Walk order (operand → conditions → else) fixes `$N` numbering; keep it.
                 operand.iter_mut().for_each(|e| take_number(e, base, &mut values));
                 conditions.iter_mut().for_each(|w| {
@@ -781,7 +776,7 @@ fn parameterize_statement(stmt: &Statement, base: usize, include_strings: bool) 
                 });
                 else_result.iter_mut().for_each(|e| take_number(e, base, &mut values));
             }
-            SqlExpr::Function(f) if include_strings => {
+            SqlExpr::Function(f) => {
                 if let FunctionArguments::List(list) = &mut f.args {
                     list.args
                         .iter_mut()
@@ -868,7 +863,11 @@ impl PlanCacheHook {
     /// tells the handler to skip `state.optimize()`.
     fn mark_served(&self, canonical: &str) {
         self.shape_hits.fetch_add(1, Relaxed);
-        soft_cap(&self.served, SERVED_CAP);
+        // Soft cap: drop a random half. These texts are one-shot, so losing a
+        // memo only costs a redundant re-optimize.
+        if self.served.len() >= SERVED_CAP {
+            self.served.retain(|_, _| fastrand::bool());
+        }
         self.served.insert(canonical.to_string(), ());
     }
 
@@ -1158,6 +1157,8 @@ impl QueryHook for PlanCacheHook {
 
 #[cfg(test)]
 mod tests {
+    use test_case::test_case;
+
     use super::*;
 
     fn parse(sql: &str) -> Statement {
@@ -1214,37 +1215,19 @@ mod tests {
         assert!(!out.contains("COUNT(*)"), "no wildcard call survives: {out}");
     }
 
-    /// Only statements DataFusion rejects today may be rewritten — a working
-    /// query must keep its exact output column names. See `normalize_count_star`.
-    #[test]
-    fn normalize_count_star_never_touches_a_query_that_already_works() {
-        for sql in [
-            // No ORDER BY at all.
-            "SELECT COUNT(*)::int8 FROM t",
-            // Ordinal resolves to a BARE count(*), which DataFusion handles.
-            "SELECT src, COUNT(*) FROM t GROUP BY src ORDER BY 2 DESC",
-            // Ordinal points at a different select item than the wrapped count.
-            "SELECT src, COUNT(*)::int8 FROM t GROUP BY src ORDER BY 1 ASC",
-            // ORDER BY by name/alias already resolves.
-            "SELECT src, COUNT(*)::int8 AS c FROM t GROUP BY src ORDER BY c DESC",
-        ] {
-            assert!(normalize_count_star(&parse(sql)).is_none(), "must decline: {sql}");
-        }
-    }
-
-    /// A statement with nothing to rewrite must return `None` — that is what
-    /// keeps it on the ordinary cache path instead of forcing a fresh plan.
-    #[test]
-    fn normalize_count_star_declines_when_there_is_no_wildcard_count() {
-        for sql in [
-            "SELECT COUNT(id)::int8 FROM t ORDER BY 1",
-            "SELECT COUNT(DISTINCT level)::int8 FROM t ORDER BY 1",
-            "SELECT SUM(d)::int8 FROM t ORDER BY 1",
-            // A qualified wildcard is not the count(*) idiom and is left alone.
-            "SELECT COUNT(t.*)::int8 FROM t ORDER BY 1",
-        ] {
-            assert!(normalize_count_star(&parse(sql)).is_none(), "must decline: {sql}");
-        }
+    /// Only statements DataFusion rejects today may be rewritten: a working query
+    /// must keep its exact output column names, and declining is also what keeps
+    /// a statement on the ordinary cache path. See `normalize_count_star`.
+    #[test_case("SELECT COUNT(*)::int8 FROM t" ; "no order by at all")]
+    #[test_case("SELECT src, COUNT(*) FROM t GROUP BY src ORDER BY 2 DESC" ; "ordinal resolves to a bare count(*)")]
+    #[test_case("SELECT src, COUNT(*)::int8 FROM t GROUP BY src ORDER BY 1 ASC" ; "ordinal points elsewhere")]
+    #[test_case("SELECT src, COUNT(*)::int8 AS c FROM t GROUP BY src ORDER BY c DESC" ; "order by alias resolves")]
+    #[test_case("SELECT COUNT(id)::int8 FROM t ORDER BY 1" ; "counts a column")]
+    #[test_case("SELECT COUNT(DISTINCT level)::int8 FROM t ORDER BY 1" ; "count distinct")]
+    #[test_case("SELECT SUM(d)::int8 FROM t ORDER BY 1" ; "not a count at all")]
+    #[test_case("SELECT COUNT(t.*)::int8 FROM t ORDER BY 1" ; "qualified wildcard is not the idiom")]
+    fn normalize_count_star_declines(sql: &str) {
+        assert!(normalize_count_star(&parse(sql)).is_none(), "must decline: {sql}");
     }
 
     /// The reason this is an AST rewrite and not a text rewrite: monoscope

--- a/src/rollup.rs
+++ b/src/rollup.rs
@@ -141,27 +141,10 @@ pub fn build_partition_sql(spec: &RollupSpec, source: &str, project_id: &str, da
     build_partition_sql_from(spec, source, source, project_id, date)
 }
 
-/// `build_partition_sql`, but reading `from` instead of the raw source.
-///
-/// When `from` is a finer rollup the measures are re-aggregated as STATES —
-/// `SUM` of counts and sums, `MIN`/`MAX` of extrema, `tdigest_merge` of digests —
-/// and each measure's declared `filter` is deliberately NOT re-applied: the base
-/// row already had it applied when it was built, and the filter's columns do not
-/// even exist on the base table.
 /// One bit per hour of a UTC day. `ALL_HOURS` is the conservative value: every
 /// invalidation means it unless the caller can prove a narrower set.
 pub(crate) const ALL_HOURS: u32 = (1 << 24) - 1;
 
-/// The hours of a partition-day a committed file can hold rows for, from its
-/// Delta stats JSON (`minValues.timestamp` / `maxValues.timestamp`). `None`
-/// when stats or timestamp bounds are absent — the caller falls back to
-/// `ALL_HOURS`, never to skipping work. A computed mask of zero (bounds
-/// entirely outside the partition day) is likewise treated as absent.
-///
-/// This is what lets a boot reconcile invalidate the ONE hour a downtime
-/// commit actually touched instead of all 24 (`enqueue_maintenance_hours`
-/// with `ALL_HOURS` was ~312 durable tasks per active project per restart,
-/// prod 2026-08-18 — the queue's dominant growth source under deploy churn).
 /// The inclusive timestamp bounds a file's Delta statistics claim.
 ///
 /// Writers spell them either as epoch micros or RFC 3339, so both are accepted.
@@ -178,6 +161,16 @@ pub(crate) fn stats_time_range(stats: &str) -> Option<(i64, i64)> {
     Some((parse_ts("minValues")?, parse_ts("maxValues")?))
 }
 
+/// The hours of a partition-day a committed file can hold rows for, from its
+/// Delta stats JSON (`minValues.timestamp` / `maxValues.timestamp`). `None`
+/// when stats or timestamp bounds are absent — the caller falls back to
+/// `ALL_HOURS`, never to skipping work. A computed mask of zero (bounds
+/// entirely outside the partition day) is likewise treated as absent.
+///
+/// This is what lets a boot reconcile invalidate the ONE hour a downtime
+/// commit actually touched instead of all 24 (`enqueue_maintenance_hours`
+/// with `ALL_HOURS` was ~312 durable tasks per active project per restart,
+/// prod 2026-08-18 — the queue's dominant growth source under deploy churn).
 pub(crate) fn hours_from_stats_json(stats: &str, day_start_micros: i64) -> Option<u32> {
     let (lo, hi) = stats_time_range(stats)?;
     let (lo_h, hi_h) = ((lo - day_start_micros).div_euclid(HOUR_MICROS), (hi - day_start_micros).div_euclid(HOUR_MICROS));
@@ -198,17 +191,17 @@ pub(crate) fn dirty_ranges(day_start: i64, hours: u32) -> Vec<(i64, i64)> {
     )
 }
 
+/// `build_partition_sql`, but reading `from` instead of the raw source.
+///
+/// When `from` is a finer rollup the measures are re-aggregated as STATES —
+/// `SUM` of counts and sums, `MIN`/`MAX` of extrema, `tdigest_merge` of digests —
+/// and each measure's declared `filter` is deliberately NOT re-applied: the base
+/// row already had it applied when it was built, and the filter's columns do not
+/// even exist on the base table.
 pub fn build_partition_sql_from(spec: &RollupSpec, source: &str, from: &str, project_id: &str, date: &str) -> anyhow::Result<String> {
     build_partition_sql_ranges(spec, source, from, "", project_id, date, &[])
 }
 
-/// The partition's rows, rebuilt over `ranges` only and carried forward from
-/// `target` everywhere else. Empty `ranges` means the whole day, from scratch.
-///
-/// The carried-forward rows are re-emitted verbatim: they were aggregated from
-/// source rows that have not changed since, so re-aggregating them would produce
-/// the same numbers at the cost of scanning the raw partition again — which is
-/// the entire expense this exists to avoid.
 /// One measure's projection in a rollup build, as `<expression> AS <name>`.
 ///
 /// `derived` selects the tier-to-tier merge (folding the base tier's stored
@@ -221,7 +214,7 @@ pub fn build_partition_sql_from(spec: &RollupSpec, source: &str, from: &str, pro
 /// applied it when the state was built, and applying it twice over an
 /// aggregated column is not the same predicate.
 fn measure_projection(spec: &RollupSpec, measure: &RollupMeasure, derived: bool) -> anyhow::Result<String> {
-    if derived {
+    let (expression, filter) = if derived {
         let expression = match measure.agg.as_str() {
             "min" => format!("MIN({})", measure.name),
             "max" => format!("MAX({})", measure.name),
@@ -242,42 +235,68 @@ fn measure_projection(spec: &RollupSpec, measure: &RollupMeasure, derived: bool)
             ),
             _ => format!("SUM({})", measure.name),
         };
-        return Ok(format!("{expression} AS {}", measure.name));
-    }
-    let expression = match (measure.agg.as_str(), measure.column.as_deref()) {
-        ("count", None) => "COUNT(*)".to_string(),
-        ("count", Some(column)) => format!("COUNT({column})"),
-        ("tdigest", Some(column)) => format!("percentile_agg(CAST({column} AS DOUBLE))"),
-        ("hll", Some(column)) => format!("hll_agg({column})"),
-        // Built from raw, the ordering key is the row's own timestamp. The
-        // FILTER appended below applies to both, so the stored value and the
-        // companion describe the SAME row.
-        ("first", Some(column)) => format!("first_value({column} ORDER BY timestamp)"),
-        (aggregate, Some(column)) => format!("{}({column})", aggregate.to_uppercase()),
-        (aggregate, None) => return Err(anyhow::anyhow!("{} measure `{}` needs a source column", aggregate, measure.name)),
+        (expression, None)
+    } else {
+        let expression = match (measure.agg.as_str(), measure.column.as_deref()) {
+            ("count", None) => "COUNT(*)".to_string(),
+            ("count", Some(column)) => format!("COUNT({column})"),
+            ("tdigest", Some(column)) => format!("percentile_agg(CAST({column} AS DOUBLE))"),
+            ("hll", Some(column)) => format!("hll_agg({column})"),
+            // Built from raw, the ordering key is the row's own timestamp. The
+            // FILTER appended below applies to both, so the stored value and the
+            // companion describe the SAME row.
+            ("first", Some(column)) => format!("first_value({column} ORDER BY timestamp)"),
+            (aggregate, Some(column)) => format!("{}({column})", aggregate.to_uppercase()),
+            (aggregate, None) => return Err(anyhow::anyhow!("{} measure `{}` needs a source column", aggregate, measure.name)),
+        };
+        (expression, measure.filter.as_deref())
     };
-    Ok(match &measure.filter {
-        Some(filter) => format!("{expression} FILTER (WHERE {filter}) AS {}", measure.name),
-        None => format!("{expression} AS {}", measure.name),
-    })
+    Ok(format!("{} AS {}", filtered(expression, filter), measure.name))
 }
 
+/// `<expression> FILTER (WHERE …)`, or the bare expression. The build side, the
+/// raw leg and the `HAVING` guard all render a measure's declared filter, and
+/// they must render it identically.
+fn filtered(expression: String, filter: Option<&str>) -> String {
+    match filter {
+        Some(filter) => format!("{expression} FILTER (WHERE {filter})"),
+        None => expression,
+    }
+}
+
+/// The bucketed `timestamp`, the dimensions and the measures every rollup build
+/// selects, plus the `, dim…` fragment its carried-forward leg reuses.
+///
+/// ONE spelling of the bucket-floor formula: it was written out in both the
+/// per-project and the cohort builder, where the two had to stay in step by
+/// hand — the same way this file has already lost a caveat.
+fn bucketed_projection(spec: &RollupSpec, derived: bool, grain: i64) -> anyhow::Result<(String, String)> {
+    let dimensions = spec.dimensions.join(", ");
+    let select_dimensions = if dimensions.is_empty() { String::new() } else { format!(", {dimensions}") };
+    let measures = spec.measures.iter().map(|measure| measure_projection(spec, measure, derived)).collect::<anyhow::Result<Vec<_>>>()?.join(", ");
+    let projection = format!(
+        "to_timestamp_micros(CAST(FLOOR(EXTRACT(EPOCH FROM timestamp) * 1000000 / {grain}) AS BIGINT) * {grain}) AS timestamp{select_dimensions}, {measures}"
+    );
+    Ok((select_dimensions, projection))
+}
+
+/// The partition's rows, rebuilt over `ranges` only and carried forward from
+/// `target` everywhere else. Empty `ranges` means the whole day, from scratch.
+///
+/// The carried-forward rows are re-emitted verbatim: they were aggregated from
+/// source rows that have not changed since, so re-aggregating them would produce
+/// the same numbers at the cost of scanning the raw partition again — which is
+/// the entire expense this exists to avoid.
 pub(crate) fn build_partition_sql_ranges(
     spec: &RollupSpec, source: &str, from: &str, target: &str, project_id: &str, date: &str, ranges: &[(i64, i64)],
 ) -> anyhow::Result<String> {
     let grain = spec.grain_micros().ok_or_else(|| anyhow::anyhow!("invalid rollup grain `{}`", spec.grain))?;
-    let derived = from != source;
-    let dimensions = spec.dimensions.join(", ");
-    let measures = spec.measures.iter().map(|measure| measure_projection(spec, measure, derived)).collect::<anyhow::Result<Vec<_>>>()?.join(", ");
+    let (select_dimensions, projection) = bucketed_projection(spec, from != source, grain)?;
     let source = from;
-    let select_dimensions = if dimensions.is_empty() { String::new() } else { format!(", {dimensions}") };
     let group_by = (1..=1 + spec.dimensions.len()).join(", ");
 
     let partition = format!("project_id = {} AND date = {}", sql_literal(project_id), sql_literal(date));
-    let rebuilt = format!(
-        "SELECT to_timestamp_micros(CAST(FLOOR(EXTRACT(EPOCH FROM timestamp) * 1000000 / {grain}) AS BIGINT) * {grain}) AS timestamp{select_dimensions}, {measures} \
-         FROM {source} WHERE {partition}"
-    );
+    let rebuilt = format!("SELECT {projection} FROM {source} WHERE {partition}");
     if ranges.is_empty() {
         return Ok(format!("{rebuilt} GROUP BY {group_by}"));
     }
@@ -300,13 +319,11 @@ pub(crate) fn build_cohort_sql_range_mode(
         anyhow::bail!("rollup cohort has no projects");
     }
     let grain = spec.grain_micros().ok_or_else(|| anyhow::anyhow!("invalid rollup grain `{}`", spec.grain))?;
-    let dimensions = spec.dimensions.join(", ");
-    let measures = spec.measures.iter().map(|measure| measure_projection(spec, measure, derived)).collect::<anyhow::Result<Vec<_>>>()?.join(", ");
-    let select_dimensions = if dimensions.is_empty() { String::new() } else { format!(", {dimensions}") };
+    let (_, projection) = bucketed_projection(spec, derived, grain)?;
     let group_by = (1..=2 + spec.dimensions.len()).join(", ");
     let projects = project_ids.iter().map(|project| sql_literal(project)).join(", ");
     Ok(format!(
-        "SELECT project_id, to_timestamp_micros(CAST(FLOOR(EXTRACT(EPOCH FROM timestamp) * 1000000 / {grain}) AS BIGINT) * {grain}) AS timestamp{select_dimensions}, {measures} \
+        "SELECT project_id, {projection} \
          FROM {from} WHERE project_id IN ({projects}) AND date = {} AND timestamp >= to_timestamp_micros({start}) AND timestamp < to_timestamp_micros({end}) \
          GROUP BY {group_by}",
         sql_literal(date)
@@ -424,13 +441,14 @@ pub(crate) fn to_rollup_batches_by_project(
         let projects = batch.column_by_name("project_id").ok_or_else(|| anyhow::anyhow!("cohort aggregate is missing project_id"))?;
         let projects = cast(projects, &DataType::Utf8)?;
         let projects = projects.as_any().downcast_ref::<StringArray>().ok_or_else(|| anyhow::anyhow!("cohort project_id cannot cast to Utf8"))?;
-        let mut rows_by_project: std::collections::HashMap<&str, Vec<u32>> = std::collections::HashMap::new();
-        for row in 0..batch.num_rows() {
-            if projects.is_null(row) {
-                anyhow::bail!("cohort aggregate project_id is null");
-            }
-            rows_by_project.entry(projects.value(row)).or_default().push(u32::try_from(row)?);
-        }
+        let rows_by_project: std::collections::HashMap<&str, Vec<u32>> = (0..batch.num_rows())
+            .map(|row| match projects.is_null(row) {
+                true => Err(anyhow::anyhow!("cohort aggregate project_id is null")),
+                false => Ok((projects.value(row), u32::try_from(row)?)),
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?
+            .into_iter()
+            .into_group_map();
         for (project_id, rows) in rows_by_project {
             let indices = arrow::array::UInt32Array::from(rows);
             let columns = batch.columns().iter().map(|column| arrow::compute::take(column, &indices, None)).collect::<arrow::error::Result<Vec<_>>>()?;
@@ -483,7 +501,9 @@ impl Merge {
             Self::Max => "MAX",
             Self::TDigest => "tdigest_merge",
             Self::Hll => "hll_merge",
-            _ => "SUM",
+            // Exhaustive rather than a catch-all: a new state-carrying variant
+            // must state its operator instead of silently folding with SUM.
+            Self::Count | Self::Sum | Self::Avg | Self::First => "SUM",
         }
     }
 
@@ -562,6 +582,7 @@ const fn ceil_grain(value: i64, grain: i64) -> i64 {
 /// half of one cannot be given to a fringe. That alignment is the invariant the
 /// whole rewrite rests on — with `a` or `b` off-grain the legs either double
 /// count a bucket or drop one, and no aggregate can detect it afterwards.
+///
 /// Test-only: the single-interval shape, kept because the cost-floor and
 /// alignment cases read far more clearly against one range than a set.
 #[cfg(test)]
@@ -753,19 +774,17 @@ pub(crate) fn verify_slice_witness(witness: Option<SliceWitness>, source: LiveSo
     let (Some(witness), Some(files)) = (witness, source.files) else { return WitnessVerdict::Unverifiable };
     match witness {
         SliceWitness::Physical(rows) => verdict(rows, files.iter().fold(0, |sum, file| sum.saturating_add(file.rows))),
-        SliceWitness::PhysicalBelow { rows, bound } => {
-            let mut below = 0u64;
-            for file in files {
-                let (Some(min_ts), Some(max_ts)) = (file.min_ts, file.max_ts) else { return WitnessVerdict::Unverifiable };
-                if min_ts < bound && max_ts >= bound {
-                    return WitnessVerdict::Unverifiable;
+        SliceWitness::PhysicalBelow { rows, bound } => files
+            .iter()
+            // A file straddling the bound, or carrying no statistics, poisons the
+            // whole witness — see the straddle rule above.
+            .try_fold(0u64, |below, file| match (file.min_ts, file.max_ts) {
+                (Some(min_ts), Some(max_ts)) if !(min_ts < bound && max_ts >= bound) => {
+                    Ok(if max_ts < bound { below.saturating_add(file.rows) } else { below })
                 }
-                if max_ts < bound {
-                    below = below.saturating_add(file.rows);
-                }
-            }
-            verdict(rows, below)
-        }
+                _ => Err(WitnessVerdict::Unverifiable),
+            })
+            .map_or_else(std::convert::identity, |below| verdict(rows, below)),
         // The witness carries its own range so a count taken over a DIFFERENT
         // window cannot be mistaken for evidence about this one — the index is
         // per (project, date) and every slice of that date asks it a different
@@ -877,17 +896,15 @@ pub(crate) struct SliceDedup<'a> {
 
 /// The identity a generated rollup tier is physically written with.
 ///
-/// A tier's own `TableSchema` deliberately declares NO `dedup_keys` — see
-/// `RollupSpec::synthesize`, where doing so made every routed read plan a
-/// `DedupExec` over columns the rewrite does not project ("DedupExec key `id`
-/// not in input schema") and dropped every query back to a raw scan. That is a
-/// statement about the QUERY path. It is not true of the tier's bytes: a
-/// rebuild appends a new version of a bucket, and the replace-set that is meant
-/// to retire the old file skips any file carrying no slice tags — so partitions
-/// really do hold several versions of one `id` (prod 2026-08-20: 7.17 per id).
+/// A tier's own `TableSchema` declares `dedup_keys = [timestamp, id]` (see
+/// `RollupSpec::synthesize`), so the QUERY path collapses versions through the
+/// planner's `DedupExec`. It has to: a rebuild appends a new version of a
+/// bucket, and the replace-set that is meant to retire the old file skips any
+/// file carrying no slice tags — so partitions really do hold several versions
+/// of one `id` (prod 2026-08-20: 7.17 per id).
 ///
-/// So a MAINTENANCE read of a tier must collapse versions explicitly, without
-/// declaring keys the query planner would then act on.
+/// A MAINTENANCE read gets no such help — it registers the tier directly rather
+/// than through the routing table — so it must spell the same identity out.
 pub(crate) fn rollup_tier_dedup(schema: &crate::schema::TableSchema) -> Option<(Vec<String>, &'static str, Option<&str>)> {
     let has = |name: &str| schema.fields.iter().any(|field| field.name == name);
     (has("timestamp") && has("id") && has("updated_at"))
@@ -966,10 +983,8 @@ pub(crate) fn slice_retires(file: &LiveFile<'_>, publish: &SlicePublish<'_>) -> 
 /// `hi` is INCLUSIVE — it is a row's timestamp, straight from file statistics —
 /// while a slice's end is exclusive, so a range must reach strictly past `hi`.
 pub(crate) fn ranges_cover(ranges: &[(i64, i64)], (lo, hi): (i64, i64)) -> bool {
-    let mut sorted: Vec<(i64, i64)> = ranges.to_vec();
-    sorted.sort_unstable();
     let mut reached = lo;
-    for (start, end) in sorted {
+    for (start, end) in ranges.iter().copied().sorted() {
         if start > reached {
             return false;
         }
@@ -998,8 +1013,7 @@ pub(crate) fn ranges_cover(ranges: &[(i64, i64)], (lo, hi): (i64, i64)) -> bool 
 /// Ends are EXCLUSIVE here, but a file's statistics `hi` is a row timestamp, so
 /// callers pass `hi + 1`.
 pub(crate) fn uncovered_gaps(untagged: &[(i64, i64)], tagged: &[(i64, i64)]) -> Vec<(i64, i64)> {
-    let mut covered = tagged.to_vec();
-    covered.sort_unstable();
+    let covered = tagged.iter().copied().sorted().collect_vec();
     let mut gaps: Vec<(i64, i64)> = Vec::new();
     for &(lo, hi) in untagged {
         let mut reached = lo;
@@ -1173,8 +1187,8 @@ pub(crate) fn slice_input_sql(
     present: Option<&std::collections::HashSet<String>>,
 ) -> String {
     let window = format!(
-        "WHERE project_id = '{}' AND timestamp >= to_timestamp_micros({start}) AND timestamp < to_timestamp_micros({end}){shard_predicate}",
-        project_id.replace('\'', "''")
+        "WHERE project_id = {} AND timestamp >= to_timestamp_micros({start}) AND timestamp < to_timestamp_micros({end}){shard_predicate}",
+        sql_literal(project_id)
     );
     // `NULL AS x` for a column the provider lacks, `x` otherwise.
     let projected = |field: &crate::schema::FieldDef| match present {
@@ -1421,12 +1435,11 @@ impl RoutedRollup {
         let group_by = self.group_by();
         let having =
             self.guard.as_ref().map_or_else(String::new, |guard| format!(" HAVING {} > 0", guard.merge.sql(&[format!("__s{}_0", self.measures.len())])));
-        let mut legs = vec![self.leg(&self.target, interiors, &generations, &rollup_projects)];
-        if !fringes.is_empty() {
-            legs.push(self.leg(&self.source, &fringes, "", &rollup_projects));
-        }
-        legs.extend(raw_only_leg);
-        format!("SELECT {outer} FROM ({}) AS rollup_union{group_by}{having}", legs.join(" UNION ALL "))
+        let legs = std::iter::once(self.leg(&self.target, interiors, &generations, &rollup_projects))
+            .chain((!fringes.is_empty()).then(|| self.leg(&self.source, &fringes, "", &rollup_projects)))
+            .chain(raw_only_leg)
+            .join(" UNION ALL ");
+        format!("SELECT {outer} FROM ({legs}) AS rollup_union{group_by}{having}")
     }
 }
 
@@ -1525,9 +1538,9 @@ fn simplify_filtered_group(
 /// exactly; anything else declines rather than guessing a type.
 fn epoch_of(expr: &datafusion::logical_expr::Expr) -> Option<(&datafusion::logical_expr::Expr, Option<&'static str>)> {
     use datafusion::logical_expr::Expr;
-    let (expr, cast) = match expr {
-        Expr::Alias(alias) => (alias.expr.as_ref(), None),
-        expr => (expr, None),
+    let expr = match expr {
+        Expr::Alias(alias) => alias.expr.as_ref(),
+        expr => expr,
     };
     let (expr, cast) = match expr {
         Expr::Cast(inner) => (
@@ -1538,7 +1551,7 @@ fn epoch_of(expr: &datafusion::logical_expr::Expr) -> Option<(&datafusion::logic
                 _ => return None,
             }),
         ),
-        expr => (expr, cast),
+        expr => (expr, None),
     };
     let Expr::ScalarFunction(function) = unaliased(expr) else { return None };
     (function.name().eq_ignore_ascii_case("date_part")
@@ -1692,12 +1705,10 @@ fn canonical(expr: &datafusion::logical_expr::Expr) -> String {
             if binary.op == Operator::And {
                 strip_index_hints(&mut operands);
             }
-            let mut terms = operands.into_iter().map(canonical).collect::<Vec<_>>();
-            terms.sort();
             // Idempotence, at EVERY level rather than only the outermost one:
             // the duplicated conjuncts observed in prod were nested inside an OR
             // branch, where a top-level dedupe cannot reach them.
-            terms.dedup();
+            let mut terms = operands.into_iter().map(canonical).sorted().dedup().collect_vec();
             // Stripping or deduping can leave one operand, and a one-element
             // conjunction IS that operand — `((X))` must not differ from `(X)`.
             if terms.len() == 1 {
@@ -1765,8 +1776,6 @@ fn strip_index_hints(operands: &mut Vec<&datafusion::logical_expr::Expr>) {
 }
 
 fn canonical_and<'a>(expressions: impl IntoIterator<Item = &'a datafusion::logical_expr::Expr>) -> String {
-    let mut expressions = expressions.into_iter().map(canonical).collect::<Vec<_>>();
-    expressions.sort();
     // AND is idempotent, so `X AND X` must canonicalize to `X`. Both sides
     // genuinely do repeat conjuncts: the optimizer leaves a predicate on the
     // Filter node AND re-pushes it into the TableScan's `partial_filters`, so
@@ -1774,8 +1783,7 @@ fn canonical_and<'a>(expressions: impl IntoIterator<Item = &'a datafusion::logic
     // every declared filter printed as `(X) AND (X)`). It happened to cancel
     // out while both sides duplicated equally, which is precisely the kind of
     // accident that stops holding the moment one side is shaped differently.
-    expressions.dedup();
-    expressions.join(" AND ")
+    expressions.into_iter().map(canonical).sorted().dedup().join(" AND ")
 }
 
 fn parse_bucket_micros(value: &str) -> Option<i64> {
@@ -2493,199 +2501,206 @@ async fn route_with_spec(
         return Err(MissReason::TinyInterior);
     }
 
-    let mut groups = Vec::new();
-    for (index, expression) in aggregate.group_expr.iter().enumerate() {
-        let alias = aggregate.schema.field(index).name();
-        let simplified = simplify_filtered_group(expression, predicates, &spec.dimensions).map_err(|_| MissReason::UnsupportedShape)?;
-        let expression = &simplified;
-        // monoscope's chart SQL groups by `extract(epoch from time_bucket(w,
-        // timestamp))::integer`, never by the bare bucket, so every percentile
-        // and grouped panel declined as `unsupported_shape` and scanned raw —
-        // 3,525 ms against 278 ms routed at 3 days (2026-08-22 A/B).
-        //
-        // Epoch-of-bucket is injective on the bucket, so the grouping is
-        // identical and only the spelling differs. The wrapper is REPRODUCED
-        // rather than lifted: the rewrite is substituted for this aggregate and
-        // must match its schema types, so dropping a cast here would fail
-        // `has_equivalent_names_and_types` instead of routing.
-        let epoch_wrapped = epoch_of(expression);
-        let expression = match epoch_wrapped.map_or_else(|| unaliased(expression), |(inner, _)| inner) {
-            // `project_id` is not a declared dimension — it is the partition
-            // column, written on every rollup row by `to_rollup_batches` — but
-            // it groups exactly like one.
-            Expr::Column(column) if column.name == "project_id" || spec.dimensions.iter().any(|dimension| dimension == &column.name) => column.name.clone(),
-            Expr::ScalarFunction(function)
-                if function.name().eq_ignore_ascii_case("time_bucket") && function.args.len() == 2 && column_name(&function.args[1]) == Some("timestamp") =>
-            {
-                let interval = string_literal(&function.args[0]).ok_or(MissReason::UnsupportedShape)?;
-                let width = parse_bucket_micros(interval).ok_or(MissReason::UnsupportedShape)?;
-                // A width that is not a whole number of grains would make one
-                // rollup row straddle two output buckets, and no state can be
-                // split across them. Raw fringes do not change this: the
-                // interior is still answered by whole rollup rows.
-                if width < grain || width % grain != 0 {
-                    return Err(MissReason::PartialBucket);
-                }
-                format!("time_bucket({}, timestamp)", sql_literal(interval))
-            }
-            // monoscope spells EVERY grouped chart's dimension
-            // `COALESCE(<dimension>, 'null')`, so the bare-column arm above
-            // never matched one and every such panel scanned raw — 3,237 ms
-            // against 276 ms routed at 3 days (2026-08-22 A/B).
+    let groups = aggregate
+        .group_expr
+        .iter()
+        .enumerate()
+        .map(|(index, expression)| {
+            let alias = aggregate.schema.field(index).name();
+            let simplified = simplify_filtered_group(expression, predicates, &spec.dimensions).map_err(|_| MissReason::UnsupportedShape)?;
+            let expression = &simplified;
+            // monoscope's chart SQL groups by `extract(epoch from time_bucket(w,
+            // timestamp))::integer`, never by the bare bucket, so every percentile
+            // and grouped panel declined as `unsupported_shape` and scanned raw —
+            // 3,525 ms against 278 ms routed at 3 days (2026-08-22 A/B).
             //
-            // Sound because `COALESCE(dim, lit)` is a FUNCTION of `dim`: the
-            // rollup's partition by `dim` therefore REFINES the partition by
-            // `COALESCE(dim, lit)`, and re-aggregating decomposable states over
-            // a refinement equals aggregating the raw rows. So the expression is
-            // emitted verbatim onto both legs and NULL needs no special case —
-            // the NULL cell and the literal-'null' cell simply merge, exactly as
-            // the raw rows do.
-            other
-                if coalesced_column(other).is_some_and(|(column, _)| column == "project_id" || spec.dimensions.iter().any(|dimension| dimension == column)) =>
-            {
-                let (column, fallback) = coalesced_column(other).ok_or(MissReason::UnsupportedShape)?;
-                format!("COALESCE({column}, {})", sql_literal(fallback))
-            }
-            Expr::Column(_) => return Err(MissReason::UnknownGroupBy),
-            _ => return Err(MissReason::UnsupportedShape),
-        };
-        // Only the bucket may wear the epoch wrapper; a dimension grouped by
-        // `extract(epoch …)` is nonsense and must not be silently accepted.
-        let expression = match epoch_wrapped {
-            Some((_, cast)) if expression.starts_with("time_bucket(") => {
-                let epoch = format!("date_part('EPOCH', {expression})");
-                match cast {
-                    Some(sql_type) => format!("CAST({epoch} AS {sql_type})"),
-                    None => epoch,
+            // Epoch-of-bucket is injective on the bucket, so the grouping is
+            // identical and only the spelling differs. The wrapper is REPRODUCED
+            // rather than lifted: the rewrite is substituted for this aggregate and
+            // must match its schema types, so dropping a cast here would fail
+            // `has_equivalent_names_and_types` instead of routing.
+            let epoch_wrapped = epoch_of(expression);
+            let expression = match epoch_wrapped.map_or_else(|| unaliased(expression), |(inner, _)| inner) {
+                // `project_id` is not a declared dimension — it is the partition
+                // column, written on every rollup row by `to_rollup_batches` — but
+                // it groups exactly like one.
+                Expr::Column(column) if column.name == "project_id" || spec.dimensions.iter().any(|dimension| dimension == &column.name) => column.name.clone(),
+                Expr::ScalarFunction(function)
+                    if function.name().eq_ignore_ascii_case("time_bucket")
+                        && function.args.len() == 2
+                        && column_name(&function.args[1]) == Some("timestamp") =>
+                {
+                    let interval = string_literal(&function.args[0]).ok_or(MissReason::UnsupportedShape)?;
+                    let width = parse_bucket_micros(interval).ok_or(MissReason::UnsupportedShape)?;
+                    // A width that is not a whole number of grains would make one
+                    // rollup row straddle two output buckets, and no state can be
+                    // split across them. Raw fringes do not change this: the
+                    // interior is still answered by whole rollup rows.
+                    if width < grain || width % grain != 0 {
+                        return Err(MissReason::PartialBucket);
+                    }
+                    format!("time_bucket({}, timestamp)", sql_literal(interval))
                 }
-            }
-            Some(_) => return Err(MissReason::UnsupportedShape),
-            None => expression,
-        };
-        groups.push((expression, alias.to_string()));
-    }
+                // monoscope spells EVERY grouped chart's dimension
+                // `COALESCE(<dimension>, 'null')`, so the bare-column arm above
+                // never matched one and every such panel scanned raw — 3,237 ms
+                // against 276 ms routed at 3 days (2026-08-22 A/B).
+                //
+                // Sound because `COALESCE(dim, lit)` is a FUNCTION of `dim`: the
+                // rollup's partition by `dim` therefore REFINES the partition by
+                // `COALESCE(dim, lit)`, and re-aggregating decomposable states over
+                // a refinement equals aggregating the raw rows. So the expression is
+                // emitted verbatim onto both legs and NULL needs no special case —
+                // the NULL cell and the literal-'null' cell simply merge, exactly as
+                // the raw rows do.
+                other
+                    if coalesced_column(other)
+                        .is_some_and(|(column, _)| column == "project_id" || spec.dimensions.iter().any(|dimension| dimension == column)) =>
+                {
+                    let (column, fallback) = coalesced_column(other).ok_or(MissReason::UnsupportedShape)?;
+                    format!("COALESCE({column}, {})", sql_literal(fallback))
+                }
+                Expr::Column(_) => return Err(MissReason::UnknownGroupBy),
+                _ => return Err(MissReason::UnsupportedShape),
+            };
+            // Only the bucket may wear the epoch wrapper; a dimension grouped by
+            // `extract(epoch …)` is nonsense and must not be silently accepted.
+            let expression = match epoch_wrapped {
+                Some((_, cast)) if expression.starts_with("time_bucket(") => {
+                    let epoch = format!("date_part('EPOCH', {expression})");
+                    match cast {
+                        Some(sql_type) => format!("CAST({epoch} AS {sql_type})"),
+                        None => epoch,
+                    }
+                }
+                Some(_) => return Err(MissReason::UnsupportedShape),
+                None => expression,
+            };
+            Ok((expression, alias.to_string()))
+        })
+        .collect::<Result<Vec<_>, MissReason>>()?;
 
-    let mut measures = Vec::new();
-    for (index, expression) in aggregate.aggr_expr.iter().enumerate() {
-        let alias = aggregate.schema.field(aggregate.group_expr.len() + index).name().to_string();
-        let Expr::AggregateFunction(function) = unaliased(expression) else { return Err(MissReason::NonDecomposableAggregate) };
-        // An ORDER BY inside an aggregate makes it depend on row order, which no
-        // partial state can carry -- with one exception. `first_value(x ORDER BY
-        // timestamp)` orders by the very axis the rollup buckets on, so the
-        // earliest row of the earliest bucket IS the earliest row overall, and a
-        // (value, timestamp) pair merges associatively. Nothing else is relaxed:
-        // ordering by any other column, or DESC, still declines.
-        let ordered_by_timestamp = function.func.name().eq_ignore_ascii_case("first_value")
-            && matches!(
-                function.params.order_by.as_slice(),
-                [sort] if column_name(&sort.expr) == Some("timestamp") && sort.asc
-            );
-        if function.params.distinct || (!function.params.order_by.is_empty() && !ordered_by_timestamp) {
-            return Err(MissReason::NonDecomposableAggregate);
-        }
-        // The promoted conjuncts join the aggregate's own, so a `count(*) FILTER
-        // (WHERE status_code = 'ERROR' …)` under the `server` row filter resolves
-        // to `server_error_count`, which is declared as exactly that conjunction.
-        let filter = canonical_and(function.params.filter.iter().flat_map(|filter| split_conjunction(filter.as_ref())).chain(promotable.iter().copied()));
-        let name = function.func.name().to_ascii_lowercase();
-        let column = function.params.args.first().and_then(column_name).map(str::to_string);
-        // Dropping `col IS NOT NULL` is only sound for aggregates that skip nulls
-        // over THAT column. `SELECT count(*), p95(duration) … WHERE duration IS NOT
-        // NULL` is real monoscope traffic (the top-K tables) and its `count(*)`
-        // counts only rows with a duration, where `request_count` counts them all.
-        //
-        // `count(*)` is the one aggregate that can be REWRITTEN to satisfy the
-        // guard instead of being refused by it: under `col IS NOT NULL`,
-        // `count(*) ≡ count(col)`. The guard was set aside above rather than
-        // pushed, so neither leg re-applies it — and `{agg: count, column: col}`
-        // skips exactly the rows the predicate excluded, while the raw leg emits
-        // `COUNT(col)` for the same measure. Before this, monoscope's log-explorer
-        // latency widget (`count(*)` folded in from `HAVING COUNT(*) > 0` beside
-        // `percentile_agg(duration)`) was refused outright and scanned 7 days raw.
-        //
-        // This was briefly withheld from queries also carrying a `percentile_agg`,
-        // because cells built before the 2026-08-22 spec change hold no
-        // `duration_digest` COLUMN and the reader null-fills it, so a routed
-        // latency chart rendered a hole over the rollup interior. That stopgap is
-        // gone: `TAG_MEASURES` now records what each cell MATERIALIZED and
-        // `Database::rollup_rewrite_for` gates both coverage paths on
-        // `RoutedRollup::measures_available`, so a date or slice that cannot prove
-        // the digest falls to the raw fringe while its siblings keep routing —
-        // pinned by `a_date_that_cannot_prove_its_digest_falls_to_the_raw_fringe`
-        // in `src/database/mod.rs`, which covers this widget's exact shape.
-        let column = match (column, null_guard) {
-            (None, Some(guard)) if name == "count" => Some(guard.to_string()),
-            (column, _) => column,
-        };
-        if null_guard.is_some() && column.as_deref() != null_guard {
-            return Err(MissReason::FilterNullGuardMismatch);
-        }
-        let measure = |aggregate: &str, column: Option<&str>| {
-            configured_filters
-                .iter()
-                .find(|(measure, measure_filter)| measure.agg == aggregate && measure.column.as_deref() == column && *measure_filter == filter)
-                .map(|(measure, _)| *measure)
-        };
-        // The raw leg reproduces the measure's DECLARED filter text verbatim.
-        // The matcher has already proven the query's aggregate filter
-        // canonicalizes to the same predicate, so this is exact — and it avoids
-        // unparsing an optimized `Expr` back into SQL.
-        let raw = |expression: String, declared: Option<&String>| match declared {
-            Some(filter) => format!("{expression} FILTER (WHERE {filter})"),
-            None => expression,
-        };
-        let (merge, resolved) = match name.as_str() {
-            "count" => (Merge::Count, measure("count", column.as_deref()).map(|m| vec![m])),
-            "sum" => (Merge::Sum, measure("sum", column.as_deref()).map(|m| vec![m])),
-            "min" => (Merge::Min, measure("min", column.as_deref()).map(|m| vec![m])),
-            "max" => (Merge::Max, measure("max", column.as_deref()).map(|m| vec![m])),
-            "avg" => (Merge::Avg, measure("sum", column.as_deref()).zip(measure("count", column.as_deref())).map(|(sum, count)| vec![sum, count])),
-            "percentile_agg" => (Merge::TDigest, measure("tdigest", column.as_deref()).map(|m| vec![m])),
-            // `hll_agg`, a.k.a. Toolkit's `approx_count_distinct`. It behaves
-            // exactly like `percentile_agg` above: the aggregate yields the STATE
-            // and the scalar that reads a number out of it (`distinct_count`)
-            // sits above, untouched. DataFusion's own `approx_distinct` is NOT
-            // routed — it returns a bare count with no state to store. Exact
-            // `COUNT(DISTINCT x)` stays non-decomposable and is still declined;
-            // approximating it without being asked is what the measure list
-            // refuses to do.
-            "hll_agg" => (Merge::Hll, measure("hll", column.as_deref()).map(|m| vec![m])),
-            // Resolves to a PAIR, exactly as `avg` resolves to sum/count: the
-            // stored value plus the companion `min(timestamp)` that says which
-            // row it came from. `RollupSpec::validate` guarantees a `first`
-            // measure cannot be declared without its companion, so a spec that
-            // reaches here either resolves both or neither.
-            //
-            // Declines under a null guard. The guard is set aside rather than
-            // applied to either leg, which is only sound for aggregates that
-            // skip nulls over the guarded column -- and `first_value` does not:
-            // it returns the earliest row's value even when that value is NULL.
-            "first_value" if null_guard.is_none() => {
-                (Merge::First, measure("first", column.as_deref()).zip(measure("min", Some("timestamp"))).map(|(first, at)| vec![first, at]))
+    let measures = aggregate
+        .aggr_expr
+        .iter()
+        .enumerate()
+        .map(|(index, expression)| {
+            let alias = aggregate.schema.field(aggregate.group_expr.len() + index).name().to_string();
+            let Expr::AggregateFunction(function) = unaliased(expression) else { return Err(MissReason::NonDecomposableAggregate) };
+            // An ORDER BY inside an aggregate makes it depend on row order, which no
+            // partial state can carry -- with one exception. `first_value(x ORDER BY
+            // timestamp)` orders by the very axis the rollup buckets on, so the
+            // earliest row of the earliest bucket IS the earliest row overall, and a
+            // (value, timestamp) pair merges associatively. Nothing else is relaxed:
+            // ordering by any other column, or DESC, still declines.
+            let ordered_by_timestamp = function.func.name().eq_ignore_ascii_case("first_value")
+                && matches!(
+                    function.params.order_by.as_slice(),
+                    [sort] if column_name(&sort.expr) == Some("timestamp") && sort.asc
+                );
+            if function.params.distinct || (!function.params.order_by.is_empty() && !ordered_by_timestamp) {
+                return Err(MissReason::NonDecomposableAggregate);
             }
-            _ => return Err(MissReason::NonDecomposableAggregate),
-        };
-        let resolved = resolved.ok_or(MissReason::MissingMeasure)?;
-        debug_assert_eq!(resolved.len(), merge.arity(), "{merge:?} resolved the wrong number of measures");
-        let raw = resolved
-            .iter()
-            .map(|measure| {
-                let aggregate = measure.agg.to_uppercase();
-                let expression = match (merge, measure.column.as_deref()) {
-                    (Merge::TDigest, Some(column)) => format!("percentile_agg(CAST({column} AS DOUBLE))"),
-                    (Merge::Hll, Some(column)) => format!("hll_agg({column})"),
-                    // The companion of a `first` pair is an ordinary `min`
-                    // measure, so it renders through the general arm below;
-                    // only the value state needs the ordered spelling.
-                    (Merge::First, Some(column)) if measure.agg == "first" => format!("first_value({column} ORDER BY timestamp)"),
-                    (_, None) => "COUNT(*)".to_string(),
-                    (_, Some(column)) => format!("{aggregate}({column})"),
-                };
-                raw(expression, measure.filter.as_ref())
-            })
-            .collect();
-        measures.push(RoutedMeasure { alias, merge, measures: resolved.iter().map(|measure| measure.name.clone()).collect(), raw });
-    }
+            // The promoted conjuncts join the aggregate's own, so a `count(*) FILTER
+            // (WHERE status_code = 'ERROR' …)` under the `server` row filter resolves
+            // to `server_error_count`, which is declared as exactly that conjunction.
+            let filter = canonical_and(function.params.filter.iter().flat_map(|filter| split_conjunction(filter.as_ref())).chain(promotable.iter().copied()));
+            let name = function.func.name().to_ascii_lowercase();
+            let column = function.params.args.first().and_then(column_name).map(str::to_string);
+            // Dropping `col IS NOT NULL` is only sound for aggregates that skip nulls
+            // over THAT column. `SELECT count(*), p95(duration) … WHERE duration IS NOT
+            // NULL` is real monoscope traffic (the top-K tables) and its `count(*)`
+            // counts only rows with a duration, where `request_count` counts them all.
+            //
+            // `count(*)` is the one aggregate that can be REWRITTEN to satisfy the
+            // guard instead of being refused by it: under `col IS NOT NULL`,
+            // `count(*) ≡ count(col)`. The guard was set aside above rather than
+            // pushed, so neither leg re-applies it — and `{agg: count, column: col}`
+            // skips exactly the rows the predicate excluded, while the raw leg emits
+            // `COUNT(col)` for the same measure. Before this, monoscope's log-explorer
+            // latency widget (`count(*)` folded in from `HAVING COUNT(*) > 0` beside
+            // `percentile_agg(duration)`) was refused outright and scanned 7 days raw.
+            //
+            // This was briefly withheld from queries also carrying a `percentile_agg`,
+            // because cells built before the 2026-08-22 spec change hold no
+            // `duration_digest` COLUMN and the reader null-fills it, so a routed
+            // latency chart rendered a hole over the rollup interior. That stopgap is
+            // gone: `TAG_MEASURES` now records what each cell MATERIALIZED and
+            // `Database::rollup_rewrite_for` gates both coverage paths on
+            // `RoutedRollup::measures_available`, so a date or slice that cannot prove
+            // the digest falls to the raw fringe while its siblings keep routing —
+            // pinned by `a_date_that_cannot_prove_its_digest_falls_to_the_raw_fringe`
+            // in `src/database/mod.rs`, which covers this widget's exact shape.
+            let column = match (column, null_guard) {
+                (None, Some(guard)) if name == "count" => Some(guard.to_string()),
+                (column, _) => column,
+            };
+            if null_guard.is_some() && column.as_deref() != null_guard {
+                return Err(MissReason::FilterNullGuardMismatch);
+            }
+            let measure = |aggregate: &str, column: Option<&str>| {
+                configured_filters
+                    .iter()
+                    .find(|(measure, measure_filter)| measure.agg == aggregate && measure.column.as_deref() == column && *measure_filter == filter)
+                    .map(|(measure, _)| *measure)
+            };
+            let (merge, resolved) = match name.as_str() {
+                "count" => (Merge::Count, measure("count", column.as_deref()).map(|m| vec![m])),
+                "sum" => (Merge::Sum, measure("sum", column.as_deref()).map(|m| vec![m])),
+                "min" => (Merge::Min, measure("min", column.as_deref()).map(|m| vec![m])),
+                "max" => (Merge::Max, measure("max", column.as_deref()).map(|m| vec![m])),
+                "avg" => (Merge::Avg, measure("sum", column.as_deref()).zip(measure("count", column.as_deref())).map(|(sum, count)| vec![sum, count])),
+                "percentile_agg" => (Merge::TDigest, measure("tdigest", column.as_deref()).map(|m| vec![m])),
+                // `hll_agg`, a.k.a. Toolkit's `approx_count_distinct`. It behaves
+                // exactly like `percentile_agg` above: the aggregate yields the STATE
+                // and the scalar that reads a number out of it (`distinct_count`)
+                // sits above, untouched. DataFusion's own `approx_distinct` is NOT
+                // routed — it returns a bare count with no state to store. Exact
+                // `COUNT(DISTINCT x)` stays non-decomposable and is still declined;
+                // approximating it without being asked is what the measure list
+                // refuses to do.
+                "hll_agg" => (Merge::Hll, measure("hll", column.as_deref()).map(|m| vec![m])),
+                // Resolves to a PAIR, exactly as `avg` resolves to sum/count: the
+                // stored value plus the companion `min(timestamp)` that says which
+                // row it came from. `RollupSpec::validate` guarantees a `first`
+                // measure cannot be declared without its companion, so a spec that
+                // reaches here either resolves both or neither.
+                //
+                // Declines under a null guard. The guard is set aside rather than
+                // applied to either leg, which is only sound for aggregates that
+                // skip nulls over the guarded column -- and `first_value` does not:
+                // it returns the earliest row's value even when that value is NULL.
+                "first_value" if null_guard.is_none() => {
+                    (Merge::First, measure("first", column.as_deref()).zip(measure("min", Some("timestamp"))).map(|(first, at)| vec![first, at]))
+                }
+                _ => return Err(MissReason::NonDecomposableAggregate),
+            };
+            let resolved = resolved.ok_or(MissReason::MissingMeasure)?;
+            debug_assert_eq!(resolved.len(), merge.arity(), "{merge:?} resolved the wrong number of measures");
+            // The raw leg reproduces the measure's DECLARED filter text verbatim.
+            // The matcher has already proven the query's aggregate filter
+            // canonicalizes to the same predicate, so this is exact — and it avoids
+            // unparsing an optimized `Expr` back into SQL.
+            let raw = resolved
+                .iter()
+                .map(|measure| {
+                    let aggregate = measure.agg.to_uppercase();
+                    let expression = match (merge, measure.column.as_deref()) {
+                        (Merge::TDigest, Some(column)) => format!("percentile_agg(CAST({column} AS DOUBLE))"),
+                        (Merge::Hll, Some(column)) => format!("hll_agg({column})"),
+                        // The companion of a `first` pair is an ordinary `min`
+                        // measure, so it renders through the general arm below;
+                        // only the value state needs the ordered spelling.
+                        (Merge::First, Some(column)) if measure.agg == "first" => format!("first_value({column} ORDER BY timestamp)"),
+                        (_, None) => "COUNT(*)".to_string(),
+                        (_, Some(column)) => format!("{aggregate}({column})"),
+                    };
+                    filtered(expression, measure.filter.as_deref())
+                })
+                .collect();
+            Ok(RoutedMeasure { alias, merge, measures: resolved.iter().map(|measure| measure.name.clone()).collect(), raw })
+        })
+        .collect::<Result<Vec<_>, MissReason>>()?;
 
     let guard = guard.map(|measure| RoutedMeasure {
         alias: "__guard".to_string(),
@@ -2694,13 +2709,7 @@ async fn route_with_spec(
         // `COUNT(col)` when the guard carries one — the raw leg must eliminate the
         // same buckets the rollup leg's `HAVING sum(count(col)) > 0` does, and
         // `COUNT(*)` there would keep an all-null bucket the rollup drops.
-        raw: vec![{
-            let counted = measure.column.as_deref().map_or_else(|| "COUNT(*)".to_string(), |column| format!("COUNT({column})"));
-            match measure.filter.as_ref() {
-                Some(filter) => format!("{counted} FILTER (WHERE {filter})"),
-                None => counted,
-            }
-        }],
+        raw: vec![filtered(measure.column.as_deref().map_or_else(|| "COUNT(*)".to_string(), |column| format!("COUNT({column})")), measure.filter.as_deref())],
     });
 
     Ok(RoutedRollup {
@@ -3302,8 +3311,6 @@ mod tests {
         assert!(target.fields.iter().any(|field| field.name == "rollup_generation"));
         assert_eq!(target.partitions, source.partitions);
         assert!(!target.version_append);
-        // A rollup must declare NO dedup keys. `replace_rollup_partition` removes
-        // every existing file in the partition in the same commit that adds the
         // Both tiers get the SAME identity, base and derived alike. The
         // asymmetry that preceded this — a derived tier protected by its input
         // collapse while the base tier had no read-time defence at all — is what
@@ -3569,12 +3576,6 @@ mod tests {
         assert_substitutes(&state, &sql, None).await;
     }
 
-    /// The same chart with the `::text` cast monoscope actually emits. The cast
-    /// is the whole difference: `COALESCE(col, 'null')` repeats a bare column,
-    /// which CSE leaves alone, while `COALESCE(col::text, 'null')` repeats a
-    /// COMPUTATION and gets lifted into `__common_expr_1` — so the test above
-    /// passed for a year while every real panel declined. Prod 2026-08-25:
-    /// 39.2s here against 4.25s for the bare-column spelling, 7 days, one project.
     /// A measure on the not-yet-servable list is refused on a TAGGED cell, not
     /// merely an untagged one. The tag proves the COLUMN existed; it cannot prove
     /// a VALUE was written, and `distinct_count` of an empty sketch is 0 — so a
@@ -3596,6 +3597,13 @@ mod tests {
         assert!(!route.measures_available(None), "and an untagged cell must not either");
     }
 
+    /// The same chart with the `::text` cast monoscope actually emits. The cast
+    /// is the whole difference: `COALESCE(col, 'null')` repeats a bare column,
+    /// which CSE leaves alone, while `COALESCE(col::text, 'null')` repeats a
+    /// COMPUTATION and gets lifted into `__common_expr_1` — so the bare-column
+    /// test above passed for a year while every real panel declined. Prod
+    /// 2026-08-25: 39.2s here against 4.25s for the bare spelling, 7 days, one
+    /// project.
     #[tokio::test]
     async fn a_grouped_chart_casting_its_dimension_routes_despite_cse() {
         let state = session().await;

--- a/src/rollup_journal.rs
+++ b/src/rollup_journal.rs
@@ -30,6 +30,8 @@ pub struct RollupInvalidation {
     pub invalidated_unix_ms: u64,
 }
 
+// Generic over `entries` so `store` can serialize a borrowed slice without
+// cloning into a `Vec` (the default, used for deserializing in `load`).
 #[derive(Deserialize, Serialize)]
 struct Snapshot<E = Vec<RollupInvalidation>> {
     version: u32,
@@ -76,43 +78,42 @@ pub fn store(data_dir: &Path, entries: &[RollupInvalidation]) -> std::io::Result
 
 #[cfg(test)]
 mod tests {
+    use test_case::test_case;
+
     use super::*;
 
-    #[test]
-    fn round_trips_entries() {
-        let dir = tempfile::tempdir().expect("temp dir");
-        let entries = vec![RollupInvalidation {
+    fn entry(invalidated_unix_ms: u64) -> RollupInvalidation {
+        RollupInvalidation {
             project_id: "p".into(),
             source: "s".into(),
             date: "2026-08-15".into(),
             epoch: 7,
             dirty_hours: 5,
             unknown: false,
-            invalidated_unix_ms: 123,
-        }];
+            invalidated_unix_ms,
+        }
+    }
+
+    #[test]
+    fn round_trips_entries() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let entries = vec![entry(123)];
         store(dir.path(), &entries).expect("store journal");
         assert_eq!(load(dir.path()), entries);
     }
 
-    #[test]
-    fn corrupt_state_falls_back_to_full_rebuild_semantics() {
+    /// Every unreadable shape must load as empty — which the builder already reads
+    /// as "full rebuild required" — and a pre-timestamp journal must still load,
+    /// with an unknown (zero) invalidation time rather than a manufactured one.
+    #[test_case(b"not json" => Vec::<RollupInvalidation>::new() ; "corrupt falls back to full rebuild semantics")]
+    #[test_case(br#"{"version":2,"entries":[]}"# => Vec::<RollupInvalidation>::new() ; "unsupported version discarded")]
+    #[test_case(br#"{"version":1,"entries":[{"project_id":"p","source":"s","date":"2026-08-15","epoch":7,"dirty_hours":5,"unknown":false}]}"#
+        => vec![entry(0)] ; "journal written before invalidation timestamps")]
+    fn loads_raw_journal(bytes: &[u8]) -> Vec<RollupInvalidation> {
         let dir = tempfile::tempdir().expect("temp dir");
         let target = path(dir.path());
         fs::create_dir_all(target.parent().expect("metadata parent")).expect("create metadata dir");
-        fs::write(target, b"not json").expect("write corrupt journal");
-        assert!(load(dir.path()).is_empty());
-    }
-
-    #[test]
-    fn journal_written_before_invalidation_timestamps_remains_readable() {
-        let dir = tempfile::tempdir().expect("temp dir");
-        let target = path(dir.path());
-        fs::create_dir_all(target.parent().expect("metadata parent")).expect("create metadata dir");
-        fs::write(target, br#"{"version":1,"entries":[{"project_id":"p","source":"s","date":"2026-08-15","epoch":2,"dirty_hours":1,"unknown":false}]}"#)
-            .expect("write old journal");
-
-        let entries = load(dir.path());
-        assert_eq!(entries.len(), 1);
-        assert_eq!(entries[0].invalidated_unix_ms, 0);
+        fs::write(&target, bytes).expect("write journal");
+        load(dir.path())
     }
 }

--- a/src/write/mem_buffer.rs
+++ b/src/write/mem_buffer.rs
@@ -20,6 +20,7 @@ use datafusion::{
         sqlparser::{dialect::GenericDialect, parser::Parser as SqlParser},
     },
 };
+use itertools::Itertools;
 use parking_lot::Mutex;
 use tracing::{debug, error, info, instrument, warn};
 
@@ -83,12 +84,13 @@ fn schemas_compatible(existing: &SchemaRef, incoming: &SchemaRef) -> bool {
     }
     // New fields are OK only if nullable (SchemaMode::Merge) — a new NOT NULL
     // field would break the already-buffered rows.
-    let new_fields = incoming.fields().iter().filter(|f| existing.field_with_name(f.name()).is_err()).collect::<Vec<_>>();
-    if new_fields.iter().any(|f| !f.is_nullable()) {
+    let Some(added) =
+        incoming.fields().iter().filter(|f| existing.field_with_name(f.name()).is_err()).try_fold(0usize, |n, f| f.is_nullable().then_some(n + 1))
+    else {
         return false;
-    }
-    if !new_fields.is_empty() {
-        info!("Schema evolution: {} new nullable field(s) added", new_fields.len());
+    };
+    if added > 0 {
+        info!("Schema evolution: {added} new nullable field(s) added");
     }
     true
 }
@@ -570,29 +572,33 @@ pub fn estimate_batch_size(batch: &RecordBatch) -> usize {
 /// views into exact-size buffers; compact arrays pass through as Arc clones.
 /// Recurses into List/LargeList/FixedSizeList/Struct children.
 fn compact_view_arrays(arr: &ArrayRef) -> ArrayRef {
-    use arrow::array::{Array, BinaryViewArray, FixedSizeListArray, LargeListArray, ListArray, StringViewArray, StructArray};
+    use arrow::{
+        array::{Array, FixedSizeListArray, GenericByteViewArray, GenericListArray, OffsetSizeTrait, StructArray},
+        datatypes::{BinaryViewType, ByteViewType, StringViewType},
+    };
     fn wasteful(buffers: &[arrow::buffer::Buffer], used: usize) -> bool {
         buffers.iter().map(|b| b.capacity()).sum::<usize>() > used * 2 + 1024
     }
+    /// Utf8View / BinaryView share one representation, hence one arm.
+    fn gc_view<T: ByteViewType + ?Sized>(arr: &ArrayRef) -> ArrayRef {
+        let v = arr.as_any().downcast_ref::<GenericByteViewArray<T>>().unwrap();
+        if wasteful(v.data_buffers(), v.total_buffer_bytes_used()) { Arc::new(v.gc()) } else { arr.clone() }
+    }
+    /// List / LargeList differ only in offset width.
+    fn compact_list<O: OffsetSizeTrait>(arr: &ArrayRef, field: &FieldRef) -> ArrayRef {
+        let l = arr.as_any().downcast_ref::<GenericListArray<O>>().unwrap();
+        let vals = compact_view_arrays(l.values());
+        if Arc::ptr_eq(&vals, l.values()) {
+            arr.clone()
+        } else {
+            Arc::new(GenericListArray::<O>::new(field.clone(), l.offsets().clone(), vals, l.nulls().cloned()))
+        }
+    }
     match arr.data_type() {
-        DataType::Utf8View => {
-            let v = arr.as_any().downcast_ref::<StringViewArray>().unwrap();
-            if wasteful(v.data_buffers(), v.total_buffer_bytes_used()) { Arc::new(v.gc()) } else { arr.clone() }
-        }
-        DataType::BinaryView => {
-            let v = arr.as_any().downcast_ref::<BinaryViewArray>().unwrap();
-            if wasteful(v.data_buffers(), v.total_buffer_bytes_used()) { Arc::new(v.gc()) } else { arr.clone() }
-        }
-        DataType::List(f) => {
-            let l = arr.as_any().downcast_ref::<ListArray>().unwrap();
-            let vals = compact_view_arrays(l.values());
-            if Arc::ptr_eq(&vals, l.values()) { arr.clone() } else { Arc::new(ListArray::new(f.clone(), l.offsets().clone(), vals, l.nulls().cloned())) }
-        }
-        DataType::LargeList(f) => {
-            let l = arr.as_any().downcast_ref::<LargeListArray>().unwrap();
-            let vals = compact_view_arrays(l.values());
-            if Arc::ptr_eq(&vals, l.values()) { arr.clone() } else { Arc::new(LargeListArray::new(f.clone(), l.offsets().clone(), vals, l.nulls().cloned())) }
-        }
+        DataType::Utf8View => gc_view::<StringViewType>(arr),
+        DataType::BinaryView => gc_view::<BinaryViewType>(arr),
+        DataType::List(f) => compact_list::<i32>(arr, f),
+        DataType::LargeList(f) => compact_list::<i64>(arr, f),
         DataType::FixedSizeList(f, size) => {
             let l = arr.as_any().downcast_ref::<FixedSizeListArray>().unwrap();
             let vals = compact_view_arrays(l.values());
@@ -1019,10 +1025,8 @@ pub fn sort_partition(schema: &crate::schema::TableSchema, batches: Vec<RecordBa
     };
     let sort_cols: Vec<SortColumn> = spec.into_iter().map(|(i, options)| SortColumn { values: combined.column(i).clone(), options: Some(options) }).collect();
     let indices = lexsort_to_indices(&sort_cols, None).ok()?;
-    let sorted = match indices.values().iter().enumerate().all(|(i, &v)| v as usize == i) {
-        true => combined,
-        false => take_record_batch(&combined, &indices).ok()?,
-    };
+    let already_ordered = indices.values().iter().enumerate().all(|(i, &v)| v as usize == i);
+    let sorted = if already_ordered { combined } else { take_record_batch(&combined, &indices).ok()? };
     // Hand back BATCHES, not the one concatenated monolith: a global lexsort has
     // to materialize the partition once, but nothing downstream should have to
     // hold it as a single value. Slicing is zero-copy and order-preserving, so
@@ -1408,40 +1412,27 @@ impl MemBuffer {
         })
     }
 
+    /// Project every bucket whose id passes `filter`, across all tables,
+    /// through `mk`. The per-table `collect` is load-bearing: the DashMap refs
+    /// can't outlive the closure.
+    fn buckets_where<T>(&self, filter: impl Fn(i64) -> bool, mk: impl Fn(&TableKey, i64, &TimeBucket) -> T) -> Vec<T> {
+        self.tables
+            .iter()
+            .flat_map(|t| t.value().buckets.iter().filter(|b| filter(*b.key())).map(|b| mk(t.key(), *b.key(), b.value())).collect::<Vec<_>>())
+            .collect()
+    }
+
     /// `(bucket_id, created_micros, memory_bytes)` for every bucket matching
     /// `filter`, across all tables — the flush dwell gate's input. Same id can
     /// appear once per (project, table).
     pub fn bucket_flush_meta(&self, filter: impl Fn(i64) -> bool) -> Vec<(i64, i64, usize)> {
-        self.tables
-            .iter()
-            .flat_map(|t| {
-                t.value()
-                    .buckets
-                    .iter()
-                    .filter(|b| filter(*b.key()))
-                    .map(|b| (*b.key(), b.value().created_micros, b.value().memory_bytes.load(std::sync::atomic::Ordering::Relaxed)))
-                    .collect::<Vec<_>>()
-            })
-            .collect()
+        self.buckets_where(filter, |_, id, b| (id, b.created_micros, b.memory_bytes.load(Ordering::Relaxed)))
     }
 
     /// (project_id, table_name, bucket_id) for every bucket whose id passes
     /// `filter`. Drives the take-based flush paths.
     pub fn bucket_keys(&self, filter: impl Fn(i64) -> bool) -> Vec<(String, String, i64)> {
-        self.tables
-            .iter()
-            .flat_map(|t| {
-                let (project_id, table_name) = t.key();
-                // Collect per table: the DashMap ref can't outlive this closure.
-                t.value()
-                    .buckets
-                    .iter()
-                    .map(|b| *b.key())
-                    .filter(|id| filter(*id))
-                    .map(|id| (project_id.to_string(), table_name.to_string(), id))
-                    .collect::<Vec<_>>()
-            })
-            .collect()
+        self.buckets_where(filter, |(project_id, table_name), id, _| (project_id.to_string(), table_name.to_string(), id))
     }
 
     #[instrument(skip(self, batches), fields(project_id, table_name, batch_count))]
@@ -1637,11 +1628,14 @@ impl MemBuffer {
         // filtered to matching rows before returning. Best-effort: anything that
         // fails to compile is left for FilterExec on top to evaluate.
         let pred = compile_filter_conjunction(filters, &table.schema).ok().flatten();
-        let mut bucket_ids: Vec<i64> = table.buckets.iter().map(|b| *b.key()).collect();
-        bucket_ids.sort_unstable();
 
-        let partitions = bucket_ids
-            .into_iter()
+        // `sorted_unstable` is eager, so the DashMap iterator is fully consumed
+        // and dropped before the per-bucket `get` below re-locks the same shard.
+        let partitions = table
+            .buckets
+            .iter()
+            .map(|b| *b.key())
+            .sorted_unstable()
             .filter_map(|bucket_id| table.buckets.get(&bucket_id).filter(|b| bucket_overlaps_range(b, &ts_range)).map(|b| (bucket_id, b)))
             .map(|(bucket_id, bucket)| {
                 // Hold the lock only long enough to clone Arc'd batch refs (and,
@@ -1840,6 +1834,9 @@ impl MemBuffer {
         let Some(table) = self.get_table(&b.project_id, &b.table_name) else {
             return true;
         };
+        // Greatest row timestamp this commit handed to Delta — both the flushed
+        // watermark and the floor the survivor's mask must start above.
+        let drained_max = b.batches.iter().filter_map(batch_timestamp_range).map(|(_, hi)| hi).max();
         let mut emptied = false;
         let mut flushed_through: Option<i64> = None;
         if let Some(bucket_ref) = table.buckets.get(&b.bucket_id) {
@@ -1863,9 +1860,7 @@ impl MemBuffer {
             emptied = g.is_empty();
             // Recorded whether or not anything survived: a bucket drained CLEAN
             // still takes later inserts, and the branch below never runs for it.
-            if let Some(hi) = b.batches.iter().filter_map(batch_timestamp_range).map(|(_, hi)| hi).max() {
-                flushed_through = Some(hi);
-            }
+            flushed_through = drained_max;
             if !emptied {
                 // Narrow the surviving bucket's time range to the remaining
                 // (late-arrival) rows: the old span still covered the DRAINED
@@ -1896,7 +1891,6 @@ impl MemBuffer {
                 // Trading a rare double-count for a certain disappearance is the
                 // right side of this: a masked row is WRONG, a duplicated one is
                 // deduped.
-                let drained_max = b.batches.iter().filter_map(batch_timestamp_range).map(|(_, hi)| hi).max();
                 let min = drained_max.map_or(min, |hi| min.max(hi.saturating_add(1)));
                 bucket.min_timestamp.store(min, Ordering::Relaxed);
                 bucket.max_timestamp.store(max, Ordering::Relaxed);
@@ -3468,6 +3462,23 @@ mod tests {
         );
     }
 
+    /// Every row's `name` column across `batches`, in order. The dedup tests
+    /// all assert on a Utf8View payload plus (sometimes) an Int64 key, so they
+    /// share these two extractors instead of re-deriving the downcast each time.
+    fn col_strings(batches: &[RecordBatch], name: &str) -> Vec<String> {
+        batches
+            .iter()
+            .flat_map(|b| {
+                let a = b.column_by_name(name).unwrap().as_any().downcast_ref::<StringViewArray>().unwrap();
+                (0..b.num_rows()).map(|i| a.value(i).to_string()).collect::<Vec<_>>()
+            })
+            .collect()
+    }
+
+    fn col_i64(batches: &[RecordBatch], name: &str) -> Vec<i64> {
+        batches.iter().flat_map(|b| b.column_by_name(name).unwrap().as_any().downcast_ref::<Int64Array>().unwrap().values().to_vec()).collect()
+    }
+
     #[test]
     fn dedup_batches_keep_last_on_composite_key() {
         let schema = Arc::new(Schema::new(vec![
@@ -3493,14 +3504,7 @@ mod tests {
         // survivors come back as multiple batches — collect across all of them.
         let total: usize = out.iter().map(|b| b.num_rows()).sum();
         assert_eq!(total, 3, "should collapse to 3 unique (id,ts)");
-        let got: Vec<(i64, String)> = out
-            .iter()
-            .flat_map(|b| {
-                let ids = b.column_by_name("id").unwrap().as_any().downcast_ref::<Int64Array>().unwrap();
-                let pl = b.column_by_name("payload").unwrap().as_any().downcast_ref::<StringViewArray>().unwrap();
-                (0..b.num_rows()).map(move |i| (ids.value(i), pl.value(i).to_string())).collect::<Vec<_>>()
-            })
-            .collect();
+        let got: Vec<(i64, String)> = col_i64(&out, "id").into_iter().zip(col_strings(&out, "payload")).collect();
         // Surviving global indices [2,3,4] → batch1 keeps (1,new),(3,v3); batch2 keeps (2,new).
         assert_eq!(got, vec![(1, "v1-new".into()), (3, "v3".into()), (2, "v2-new".into())]);
     }
@@ -3533,14 +3537,7 @@ mod tests {
         for (batches, want) in [(vec![mk(None, "legacy"), mk(Some(10), "stamped")], "stamped"), (vec![mk(Some(10), "stamped"), mk(None, "legacy")], "stamped")]
         {
             let out = dedup_batches(batches, &keys, Some("updated_at"), None).expect("dedup ok");
-            let survivors: Vec<String> = out
-                .iter()
-                .flat_map(|b| {
-                    let pl = b.column_by_name("payload").unwrap().as_any().downcast_ref::<StringViewArray>().unwrap();
-                    (0..b.num_rows()).map(|i| pl.value(i).to_string()).collect::<Vec<_>>()
-                })
-                .collect();
-            assert_eq!(survivors, vec![want.to_string()], "NULL tiebreak must lose regardless of arrival order");
+            assert_eq!(col_strings(&out, "payload"), vec![want.to_string()], "NULL tiebreak must lose regardless of arrival order");
         }
     }
 
@@ -3594,14 +3591,7 @@ mod tests {
         };
         let batches = vec![mk(vec![1], vec!["old"]), mk(vec![1], vec!["new"])];
         let out = dedup_batches(batches, &["id".to_string()], Some("updated_at"), None).expect("a legacy batch must flush, not fail the whole commit");
-        let got: Vec<String> = out
-            .iter()
-            .flat_map(|b| {
-                let pl = b.column_by_name("payload").unwrap().as_any().downcast_ref::<StringViewArray>().unwrap();
-                (0..b.num_rows()).map(|i| pl.value(i).to_string()).collect::<Vec<_>>()
-            })
-            .collect();
-        assert_eq!(got, vec!["new".to_string()], "with no tiebreak available the last occurrence must win");
+        assert_eq!(col_strings(&out, "payload"), vec!["new".to_string()], "with no tiebreak available the last occurrence must win");
 
         // A missing dedup KEY stays fatal — that is a schema fault, not legacy data.
         assert!(dedup_batches(vec![mk(vec![1], vec!["x"])], &["nope".to_string()], None, None).is_err(), "a missing dedup key must still fail loudly");
@@ -3630,14 +3620,7 @@ mod tests {
         let batches =
             vec![mk(vec![1, 2], vec![Some(200), None], vec!["1-enriched", "2-base"]), mk(vec![1, 2], vec![Some(100), Some(50)], vec!["1-base", "2-enriched"])];
         let out = dedup_batches(batches, &["id".to_string()], Some("observed"), None).expect("dedup ok");
-        let mut got: Vec<(i64, String)> = out
-            .iter()
-            .flat_map(|b| {
-                let ids = b.column_by_name("id").unwrap().as_any().downcast_ref::<Int64Array>().unwrap();
-                let pl = b.column_by_name("payload").unwrap().as_any().downcast_ref::<StringViewArray>().unwrap();
-                (0..b.num_rows()).map(move |i| (ids.value(i), pl.value(i).to_string())).collect::<Vec<_>>()
-            })
-            .collect();
+        let mut got: Vec<(i64, String)> = col_i64(&out, "id").into_iter().zip(col_strings(&out, "payload")).collect();
         got.sort();
         assert_eq!(got, vec![(1, "1-enriched".into()), (2, "2-enriched".into())]);
     }
@@ -3674,15 +3657,14 @@ mod tests {
 
         fn collapse(batches: Vec<RecordBatch>, drop_tombstones: Option<&str>) -> Vec<(i64, String, Option<bool>)> {
             let out = dedup_batches(batches, &["id".to_string()], Some("updated_at"), drop_tombstones).expect("collapse ok");
-            let mut got: Vec<(i64, String, Option<bool>)> = out
+            let deleted: Vec<Option<bool>> = out
                 .iter()
                 .flat_map(|b| {
-                    let ids = b.column_by_name("id").unwrap().as_any().downcast_ref::<Int64Array>().unwrap();
-                    let del = b.column_by_name("deleted").unwrap().as_any().downcast_ref::<BooleanArray>().unwrap();
-                    let pl = b.column_by_name("payload").unwrap().as_any().downcast_ref::<StringViewArray>().unwrap();
-                    (0..b.num_rows()).map(move |i| (ids.value(i), pl.value(i).to_string(), del.is_valid(i).then(|| del.value(i)))).collect::<Vec<_>>()
+                    let d = b.column_by_name("deleted").unwrap().as_any().downcast_ref::<BooleanArray>().unwrap();
+                    (0..b.num_rows()).map(|i| d.is_valid(i).then(|| d.value(i))).collect::<Vec<_>>()
                 })
                 .collect();
+            let mut got: Vec<(i64, String, Option<bool>)> = itertools::izip!(col_i64(&out, "id"), col_strings(&out, "payload"), deleted).collect();
             got.sort();
             got
         }
@@ -4539,42 +4521,22 @@ mod tests {
         assert!(!buffer.has_table("project2", "table1"));
     }
 
+    /// A window is half-open: the last microsecond before a boundary belongs to
+    /// the previous bucket, and the boundary itself opens the next one — so two
+    /// rows one microsecond apart across it must land in two separate buckets.
     #[test]
-    fn test_bucket_boundary_exact() {
+    fn bucket_boundaries_are_half_open() {
+        for (ts, want) in [(0, 0), (BUCKET_DURATION_MICROS - 1, 0), (BUCKET_DURATION_MICROS, 1), (BUCKET_DURATION_MICROS * 2, 2)] {
+            assert_eq!(MemBuffer::compute_bucket_id(ts), want, "ts {ts}");
+        }
+
         let buffer = MemBuffer::new();
+        buffer.insert("project1", "table1", create_test_batch(BUCKET_DURATION_MICROS), BUCKET_DURATION_MICROS).unwrap();
+        assert_eq!(buffer.get_stats().total_buckets, 1, "the boundary instant alone opens exactly one bucket");
 
-        // Test timestamps exactly at bucket boundaries
-        let bucket_0_start = 0i64;
-        let bucket_1_start = BUCKET_DURATION_MICROS;
-        let bucket_2_start = BUCKET_DURATION_MICROS * 2;
-
-        assert_eq!(MemBuffer::compute_bucket_id(bucket_0_start), 0);
-        assert_eq!(MemBuffer::compute_bucket_id(bucket_1_start), 1);
-        assert_eq!(MemBuffer::compute_bucket_id(bucket_2_start), 2);
-
-        // Insert at exact boundary
-        buffer.insert("project1", "table1", create_test_batch(bucket_1_start), bucket_1_start).unwrap();
-
-        let stats = buffer.get_stats();
-        assert_eq!(stats.total_buckets, 1);
-    }
-
-    #[test]
-    fn test_bucket_boundary_one_before() {
-        let buffer = MemBuffer::new();
-
-        // Test timestamp one microsecond before bucket boundary
-        let just_before_bucket_1 = BUCKET_DURATION_MICROS - 1;
-        let bucket_1_start = BUCKET_DURATION_MICROS;
-
-        assert_eq!(MemBuffer::compute_bucket_id(just_before_bucket_1), 0);
-        assert_eq!(MemBuffer::compute_bucket_id(bucket_1_start), 1);
-
-        buffer.insert("project1", "table1", create_test_batch(just_before_bucket_1), just_before_bucket_1).unwrap();
-        buffer.insert("project1", "table1", create_test_batch(bucket_1_start), bucket_1_start).unwrap();
-
-        let stats = buffer.get_stats();
-        assert_eq!(stats.total_buckets, 2, "Should have 2 separate buckets");
+        let just_before = BUCKET_DURATION_MICROS - 1;
+        buffer.insert("project1", "table1", create_test_batch(just_before), just_before).unwrap();
+        assert_eq!(buffer.get_stats().total_buckets, 2, "one microsecond earlier belongs to the previous bucket");
     }
 
     /// The rollup read path splits a window at the oldest buffered row:

--- a/src/write/mod.rs
+++ b/src/write/mod.rs
@@ -2,14 +2,16 @@ pub mod mem_buffer;
 pub mod wal;
 
 use std::{
+    collections::{BTreeSet, HashMap, HashSet},
     sync::{
         Arc,
-        atomic::{AtomicU64, AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicI64, AtomicU64, AtomicUsize, Ordering},
     },
     time::Duration,
 };
 
 use arrow::array::RecordBatch;
+use dashmap::DashMap;
 use futures::stream::{self, StreamExt};
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
@@ -358,12 +360,39 @@ pub type DeltaWatermark = Vec<Option<walrus_rust::WalPosition>>;
 pub type DeltaWriteCallback =
     Arc<dyn Fn(String, String, Vec<RecordBatch>, DeltaWatermark) -> futures::future::BoxFuture<'static, anyhow::Result<Vec<String>>> + Send + Sync>;
 
+/// Width of a landed-batch identity. 128 bits: with at most a few dozen
+/// identities live per topic, a random collision is out of reach by ~25 orders
+/// of magnitude, and the hash is not exposed to clients (it lives in Delta
+/// commit metadata, and TF — not the client — assigns the `updated_at` that
+/// goes into it), so the non-cryptographic hash cannot be aimed.
+pub const DIGEST_BYTES: usize = 16;
+
+/// Identity of a batch set. See [`landed_digest`].
+pub type LandedDigest = [u8; DIGEST_BYTES];
+
+/// Multiple of `delta_scan_depth` bounding the in-process landed-identity set
+/// per topic. Only duplicates are at stake if it is too small.
+const LANDED_WINDOW_COMMITS: usize = 4;
+
+/// Whether "identical content" is safe to read as "already durable" for this
+/// table — it is only so when the table declares `dedup_keys`.
+///
+/// `prepare_flush` documents that an empty key list is a PASS-THROUGH: for an
+/// append-only table with no keys, two byte-identical batches are two distinct
+/// facts, and a client that legitimately re-sends one would have the second
+/// silently dropped. That is acked-write loss, which is the one outcome this
+/// path may never produce — so the identity is simply not defined for such a
+/// table, and neither the record nor the check is taken.
+pub(crate) fn landed_identity_applies(table_name: &str) -> bool {
+    crate::schema::get_schema(table_name).is_some_and(|s| !s.dedup_keys.is_empty())
+}
+
 /// Identity of a set of batches, used to decline a flush whose rows are
 /// provably already committed — the duplicates WAL replay manufactures after an
 /// unclean exit (`docs/plans/2026-09-02-stop-manufacturing-duplicates.md`).
 ///
 /// One hash per batch over its Arrow IPC bytes, combined by **wrapping
-/// addition**. Three properties, each load-bearing:
+/// addition**. Two properties, each load-bearing:
 ///
 /// - **Commutative**, so the digest is immune to batch ORDER. This is required,
 ///   not a nicety: the original arrives interleaved across concurrent
@@ -371,22 +400,13 @@ pub type DeltaWriteCallback =
 ///   differs for content that is identical.
 /// - **Addition, not XOR.** XOR cancels in pairs, so two identical batches
 ///   would digest the same as no batches at all — a skip of a real write.
-/// - **256-bit and cryptographic, not a 64-bit fast hash.** A collision here
-///   declines a write that should have happened, which is silent data loss.
 ///
-/// **Cost, measured — the `landed_digest` bench in `dedup_benchmarks`, release,
-/// 200k rows:** 17.3 ms (1.29 GiB/s) against 20.5 ms for the parquet encode
-/// this avoids, so **0.84x the work it guards**.
+/// A collision declines a write that should have happened, i.e. silent data
+/// loss — see [`DIGEST_BYTES`] for why 128 non-cryptographic bits are enough.
 ///
-/// That bench exists because the first estimate was taken in a debug build,
-/// where SHA-256 runs far under its release speed and made the digest look 5x
-/// the encode. Decomposing it showed the hash was 83% of the total, and moving
-/// from SHA-256 to blake3 (already in the lock file, SIMD, same 256 bits) cut
-/// the whole digest by **72%**. The Arrow passes are the remainder.
-///
-/// Steady state is cheaper still: the CHECK short-circuits on the identity set
-/// being empty, which without a dirty boot it is, so it costs a map lookup.
-/// Only the RECORD is paid per flush commit while the feature is on.
+/// Steady state is cheap: the CHECK short-circuits on the identity set being
+/// empty, which without a dirty boot it is, so it costs a map lookup. Only the
+/// RECORD is paid per flush commit while the feature is on.
 ///
 /// The bytes hashed are the batch's **IPC round-trip fixed point**, not its
 /// current encoding. Measured, not assumed: a client-supplied batch and the
@@ -399,33 +419,6 @@ pub type DeltaWriteCallback =
 ///
 /// `None` for an empty set (nothing to skip) and on any serialization failure —
 /// both mean "no identity", which declines the skip and flushes normally.
-/// Width of a landed-batch identity. 128 bits: with at most a few dozen
-/// identities live per topic, a random collision is out of reach by ~25 orders
-/// of magnitude, and the hash is not exposed to clients (it lives in Delta
-/// commit metadata, and TF — not the client — assigns the `updated_at` that
-/// goes into it), so the non-cryptographic hash below cannot be aimed.
-pub const DIGEST_BYTES: usize = 16;
-
-/// Identity of a batch set. See [`landed_digest`].
-pub type LandedDigest = [u8; DIGEST_BYTES];
-
-/// Whether "identical content" is safe to read as "already durable" for this
-/// table — it is only so when the table declares `dedup_keys`.
-///
-/// `prepare_flush` documents that an empty key list is a PASS-THROUGH: for an
-/// append-only table with no keys, two byte-identical batches are two distinct
-/// facts, and a client that legitimately re-sends one would have the second
-/// silently dropped. That is acked-write loss, which is the one outcome this
-/// path may never produce — so the identity is simply not defined for such a
-/// table, and neither the record nor the check is taken.
-/// Multiple of `delta_scan_depth` bounding the in-process landed-identity set
-/// per topic. Only duplicates are at stake if it is too small.
-const LANDED_WINDOW_COMMITS: usize = 4;
-
-pub(crate) fn landed_identity_applies(table_name: &str) -> bool {
-    crate::schema::get_schema(table_name).is_some_and(|s| !s.dedup_keys.is_empty())
-}
-
 pub fn landed_digest(batches: &[RecordBatch]) -> Option<LandedDigest> {
     if batches.iter().all(|b| b.num_rows() == 0) {
         return None;
@@ -523,7 +516,7 @@ pub fn ingest_dedup_filter_batch(idx: &IngestDedupIndex, table_name: &str, batch
     let indices = arrow::array::UInt64Array::from(hits.iter().map(|&(r, _)| r as u64).collect::<Vec<_>>());
     let Ok(sub) = datafusion::arrow::compute::take_record_batch(&batch, &indices) else { return pass(batch, key_hits) };
     let Some(content_hashes) = row_hashes(&sub, &content_idxs) else { return pass(batch, key_hits) };
-    let dropped: std::collections::HashSet<usize> =
+    let dropped: HashSet<usize> =
         hits.iter().zip(&content_hashes).filter(|&(&(_, (cur, prev)), &c)| cur == Some(c) || prev == Some(c)).map(|(&(r, _), _)| r).collect();
     if dropped.is_empty() {
         return pass(batch, key_hits);
@@ -560,8 +553,8 @@ pub struct IngestDedupIndex {
 }
 
 struct IngestEpochs {
-    current: std::sync::Arc<dashmap::DashMap<u128, u128>>,
-    previous: std::sync::Arc<dashmap::DashMap<u128, u128>>,
+    current: Arc<DashMap<u128, u128>>,
+    previous: Arc<DashMap<u128, u128>>,
     current_started_micros: i64,
 }
 
@@ -582,8 +575,8 @@ impl IngestDedupIndex {
         const BYTES_PER_ENTRY: usize = 50; // 32 B payload + DashMap overhead
         Self {
             epochs: std::sync::RwLock::new(IngestEpochs {
-                current: std::sync::Arc::new(dashmap::DashMap::new()),
-                previous: std::sync::Arc::new(dashmap::DashMap::new()),
+                current: Arc::new(DashMap::new()),
+                previous: Arc::new(DashMap::new()),
                 current_started_micros: now_micros,
             }),
             rotate_at_entries: (max_bytes / 2 / BYTES_PER_ENTRY).max(1),
@@ -621,7 +614,7 @@ impl IngestDedupIndex {
     pub fn key_contents(&self, key_hash: u128) -> (Option<u128>, Option<u128>) {
         let (current, previous) = {
             let e = self.read();
-            (std::sync::Arc::clone(&e.current), std::sync::Arc::clone(&e.previous))
+            (Arc::clone(&e.current), Arc::clone(&e.previous))
         };
         (current.get(&key_hash).map(|c| *c), previous.get(&key_hash).map(|c| *c))
     }
@@ -631,7 +624,7 @@ impl IngestDedupIndex {
     /// content, passes, and maintenance dedup resolves it).
     pub fn populate(&self, key_hash: u128, content_hash: u128) {
         // Clone the handle out so the read lock is dropped before the insert.
-        let current = std::sync::Arc::clone(&self.read().current);
+        let current = Arc::clone(&self.read().current);
         current.insert(key_hash, content_hash);
     }
 
@@ -646,7 +639,7 @@ impl IngestDedupIndex {
         let mut e = self.epochs.write().unwrap_or_else(std::sync::PoisonError::into_inner);
         // Re-check under the write lock (another thread may have rotated).
         if due(&e) {
-            e.previous = std::mem::replace(&mut e.current, std::sync::Arc::new(dashmap::DashMap::new()));
+            e.previous = std::mem::replace(&mut e.current, Arc::new(DashMap::new()));
             e.current_started_micros = now_micros;
             return true;
         }
@@ -784,7 +777,7 @@ pub struct BufferedWriteLayer {
     /// connection drain prevents already-accepted PGWire sockets from appending
     /// after the shutdown flush/snapshot (the accept loop itself does not join
     /// its spawned connection tasks).
-    accepting_writes: std::sync::atomic::AtomicBool,
+    accepting_writes: AtomicBool,
     active_writes: AtomicU64,
     writes_drained: Notify,
     /// Invalidates leased pre-deploy write fences. Shutdown increments this
@@ -793,7 +786,7 @@ pub struct BufferedWriteLayer {
     /// True only after HANDOFF fenced admission, quiesced admitted writers,
     /// and flushed every WAL-backed hold. A start-first replacement may then
     /// ask this process to relinquish the single-writer WAL lock.
-    deploy_handoff_ready: std::sync::atomic::AtomicBool,
+    deploy_handoff_ready: AtomicBool,
     delta_write_callback: Option<DeltaWriteCallback>,
     /// Set alongside `delta_write_callback`; used instead of it when
     /// `TIMEFUSION_FLUSH_COALESCE_COMMITS` is on (see `flush_groups_coalesced`).
@@ -824,7 +817,7 @@ pub struct BufferedWriteLayer {
     /// `support::now_micros()` of the most recent flush failure (0 = never).
     /// A broken flush is a durability backlog even while the backlog gauge is
     /// briefly small, so the compaction brake ORs on its recency.
-    last_flush_failure_micros: std::sync::atomic::AtomicI64,
+    last_flush_failure_micros: AtomicI64,
     backpressure_engaged_total: AtomicU64,
     backpressure_rejected_total: AtomicU64,
     backpressure_force_flush_total: AtomicU64,
@@ -832,7 +825,7 @@ pub struct BufferedWriteLayer {
     /// (`wal_hard_limit_bytes`); while set, `insert` rejects instead of acking
     /// into an unbounded backlog (the upstream DLQ absorbs + replays). Cleared
     /// by the same loop once the backlog drains below the limit.
-    wal_hard_backpressure: std::sync::atomic::AtomicBool,
+    wal_hard_backpressure: AtomicBool,
     /// Cumulative rows accepted into MemBuffer (post-WAL) and rows drained to
     /// Delta. Diff two `timefusion_stats` scrapes to get ingest-rate vs
     /// drain-rate: if `rows_ingested_total` climbs faster than
@@ -867,7 +860,7 @@ pub struct BufferedWriteLayer {
     /// visibility gap). Raised before the commit so a query can't race in
     /// between commit-visible and watermark-raise; a failed commit leaves it
     /// conservatively high.
-    delta_flushed_watermark: dashmap::DashMap<crate::write::mem_buffer::TableKey, i64>,
+    delta_flushed_watermark: DashMap<crate::write::mem_buffer::TableKey, i64>,
     /// Recovery-time floor for the watermark: anything committed by earlier
     /// process lifetimes has row timestamps at/below roughly this (event
     /// timestamps drive bucketing; far-future-skewed pre-boot rows are the
@@ -878,12 +871,12 @@ pub struct BufferedWriteLayer {
     /// window). Registered under the shard append lock BEFORE the entry
     /// exists — see `WalManager::append_batch` for the ordering argument.
     /// Keyed (project, table) → token → (shard, pre-append position).
-    pending_wal_holds: dashmap::DashMap<(String, String), std::collections::HashMap<u64, (usize, walrus_rust::WalPosition)>>,
+    pending_wal_holds: DashMap<(String, String), HashMap<u64, (usize, walrus_rust::WalPosition)>>,
     /// Holds for buckets taken out of MemBuffer for an in-flight Delta
     /// commit: while airborne they're invisible to `MemBuffer::wal_holds`,
     /// but until the commit lands their WAL entries must still pin the
     /// cursor. Keyed (project, table) → token → per-shard holds.
-    inflight_flush_holds: dashmap::DashMap<(String, String), std::collections::HashMap<u64, ShardHolds>>,
+    inflight_flush_holds: DashMap<(String, String), HashMap<u64, ShardHolds>>,
     /// Holds for buckets that could not be restored after a failed commit
     /// (evicted / incompatible schema): the rows exist only in the WAL, so
     /// the cursor must stay pinned until restart replays them. Kept apart
@@ -895,21 +888,21 @@ pub struct BufferedWriteLayer {
     /// rows exist only in the WAL until a restart replays them. Surfaced in
     /// `timefusion_stats` (orphaned_topics / orphan_pin_age) so an operator
     /// knows a restart is due before the pinned WAL fills the disk.
-    orphaned_wal_holds: dashmap::DashMap<(String, String), (ShardHolds, i64)>,
+    orphaned_wal_holds: DashMap<(String, String), (ShardHolds, i64)>,
     /// WAL GC floor legs for taken buckets while their commit is airborne:
     /// token → `first_wal_pin_micros`. Keeps `gc_wal_files` from deleting
     /// files their entries live in.
-    inflight_wal_pins: dashmap::DashMap<u64, i64>,
+    inflight_wal_pins: DashMap<u64, i64>,
     wal_hold_seq: AtomicU64,
     /// True while `recover_from_wal` runs. Suppresses cursor-snapshot writes
     /// from mid-replay relief flushes — see `write_post_flush_snapshot`.
-    recovery_active: std::sync::atomic::AtomicBool,
+    recovery_active: AtomicBool,
     /// Duration of the completed startup WAL replay, surfaced for deploy alerts.
     wal_recovery_duration_ms: AtomicU64,
     /// Rows that replay re-inserted, surfaced next to the duplicates they make.
     wal_replay_rows: AtomicU64,
     /// Set only after `recover_from_wal` returns successfully.
-    wal_recovery_complete: std::sync::atomic::AtomicBool,
+    wal_recovery_complete: AtomicBool,
     /// Per-topic pre-recovery cursor (P0), set once at the start of
     /// `recover_from_wal`. While `recovery_active`, `compute_wal_watermark`
     /// floors its result here so a mid-replay Delta commit's watermark metadata
@@ -919,7 +912,7 @@ pub struct BufferedWriteLayer {
     /// `refresh_replay_rewind_marker`), so this floor doesn't freeze recovery.
     /// Static (read-only during replay) → no per-entry cost, safe for the
     /// concurrent relief drain to read. Empty outside recovery.
-    recovery_commit_floor: dashmap::DashMap<(String, String), ShardHolds>,
+    recovery_commit_floor: DashMap<(String, String), ShardHolds>,
     /// Delta files committed by replay relief flushes. Indexing them before
     /// replay ends would publish a partial replayed state.
     deferred_tantivy_files: std::sync::Mutex<Vec<DeferredTantivyFile>>,
@@ -934,12 +927,12 @@ pub struct BufferedWriteLayer {
     /// commits — the same shape as ClickHouse's
     /// `replicated_deduplication_window`. Empty means "no proof of anything",
     /// which costs duplicates, never a loss.
-    landed_digests: dashmap::DashMap<(String, String), std::collections::HashSet<LandedDigest>>,
+    landed_digests: DashMap<(String, String), HashSet<LandedDigest>>,
     /// Per-(project, table) recently-flushed content-identity index for
     /// ingest-time client-retry dedup (see `filter_ingest_dedup`). Arc so a
     /// probe clones the handle out instead of holding a DashMap shard guard
     /// across its per-row loop.
-    ingest_dedup: dashmap::DashMap<(String, String), Arc<IngestDedupIndex>>,
+    ingest_dedup: DashMap<(String, String), Arc<IngestDedupIndex>>,
     /// Test hook: drop the post-commit cursor advance, modelling the one
     /// producer of replay duplicates that a test can otherwise not reach — a
     /// Delta commit that LANDS while the advance that should follow it is
@@ -947,7 +940,7 @@ pub struct BufferedWriteLayer {
     /// which `settle_flushed_group` documents as benign). Everything else
     /// about the flush proceeds normally, so the next boot replays rows Delta
     /// already holds. Not `#[cfg(test)]`: the e2e suite links the real crate.
-    test_drop_cursor_advance: std::sync::atomic::AtomicBool,
+    test_drop_cursor_advance: AtomicBool,
     landed_skips_total: AtomicU64,
     landed_skipped_rows_total: AtomicU64,
     /// Test-only: bail out of `recover_from_wal` once this many relief drains
@@ -1045,11 +1038,11 @@ impl BufferedWriteLayer {
             wal,
             mem_buffer,
             shutdown: CancellationToken::new(),
-            accepting_writes: std::sync::atomic::AtomicBool::new(true),
+            accepting_writes: AtomicBool::new(true),
             active_writes: AtomicU64::new(0),
             writes_drained: Notify::new(),
             handoff_generation: AtomicU64::new(0),
-            deploy_handoff_ready: std::sync::atomic::AtomicBool::new(false),
+            deploy_handoff_ready: AtomicBool::new(false),
             delta_write_callback: None,
             coalesced_write_callback: None,
             tantivy_index_callback: None,
@@ -1057,13 +1050,13 @@ impl BufferedWriteLayer {
             flush_lock: Mutex::new(()),
             relief_lock: Mutex::new(()),
             reserved_bytes: AtomicUsize::new(0),
-            wal_hard_backpressure: std::sync::atomic::AtomicBool::new(false),
+            wal_hard_backpressure: AtomicBool::new(false),
             pressure_notify: Arc::new(Notify::new()),
             flush_tick_notify: Arc::new(Notify::new()),
             eviction_tick_notify: Arc::new(Notify::new()),
             flush_completed_total: AtomicU64::new(0),
             flush_failed_total: AtomicU64::new(0),
-            last_flush_failure_micros: std::sync::atomic::AtomicI64::new(0),
+            last_flush_failure_micros: AtomicI64::new(0),
             backpressure_engaged_total: AtomicU64::new(0),
             backpressure_rejected_total: AtomicU64::new(0),
             backpressure_force_flush_total: AtomicU64::new(0),
@@ -1076,21 +1069,21 @@ impl BufferedWriteLayer {
             // bounding worst-case S3 / tantivy heap usage if more tables
             // appear.
             tantivy_spawn_sem: Arc::new(tokio::sync::Semaphore::new(16)),
-            delta_flushed_watermark: dashmap::DashMap::new(),
+            delta_flushed_watermark: DashMap::new(),
             boot_micros: crate::support::now_micros(),
-            pending_wal_holds: dashmap::DashMap::new(),
-            inflight_flush_holds: dashmap::DashMap::new(),
-            orphaned_wal_holds: dashmap::DashMap::new(),
-            inflight_wal_pins: dashmap::DashMap::new(),
+            pending_wal_holds: DashMap::new(),
+            inflight_flush_holds: DashMap::new(),
+            orphaned_wal_holds: DashMap::new(),
+            inflight_wal_pins: DashMap::new(),
             wal_hold_seq: AtomicU64::new(0),
-            recovery_active: std::sync::atomic::AtomicBool::new(false),
+            recovery_active: AtomicBool::new(false),
             wal_recovery_duration_ms: AtomicU64::new(0),
             wal_replay_rows: AtomicU64::new(0),
-            wal_recovery_complete: std::sync::atomic::AtomicBool::new(false),
-            recovery_commit_floor: dashmap::DashMap::new(),
-            landed_digests: dashmap::DashMap::new(),
-            ingest_dedup: dashmap::DashMap::new(),
-            test_drop_cursor_advance: std::sync::atomic::AtomicBool::new(false),
+            wal_recovery_complete: AtomicBool::new(false),
+            recovery_commit_floor: DashMap::new(),
+            landed_digests: DashMap::new(),
+            ingest_dedup: DashMap::new(),
+            test_drop_cursor_advance: AtomicBool::new(false),
             landed_skips_total: AtomicU64::new(0),
             landed_skipped_rows_total: AtomicU64::new(0),
             deferred_tantivy_files: std::sync::Mutex::new(std::fs::read(&deferred_path).ok().and_then(|b| serde_json::from_slice(&b).ok()).unwrap_or_default()),
@@ -1928,7 +1921,7 @@ impl BufferedWriteLayer {
         let mut drain_task: Option<JoinHandle<()>> = None;
         let mut iter = self.wal.replay_iter().map_err(|e| anyhow::anyhow!("WAL replay iterator init failed: {}", e))?;
         let mut processed_total = 0u64;
-        let mut applied_frontiers: std::collections::HashMap<(String, String), ShardHolds> = std::collections::HashMap::new();
+        let mut applied_frontiers: HashMap<(String, String), ShardHolds> = HashMap::new();
         const DECODE_CHUNK_ENTRIES: usize = 64;
         /// Cap on concurrent decode tasks. Replay must not monopolise a box that
         /// is also serving the early-bind PGWire responder.
@@ -1981,42 +1974,33 @@ impl BufferedWriteLayer {
                     (batch, started.elapsed().as_nanos())
                 })
             }
-            let threads = std::thread::available_parallelism().map_or(1, |n| n.get()).min(DECODE_MAX_TASKS);
-            let ready: Vec<_> = if threads > 1 && chunk.len() >= DECODE_PARALLEL_MIN_ENTRIES {
-                let per = chunk.len().div_ceil(threads);
-                let mut slices: Vec<Vec<_>> = Vec::with_capacity(threads);
-                let mut rest = chunk;
-                while !rest.is_empty() {
-                    let tail = rest.split_off(per.min(rest.len()));
-                    slices.push(std::mem::replace(&mut rest, tail));
-                }
-                let handles: Vec<_> = slices
-                    .into_iter()
-                    .map(|slice| {
-                        tokio::task::spawn_blocking(move || {
-                            slice
-                                .into_iter()
-                                .map(|(entry, shard, pos, frontier)| {
-                                    let d = decode_one(&entry);
-                                    (entry, shard, pos, frontier, d)
-                                })
-                                .collect::<Vec<_>>()
-                        })
-                    })
-                    .collect();
-                let mut out = Vec::new();
-                for h in handles {
-                    out.extend(h.await.expect("WAL decode task panicked"));
-                }
-                out
-            } else {
-                chunk
+            // Non-capturing (so `Copy`, hence usable from every spawned task).
+            let decode_slice = |slice: Vec<_>| {
+                slice
                     .into_iter()
                     .map(|(entry, shard, pos, frontier)| {
                         let d = decode_one(&entry);
                         (entry, shard, pos, frontier, d)
                     })
-                    .collect()
+                    .collect::<Vec<_>>()
+            };
+            let threads = std::thread::available_parallelism().map_or(1, |n| n.get()).min(DECODE_MAX_TASKS);
+            let chunk_len = chunk.len();
+            let ready = if threads > 1 && chunk_len >= DECODE_PARALLEL_MIN_ENTRIES {
+                // Scoped so the (non-`Sync`) chunker is dropped before the await.
+                let handles: Vec<_> = {
+                    let slices = chunk.into_iter().chunks(chunk_len.div_ceil(threads));
+                    slices
+                        .into_iter()
+                        .map(|s| {
+                            let slice = s.collect_vec();
+                            tokio::task::spawn_blocking(move || decode_slice(slice))
+                        })
+                        .collect()
+                };
+                futures::future::join_all(handles).await.into_iter().flat_map(|r| r.expect("WAL decode task panicked")).collect()
+            } else {
+                decode_slice(chunk)
             };
 
             for (entry, shard, pos, (safe_topic, safe_frontier), decoded) in ready {
@@ -2329,7 +2313,7 @@ impl BufferedWriteLayer {
         while self.is_memory_pressure() {
             let current = MemBuffer::current_bucket_id();
             // BTreeSet = sorted+deduped in one pass; the oldest quartile's upper id is the cutoff.
-            let ids: std::collections::BTreeSet<i64> = self.mem_buffer.bucket_keys(|id| id < current).into_iter().map(|(_, _, id)| id).collect();
+            let ids: BTreeSet<i64> = self.mem_buffer.bucket_keys(|id| id < current).into_iter().map(|(_, _, id)| id).collect();
             let Some(&cutoff) = ids.iter().nth(ids.len().saturating_sub(1) / 4) else { break };
             if let Err(e) = self.flush_buckets_where(|id| id <= cutoff).await {
                 warn!("replay relief: flush failed: {}", e);
@@ -2737,24 +2721,22 @@ impl BufferedWriteLayer {
         const FLUSH_DWELL_BYPASS_BYTES: usize = 32 << 20;
         let dwell_micros = self.config.buffer.flush_dwell_micros();
         let now = crate::support::now_micros();
-        let mut fresh_small: std::collections::BTreeSet<i64> = Default::default();
-        let mut ids: std::collections::BTreeSet<i64> = Default::default();
-        for (id, created, bytes) in self.mem_buffer.bucket_flush_meta(|id| id < current_bucket) {
-            ids.insert(id);
-            if now.saturating_sub(created) < dwell_micros && bytes < FLUSH_DWELL_BYPASS_BYTES {
-                fresh_small.insert(id);
-            }
-        }
+        let meta = self.mem_buffer.bucket_flush_meta(|id| id < current_bucket);
+        let fresh_small: BTreeSet<i64> = meta
+            .iter()
+            .filter(|(_, created, bytes)| now.saturating_sub(*created) < dwell_micros && *bytes < FLUSH_DWELL_BYPASS_BYTES)
+            .map(|(id, _, _)| *id)
+            .collect();
         // An id is held back while ANY table's bucket at it is fresh and
         // small (range-flushing below cannot split one id per table). This
         // cannot starve: a held bucket is not flushed, so no NEW bucket can
         // replace it at that id — the id becomes eligible at most one dwell
-        // after the youngest bucket's creation.
-        ids.retain(|id| !fresh_small.contains(id));
-        for chunk in ids.iter().copied().collect::<Vec<_>>().chunks(FLUSH_CHUNK_BUCKET_IDS) {
+        // after the youngest bucket's creation. BTreeSet = sorted + deduped.
+        let ids: Vec<i64> = meta.iter().map(|(id, _, _)| *id).filter(|id| !fresh_small.contains(id)).collect::<BTreeSet<_>>().into_iter().collect();
+        for chunk in ids.chunks(FLUSH_CHUNK_BUCKET_IDS) {
             // Membership, not a range: the ids between chunk members may be
             // dwell-held and a range predicate would flush them anyway.
-            let members: std::collections::BTreeSet<i64> = chunk.iter().copied().collect();
+            let members: BTreeSet<i64> = chunk.iter().copied().collect();
             self.flush_buckets_where(move |id| members.contains(&id)).await?;
         }
         Ok(())
@@ -2773,8 +2755,7 @@ impl BufferedWriteLayer {
         // Group the matching bucket keys per (project, table) FIRST: the
         // in-flight registration below must precede any snapshot of that
         // topic's buckets.
-        let by_topic: std::collections::HashMap<(String, String), Vec<i64>> =
-            self.mem_buffer.bucket_keys(&pred).into_iter().map(|(p, t, id)| ((p, t), id)).into_group_map();
+        let by_topic: HashMap<(String, String), Vec<i64>> = self.mem_buffer.bucket_keys(&pred).into_iter().map(|(p, t, id)| ((p, t), id)).into_group_map();
 
         // Snapshot (not take): rows stay queryable in MemBuffer while the
         // Delta commit is airborne — a take here blacked out the flushed
@@ -3119,52 +3100,51 @@ impl BufferedWriteLayer {
             self.note_landed_skip(bucket, &batches);
             return Ok(());
         }
-        let added_files = if let Some(ref callback) = self.delta_write_callback {
-            // Await ensures Delta commit completes before we return.
-            let commit = callback(bucket.project_id.clone(), bucket.table_name.clone(), batches.clone(), delta_watermark);
-            // Watchdog: an un-timed-out commit that hangs would pin `flush_lock`
-            // forever with no log (see `d_flush_bucket_timeout_secs`). On elapse
-            // we bail so the caller counts flush_failed + retries next cycle;
-            // rows stay durable in MemBuffer + WAL. 0 disables the watchdog.
-            //
-            // Abandoned-commit window: dropping the timed-out future cancels
-            // its polling, but a Delta commit PUT already issued to S3 can
-            // still land after the drop. The retained bucket is then re-
-            // committed next cycle → the same rows land twice. Accepted:
-            // dedup_keys (write-side) and DedupExec (read-side) collapse the
-            // duplicates, and a slow-but-successful commit is rare next to a
-            // truly hung one; size the timeout well above normal commit p99.
-            let timeout = self.adaptive_flush_timeout();
-            if timeout.is_zero() {
-                commit.await?
-            } else {
-                tokio::time::timeout(timeout, commit)
-                    .await
-                    .map_err(|_| {
-                        crate::observability::record_flush_stalled();
-                        error!(
-                            "flush_bucket Delta commit stalled >{:?} (project={}, table={}, bucket_id={}) — aborting this flush so flush_lock releases and relief can retry; rows remain durable in MemBuffer + WAL",
-                            timeout, bucket.project_id, bucket.table_name, bucket.bucket_id
-                        );
-                        anyhow::anyhow!("flush_bucket commit timed out after {:?} (Delta/S3 stalled)", timeout)
-                    })??
-            }
-        } else {
-            // A missing callback must FAIL the flush, never "succeed" having
-            // written nothing. The caller treats Ok as "the rows are durable in
-            // Delta" and drains them out of MemBuffer + advances the WAL
-            // watermark, so returning Ok here destroyed every row in the bucket
-            // and left only a warn line — while `layer.is_empty()` and the flush
-            // metrics both reported success. Failing puts it on the same footing
-            // as a Delta/S3 commit failure: rows stay durable in MemBuffer + WAL
-            // and the next cycle retries. (`drain_to_budget` already declines to
-            // run without a callback, so this cannot spin.)
+        // A missing callback must FAIL the flush, never "succeed" having
+        // written nothing. The caller treats Ok as "the rows are durable in
+        // Delta" and drains them out of MemBuffer + advances the WAL
+        // watermark, so returning Ok here destroyed every row in the bucket
+        // and left only a warn line — while `layer.is_empty()` and the flush
+        // metrics both reported success. Failing puts it on the same footing
+        // as a Delta/S3 commit failure: rows stay durable in MemBuffer + WAL
+        // and the next cycle retries. (`drain_to_budget` already declines to
+        // run without a callback, so this cannot spin.)
+        let Some(callback) = self.delta_write_callback.as_ref() else {
             return Err(anyhow::anyhow!(
                 "no delta write callback configured for {}.{} — refusing to drain bucket {} (rows stay in MemBuffer + WAL)",
                 bucket.project_id,
                 bucket.table_name,
                 bucket.bucket_id
             ));
+        };
+        // Await ensures Delta commit completes before we return.
+        let commit = callback(bucket.project_id.clone(), bucket.table_name.clone(), batches.clone(), delta_watermark);
+        // Watchdog: an un-timed-out commit that hangs would pin `flush_lock`
+        // forever with no log (see `d_flush_bucket_timeout_secs`). On elapse
+        // we bail so the caller counts flush_failed + retries next cycle;
+        // rows stay durable in MemBuffer + WAL. 0 disables the watchdog.
+        //
+        // Abandoned-commit window: dropping the timed-out future cancels
+        // its polling, but a Delta commit PUT already issued to S3 can
+        // still land after the drop. The retained bucket is then re-
+        // committed next cycle → the same rows land twice. Accepted:
+        // dedup_keys (write-side) and DedupExec (read-side) collapse the
+        // duplicates, and a slow-but-successful commit is rare next to a
+        // truly hung one; size the timeout well above normal commit p99.
+        let timeout = self.adaptive_flush_timeout();
+        let added_files = if timeout.is_zero() {
+            commit.await?
+        } else {
+            tokio::time::timeout(timeout, commit)
+                .await
+                .map_err(|_| {
+                    crate::observability::record_flush_stalled();
+                    error!(
+                        "flush_bucket Delta commit stalled >{:?} (project={}, table={}, bucket_id={}) — aborting this flush so flush_lock releases and relief can retry; rows remain durable in MemBuffer + WAL",
+                        timeout, bucket.project_id, bucket.table_name, bucket.bucket_id
+                    );
+                    anyhow::anyhow!("flush_bucket commit timed out after {:?} (Delta/S3 stalled)", timeout)
+                })??
         };
         self.index_flushed_files(bucket, batches, added_files);
         Ok(())
@@ -3321,10 +3301,8 @@ impl BufferedWriteLayer {
     /// advances freely after relief commits while never crossing buffered data.
     ///
     /// Best-effort: a failure only means a crash re-replays a bit more.
-    fn refresh_replay_rewind_marker(
-        &self, p0: &std::collections::HashMap<(String, String), ShardHolds>, applied_frontiers: &std::collections::HashMap<(String, String), ShardHolds>,
-    ) {
-        let positions: std::collections::HashMap<(String, String), ShardHolds> = p0
+    fn refresh_replay_rewind_marker(&self, p0: &HashMap<(String, String), ShardHolds>, applied_frontiers: &HashMap<(String, String), ShardHolds>) {
+        let positions: HashMap<(String, String), ShardHolds> = p0
             .iter()
             .map(|(key, p0_holds)| {
                 let baseline = applied_frontiers.get(key).unwrap_or(p0_holds).clone();
@@ -3953,7 +3931,7 @@ impl BufferedWriteLayer {
     /// fields — cannot resolve, quarantining every `UPDATE ... FROM` on restart
     /// (the 2026-07-05 "No field named otel_logs_and_spans.context___span_id"
     /// flood). `source_cols` are the source batch's field names.
-    fn normalized_wal_sql(expr: &datafusion::logical_expr::Expr, source_cols: &std::collections::HashSet<String>) -> String {
+    fn normalized_wal_sql(expr: &datafusion::logical_expr::Expr, source_cols: &HashSet<String>) -> String {
         use datafusion::{common::tree_node::TreeNode, logical_expr::Expr};
         let bare = strip_column_qualifiers(expr.clone()).unwrap_or_else(|_| expr.clone());
         let normalized = bare
@@ -3978,9 +3956,7 @@ impl BufferedWriteLayer {
         Self::expr_to_wal_sql(&strip_column_qualifiers(expr.clone()).unwrap_or_else(|_| expr.clone()))
     }
 
-    fn assignments_to_wal_sql(
-        assignments: &[(String, datafusion::logical_expr::Expr)], source_cols: &std::collections::HashSet<String>,
-    ) -> Vec<(String, String)> {
+    fn assignments_to_wal_sql(assignments: &[(String, datafusion::logical_expr::Expr)], source_cols: &HashSet<String>) -> Vec<(String, String)> {
         assignments.iter().map(|(col, expr)| (col.clone(), Self::normalized_wal_sql(expr, source_cols))).collect()
     }
 
@@ -4049,7 +4025,7 @@ impl BufferedWriteLayer {
     ) -> datafusion::error::Result<u64> {
         let _admission = self.admit_write().map_err(|e| datafusion::error::DataFusionError::Execution(e.to_string()))?;
         let predicate_sql = predicate.map(Self::stripped_wal_sql);
-        let assignments_sql = Self::assignments_to_wal_sql(assignments, &std::collections::HashSet::new());
+        let assignments_sql = Self::assignments_to_wal_sql(assignments, &HashSet::new());
         // See `delete()` — WAL failure must propagate so the client doesn't
         // see a "successful" update that disappears on the next restart.
         self.with_wal_pin(
@@ -4071,7 +4047,7 @@ impl BufferedWriteLayer {
         assignments: &[(String, datafusion::logical_expr::Expr)], source: &crate::dml::UpdateSource,
     ) -> datafusion::error::Result<u64> {
         let _admission = self.admit_write().map_err(|e| datafusion::error::DataFusionError::Execution(e.to_string()))?;
-        let source_cols: std::collections::HashSet<String> = source.schema.fields().iter().map(|f| f.name().clone()).collect();
+        let source_cols: HashSet<String> = source.schema.fields().iter().map(|f| f.name().clone()).collect();
         let predicate_sql = predicate.map(|p| Self::normalized_wal_sql(p, &source_cols));
         let assignments_sql = Self::assignments_to_wal_sql(assignments, &source_cols);
         let batch_ipc = crate::write::wal::serialize_record_batch(&source.batch).map_err(wal_err("source serialize"))?;
@@ -4292,7 +4268,7 @@ mod tests {
     #[test]
     fn normalized_wal_sql_strips_qualifiers_and_prefixes_source() {
         use datafusion::logical_expr::col;
-        let source_cols: std::collections::HashSet<String> = ["id", "tag"].iter().map(|s| s.to_string()).collect();
+        let source_cols: HashSet<String> = ["id", "tag"].iter().map(|s| s.to_string()).collect();
 
         let pred = col("otel_logs_and_spans.context___span_id").is_not_null();
         let norm = BufferedWriteLayer::normalized_wal_sql(&pred, &source_cols);
@@ -4410,8 +4386,8 @@ mod tests {
         let test_id = &uuid::Uuid::new_v4().to_string()[..4];
         let (project, table) = (format!("p{test_id}"), format!("t{test_id}"));
 
-        let commits = Arc::new(std::sync::atomic::AtomicU64::new(0));
-        let rows = Arc::new(std::sync::atomic::AtomicU64::new(0));
+        let commits = Arc::new(AtomicU64::new(0));
+        let rows = Arc::new(AtomicU64::new(0));
         let (c, r) = (commits.clone(), rows.clone());
         let mut layer = crate::support::test_helpers::test_layer(cfg).unwrap();
         layer.delta_write_callback = Some(Arc::new(move |_p: String, _t: String, batches: Vec<RecordBatch>, _w| {
@@ -4457,7 +4433,7 @@ mod tests {
         let test_id = &uuid::Uuid::new_v4().to_string()[..4];
         let (project, table) = (format!("p{test_id}"), format!("t{test_id}"));
 
-        let commits = Arc::new(std::sync::atomic::AtomicU64::new(0));
+        let commits = Arc::new(AtomicU64::new(0));
         let c = commits.clone();
         let mut layer = crate::support::test_helpers::test_layer(cfg).unwrap();
         layer.delta_write_callback = Some(Arc::new(move |_p: String, _t: String, _b: Vec<RecordBatch>, _w| {
@@ -4590,7 +4566,7 @@ mod tests {
         let table = format!("cf{test_id}");
         let projects: Vec<String> = (0..3).map(|i| format!("fp{i}{test_id}")).collect();
 
-        let fail = Arc::new(std::sync::atomic::AtomicBool::new(true));
+        let fail = Arc::new(AtomicBool::new(true));
         let f = fail.clone();
         let mut layer = crate::support::test_helpers::test_layer(Arc::clone(&cfg)).unwrap();
         layer.coalesced_write_callback =
@@ -5119,9 +5095,9 @@ mod tests {
         // Second life: tight budget — replay must flush-to-make-room.
         let cfg_small = test_config_with(dir.path().to_path_buf(), |c| c.buffer.timefusion_buffer_max_memory_mb = 64);
 
-        let flushed_rows = Arc::new(std::sync::atomic::AtomicU64::new(0));
-        let flushes = Arc::new(std::sync::atomic::AtomicU64::new(0));
-        let unsafe_claims = Arc::new(std::sync::atomic::AtomicU64::new(0));
+        let flushed_rows = Arc::new(AtomicU64::new(0));
+        let flushes = Arc::new(AtomicU64::new(0));
+        let unsafe_claims = Arc::new(AtomicU64::new(0));
         let (fr, fl, tc) = (flushed_rows.clone(), flushes.clone(), unsafe_claims.clone());
         let mut layer = crate::support::test_helpers::test_layer(Arc::clone(&cfg_small)).unwrap();
         let wal_probe = Arc::clone(layer.wal());
@@ -5146,7 +5122,7 @@ mod tests {
                 Ok(vec![format!("s3://test/otel_logs_and_spans/project_id={p}/date=2026-07-20/part-{t}.parquet")])
             })
         }));
-        let tantivy_builds = Arc::new(std::sync::atomic::AtomicU64::new(0));
+        let tantivy_builds = Arc::new(AtomicU64::new(0));
         let tb = tantivy_builds.clone();
         layer.tantivy_index_callback = Some(Arc::new(move |_p, _t, _b, _files| {
             let tb = tb.clone();
@@ -5878,7 +5854,7 @@ mod tests {
     #[serial]
     #[tokio::test(flavor = "multi_thread")]
     async fn already_drained_shutdown_caps_wedged_worker_handoff_to_250ms() {
-        struct Dropped(Arc<std::sync::atomic::AtomicBool>);
+        struct Dropped(Arc<AtomicBool>);
         impl Drop for Dropped {
             fn drop(&mut self) {
                 self.0.store(true, Ordering::Release);
@@ -5888,7 +5864,7 @@ mod tests {
         let dir = tempdir().unwrap();
         let cfg = test_config_with(dir.path().to_path_buf(), |c| c.buffer.timefusion_stop_grace_secs = 70);
         let layer = Arc::new(crate::support::test_helpers::test_layer(Arc::clone(&cfg)).unwrap());
-        let worker_dropped = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let worker_dropped = Arc::new(AtomicBool::new(false));
         let dropped = Arc::clone(&worker_dropped);
         let worker_started = Arc::new(Notify::new());
         let started_signal = Arc::clone(&worker_started);
@@ -6458,13 +6434,13 @@ mod tests {
         let table = format!("o{}", test_id);
 
         // Use a stub delta callback so flush succeeds without S3.
-        let delta_calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let delta_calls = Arc::new(AtomicUsize::new(0));
         let delta_calls_cb = delta_calls.clone();
         let mut layer = crate::support::test_helpers::test_layer(Arc::clone(&cfg)).unwrap();
         layer.delta_write_callback = Some(Arc::new(move |_p, _t, _batches, _wm| {
             let c = delta_calls_cb.clone();
             Box::pin(async move {
-                c.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                c.fetch_add(1, Ordering::SeqCst);
                 Ok(Vec::new())
             })
         }));
@@ -6484,7 +6460,7 @@ mod tests {
 
         // Flush only completed (= old) buckets. Open bucket stays in MemBuffer + WAL.
         layer.flush_completed_buckets().await.unwrap();
-        assert!(delta_calls.load(std::sync::atomic::Ordering::SeqCst) >= 1, "old bucket should have flushed");
+        assert!(delta_calls.load(Ordering::SeqCst) >= 1, "old bucket should have flushed");
 
         // Drop this layer; spin up a fresh one and recover. The open bucket's
         // WAL entry must still be there.
@@ -6783,14 +6759,14 @@ mod tests {
         let project = format!("g{}", test_id);
         let table = format!("g{}", test_id);
 
-        let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let calls = Arc::new(AtomicUsize::new(0));
         let calls_cb = calls.clone();
         {
             let mut layer = crate::support::test_helpers::test_layer(Arc::clone(&cfg)).unwrap();
             layer.delta_write_callback = Some(Arc::new(move |_p, _t, _b, _wm| {
                 let c = calls_cb.clone();
                 Box::pin(async move {
-                    c.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    c.fetch_add(1, Ordering::SeqCst);
                     Ok(Vec::new())
                 })
             }));
@@ -6804,7 +6780,7 @@ mod tests {
             layer.insert(&project, &table, vec![create_test_batch(&project)]).await.unwrap();
 
             layer.force_flush_current_buckets().await.unwrap();
-            assert_eq!(calls.load(std::sync::atomic::Ordering::SeqCst), 1, "force-flush must drain the open window even with a stuck completed bucket");
+            assert_eq!(calls.load(Ordering::SeqCst), 1, "force-flush must drain the open window even with a stuck completed bucket");
             // Crash: drop without shutdown.
         }
 
@@ -7050,8 +7026,6 @@ mod replay_cost_probe {
 }
 
 // ===== batch_queue =====
-use std::collections::HashMap;
-
 use anyhow::{Result, anyhow};
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
@@ -7072,10 +7046,7 @@ fn group_by_project(batches: impl IntoIterator<Item = RecordBatch>) -> HashMap<S
                 .ok()
         })
         .flatten()
-        .fold(HashMap::new(), |mut grouped, (project_id, sub)| {
-            grouped.entry(project_id).or_default().push(sub);
-            grouped
-        })
+        .into_group_map()
 }
 
 impl BatchQueue {
@@ -7195,9 +7166,8 @@ mod batch_queue_tests {
 // a node per cell, because a prepared statement retains its whole plan for
 // the life of the connection. See `rewrite_plan`.
 
-use std::sync::{OnceLock, atomic::AtomicI64};
+use std::sync::OnceLock;
 
-use dashmap::DashMap;
 use datafusion::{
     arrow::{
         array::{Array, ArrayRef, TimestampMicrosecondArray},

--- a/src/write/wal.rs
+++ b/src/write/wal.rs
@@ -63,6 +63,15 @@ pub fn meta_path(data_dir: &Path, file: &str) -> PathBuf {
     data_dir.join(META_DIR).join(file)
 }
 
+/// Remove `path`, treating "already absent" as success — every caller here
+/// wants the goal state ("no file"), not the event.
+fn remove_if_exists(path: &Path) -> std::io::Result<()> {
+    match std::fs::remove_file(path) {
+        Err(e) if e.kind() != std::io::ErrorKind::NotFound => Err(e),
+        _ => Ok(()),
+    }
+}
+
 /// Magic bytes identifying the WAL format ("WAL2").
 const WAL_MAGIC: [u8; 4] = [0x57, 0x41, 0x4C, 0x32];
 /// Insert batches are stored as Arrow IPC stream bytes. Embeds the schema so
@@ -643,7 +652,7 @@ impl WalManager {
     pub fn replay_iter(&self) -> Result<WalReplayIter<'_>, WalError> {
         Ok(WalReplayIter {
             wal: self,
-            topics: self.list_topics(),
+            topics: self.known_topics.iter().map(|t| t.clone()).collect(),
             topic_idx: 0,
             heap: std::collections::BinaryHeap::new(),
             shard_keys: Vec::new(),
@@ -701,12 +710,8 @@ impl WalManager {
         }
     }
 
-    fn list_topics(&self) -> Vec<String> {
-        self.known_topics.iter().map(|t| t.clone()).collect()
-    }
-
-    /// Same as `list_topics` but parsed into `(project_id, table_name)` pairs.
-    /// Callers iterating topics shouldn't need to know the joining convention.
+    /// Known topics parsed into `(project_id, table_name)` pairs. Callers
+    /// iterating topics shouldn't need to know the joining convention.
     pub fn list_topic_pairs(&self) -> Vec<(String, String)> {
         self.known_topics.iter().filter_map(|t| Self::parse_topic(&t)).collect()
     }
@@ -892,10 +897,7 @@ impl WalManager {
     /// and shallow-scan over commits made since the last good write. NotFound
     /// is silently ignored (caller's intent — "no file" is the goal state).
     pub fn delete_cursor_snapshot(&self) -> Result<(), WalError> {
-        match std::fs::remove_file(self.cursor_snapshot_path()) {
-            Err(e) if e.kind() != std::io::ErrorKind::NotFound => Err(WalError::Io(e)),
-            _ => Ok(()),
-        }
+        Ok(remove_if_exists(&self.cursor_snapshot_path())?)
     }
 
     fn recovery_rewind_path(&self) -> PathBuf {
@@ -992,9 +994,7 @@ impl WalManager {
     }
 
     pub fn remove_recovery_rewind_marker(&self) {
-        if let Err(e) = std::fs::remove_file(self.recovery_rewind_path())
-            && e.kind() != std::io::ErrorKind::NotFound
-        {
+        if let Err(e) = remove_if_exists(&self.recovery_rewind_path()) {
             warn!("failed to remove recovery rewind marker: {}", e);
         }
     }
@@ -1481,7 +1481,7 @@ impl WalDirLock {
 }
 
 pub fn takeover_requested(wal_dir: &std::path::Path) -> bool {
-    wal_dir.join(META_DIR).join(TAKEOVER_REQUEST_FILE).is_file()
+    meta_path(wal_dir, TAKEOVER_REQUEST_FILE).is_file()
 }
 
 /// How long a takeover request has been outstanding, or `None` when none is.
@@ -1489,7 +1489,7 @@ pub fn takeover_requested(wal_dir: &std::path::Path) -> bool {
 /// The predecessor escalates on this: a request it keeps ignoring because it
 /// never reaches handoff readiness is exactly the wedge this bounds.
 pub fn takeover_request_age(wal_dir: &std::path::Path) -> Option<std::time::Duration> {
-    let path = wal_dir.join(META_DIR).join(TAKEOVER_REQUEST_FILE);
+    let path = meta_path(wal_dir, TAKEOVER_REQUEST_FILE);
     let requested_at =
         std::fs::read_to_string(&path).ok()?.split_whitespace().find_map(|field| field.strip_prefix("requested_at_micros=")?.parse::<i64>().ok())?;
     let elapsed = crate::support::now_micros().saturating_sub(requested_at).max(0);
@@ -1497,10 +1497,8 @@ pub fn takeover_request_age(wal_dir: &std::path::Path) -> Option<std::time::Dura
 }
 
 pub fn clear_takeover_request(wal_dir: &std::path::Path) {
-    match std::fs::remove_file(wal_dir.join(META_DIR).join(TAKEOVER_REQUEST_FILE)) {
-        Ok(()) => {}
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-        Err(e) => warn!("could not clear WAL takeover request: {e}"),
+    if let Err(e) = remove_if_exists(&meta_path(wal_dir, TAKEOVER_REQUEST_FILE)) {
+        warn!("could not clear WAL takeover request: {e}");
     }
 }
 
@@ -1544,9 +1542,7 @@ pub fn boot_wal_gc(wal_dir: &std::path::Path) {
         // the un-swept dir only costs startup time, and the next boot
         // re-attempts.
         warn!("bootstrap.phase=wal_gc could not consume drained flag ({e}) — skipping sweep, deleting snapshot");
-        if let Err(rm) = std::fs::remove_file(&target)
-            && rm.kind() != std::io::ErrorKind::NotFound
-        {
+        if let Err(rm) = remove_if_exists(&target) {
             error!(
                 "bootstrap.phase=wal_gc stale drained=true snapshot could not be removed ({rm}) — \
                  delete {:?} manually before the next restart or the boot sweep may delete un-flushed WAL",


### PR DESCRIPTION
Second `rs-distill` round over the database/maintenance/write files, plus the
whole read path (`bloom_prune`, `functions`, `mod`, `optimizers`, `plan_cache`).

**15 files, 1515 insertions / 1843 deletions — a net 328 lines removed.**

Mechanical in character: iterator and itertools pipelines replacing
accumulate-and-push loops, combinators replacing match ladders, expression-form
`match`/`if`. Two changes worth a reviewer's eye:

- `read/optimizers.rs`: `!skip.is_some_and(|s| count(s) != Some(0))` became
  `skip.is_none_or(|s| count(s) == Some(0))` — clippy's `nonminimal_bool`
  asked for it, and it drops a negation from an OFFSET guard.
- `maintenance_sim.rs`: `synth_run_at` takes `duration_scale` instead of
  duplicating the `SimConfig` literal.

## Verification

The full five-check gate passed locally on this tree before the last rebase:
fmt, clippy, test (1483 passed, 1 flaky retried green, 17 skipped), pg-smoke,
and e2e (63 passed). Attestations were published for each.

Rebased since onto #231 and #232; neither touches any of the 15 files here, so
CI is re-running the gate on the final tree.