### PR TITLE
Avoid whole-day work for narrow hash histograms

### DIFF
--- a/docs/plans/2026-09-08-histogram-rust-review.md
+++ b/docs/plans/2026-09-08-histogram-rust-review.md
@@ -217,3 +217,60 @@ Full local `make ci-signoff` passed all checks for the cleanup: fmt, Clippy,
 1,474 tests, eight doctests, PostgreSQL smoke, and 63 e2e tests. E2E nextest
 `12ac8937-f007-4785-af19-e6d953234d67` passed in 264.468s. All checks are
 attested locally; no failed check was attested.
+
+
+### No-coverage SQL admission — 2026-09-09
+
+Scoped rs-distill pass 1: the planner reuses `Manifest::histogram_entries`
+to select physical-ordinal coverage from the captured manifest. It uses the
+existing membership column set, `try_fold`, `flatten`, and `all`; no new
+configuration or index-selection abstraction is needed. The regression
+extends the existing real SQL/Delta test and preserves its later partial
+coverage, mutable-version, and routing assertions. No consolidation finding.
+
+Scoped rs-evasion pass 1: `histogram_plan` returns its existing `Ok(None)`
+when no captured file has coverage for all predicate columns. The caller
+then performs ordinary SQL planning. Invalid manifest errors still propagate
+to the existing logged planner fallback. The direct captured histogram APIs
+retain their fallback semantics and budgets. No unsafe code, suppression,
+sentinel, or weakened version mask was added. The new regression failed
+before the fix: histogram execution count 1 versus expected 0.
+
+This is an admission fix for zero usable coverage. Partial coverage can
+still incur daily visibility work, and capture still loads the manifest.
+Production latency validation and further narrow-window work remain open.
+
+
+Second scoped pass found two fixture limitations. `build_db` did not call
+`TantivyIndexService::with_reader`, unlike production startup, so it could
+retain an empty cached manifest after publication. Adding that wiring alone
+did not restore the routing assertion: flush indexes deliberately have
+`ordinals_valid: false`. The previous assertion proved histogram fallback
+execution, not use of an ordinal index.
+
+The test now asserts ordinary SQL for the flush-only state, then uses the
+real Parquet index builder to backfill only the newer file. It retains the
+uncovered older file and all existing mutable-version and routing assertions.
+No assertion was relaxed, and no sleep or cache-TTL workaround was added.
+
+rs-distill: the fixture reuses production reader wiring and the existing
+Parquet builder; no new cache or index-building mechanism. rs-evasion:
+publication still uses real Parquet and object storage. The reader remains
+a weak reference, and the fixture never marks flush ordinals valid by fiat.
+Targeted verification is pending.
+
+
+Final targeted run passed: `cargo nextest run --test suite
+mutable_index_filter_cannot_resurrect_an_uncovered_version`, nextest
+`8fe46d7a-ddb8-48ab-813c-5a0698a1bf56`, 3.015s. The test verifies no
+usable coverage, flush-only unusable ordinals, then real partial Parquet
+index coverage with mutable versions, memory rows, and SQL predicate forms.
+A final reread found no additional scoped rs-distill or rs-evasion finding.
+The complete local signoff remains required before pushing.
+
+
+Complete local signoff passed for no-coverage admission: `make ci-signoff`
+exited 0. Formatting, Clippy, 1,474 tests, eight doctests, PostgreSQL smoke,
+and 63 e2e tests passed. Every check was attested locally; final status
+leaves nothing for GitHub. Nextest runs: `e6066424-a057-4119-9366-997afd76a457`
+(full suite) and `59ace074-928a-4245-ac40-4b7774e96168` (e2e).

--- a/docs/plans/2026-09-08-histogram-rust-review.md
+++ b/docs/plans/2026-09-08-histogram-rust-review.md
@@ -274,3 +274,42 @@ exited 0. Formatting, Clippy, 1,474 tests, eight doctests, PostgreSQL smoke,
 and 63 e2e tests passed. Every check was attested locally; final status
 leaves nothing for GitHub. Nextest runs: `e6066424-a057-4119-9366-997afd76a457`
 (full suite) and `59ace074-928a-4245-ac40-4b7774e96168` (e2e).
+
+
+### Narrow-window visibility — 2026-09-09
+
+rs-distill pass 1: use DataFusion's existing `FilterExec` before the sort.
+This avoids a new filtering field or a custom stream adapter. A small bound
+expression closure reuses scalar casts and binary comparisons for the two
+endpoints. Whole-day windows retain the existing plan without an extra filter.
+The regression extends the real captured-histogram fixture.
+
+rs-evasion pass 1: capture requires timestamp in the immutable key. Thus an
+excluded timestamp cannot compete with an included version. The filter
+preserves the complete schema and the already attached source/row ordinals.
+File-date validation, memory authority, DVs, greatest-version ordering, and
+tombstone removal remain intact. The test disables disk spill in its query
+runtime to prove that unrelated same-day keys do not require sort storage;
+this adds no production configuration.
+
+The regression adds 20,000 unique out-of-window keys, each over 2 KiB, to
+the same day as a one-microsecond query with partial index coverage. Before
+the filter, it failed with `Memory Exhausted while Sorting (DiskManager is
+disabled)`. After the filter, it returned the expected count 63 under the
+same 32 MiB pool and released all reservations. The full targeted fixture
+passed in 11.253s, nextest `fcb19cf2-f9f5-40d3-8472-088ae28495d6`. This
+is a resource regression, not a production latency measurement.
+
+Second scoped rs-distill and rs-evasion pass: no additional finding. Bounds
+are cast to the existing timestamp field type, errors propagate, and the
+filter uses inclusive start/exclusive end. No masks, assertions, or budget
+checks were weakened. Further file/row-group pruning and production timing
+remain open. The complete combined change now includes upstream read-path
+refactor `a56f0be8` and requires a fresh local signoff before merge.
+
+
+The combined tree, including upstream `a56f0be8`, passed full local
+`make ci-signoff`: formatting, Clippy, 1,483 tests, ten doctests, PostgreSQL
+smoke, and 63 e2e tests. All checks are attested; none remains for GitHub.
+Full-suite nextest: `0db7b705-7f3b-46d1-8001-84369ca1084b`; e2e:
+`9b29b1d3-b5b7-4a0c-9482-049da39bc1ca`.

--- a/docs/plans/2026-09-08-indexed-hash-histogram-plan.md
+++ b/docs/plans/2026-09-08-indexed-hash-histogram-plan.md
@@ -740,3 +740,75 @@ schema deploy, verify new coverage convergence and histogram routing, then
 repeat the saved bounded correctness/latency probe before widening ranges.
 The remaining reviews, complete-path benchmarks, and CPU/memory profiling
 remain open. Next audit: 07:49 UTC.
+
+
+### First live automatic-index validation — 2026-09-09 07:42 UTC
+
+Production now serves `413f1ef`. The saved one-second histogram probe timed
+out at 3113.41ms; its ID control returned the expected event in 1091.47ms.
+Two repeats returned the correct count in 367.20ms, then timed out at
+3119.62ms. Histogram execution counters remained zero. Coverage reported
+2,391 uncovered files, zero oversized skips, and zero backfill builds.
+
+Logs show the first request triggered a uniqueness proof for 2026-09-02,
+which completed in about five seconds with 3,031,107 rows. The source also
+resolves daily visibility before fallback. Investigate that work for narrow
+queries without usable element indexes; do not treat a successful repeat
+or the running service as production performance success. The probe JSON
+files record the exact SQL and results. Count-merging cleanup PR #232 is
+merged at `21a458c5` after complete local signoff.
+
+
+### Goal audit — 2026-09-09 07:49 UTC
+
+The previous turn verified the requested remote pull; it made no feature
+change. This turn reproduced unnecessary histogram execution locally: a
+one-microsecond SQL query against an unindexed Delta file returned the
+correct count but incremented the histogram execution counter. The new
+regression assertion failed with 1 versus the expected 0. The planner now
+checks captured physical-ordinal element coverage before executing the
+histogram or seeding a proof. Targeted verification is running. The same
+test subsequently exercises partial indexed coverage and newer versions.
+
+Deployment run 34323175414 completed successfully. Production logs show
+automatic backfill started at 07:45:11 with 52 files (1,959 MiB) selected,
+and index builds completed at 07:45:35. A follow-up statistics connection
+timed out; this does not establish a service failure or coverage convergence.
+The narrow-query fix, repeated reviews, local signoff, deployment validation,
+full-range benchmarks, and CPU/memory profiles remain open. Next audit:
+08:19 UTC.
+
+
+### Local no-coverage regression — 2026-09-09 07:55 UTC
+
+The regression passed in 3.015s after adding automatic SQL admission and
+correcting the integration fixture. The fixture now checks three states:
+no index, a flush index without physical ordinals, and a Parquet-backed
+index for only the newer file. Existing version, memory, and membership
+assertions still pass. The first two states use ordinary SQL; the third
+uses the histogram service automatically. Full `make ci-signoff` is running.
+
+The next performance investigation must retain the original scope: partial
+coverage still sorts daily visibility. Timestamp belongs to the immutable
+key, so rows outside the requested timestamp interval cannot compete with
+rows inside it. Test narrowing visibility before the sort while preserving
+physical ordinals, DV exclusions, tombstones, and memory authority. Do not
+claim that the no-coverage admission fix resolves partial-coverage latency.
+
+
+### Production routing comparison — 2026-09-09 07:58 UTC
+
+The production task changed at 07:54:49 without changing image `413f1ef`.
+The old task exited 0; startup reported a clean cursor snapshot. The old
+container has already been removed, so the restart cause is unverified.
+The statistics query now succeeds in 265ms: 2,380 uncovered files, zero
+oversized skips, four completed histogram snapshots, and no unique-partition
+counts. The restart reset process counters, so they cannot establish build
+throughput across the restart.
+
+On the same connection, ordinary SQL using `count(timestamp)` returned
+the known count 1 in 314.46ms. The otherwise identical `count(*)` histogram
+query timed out in 3140.29ms. Both include explicit timestamp bounds, so
+null timestamps cannot change the count. This strengthens the evidence
+that histogram routing adds work for this narrow query. Exact SQL and
+results are saved in `production-histogram-ordinary-comparison.json`.

--- a/docs/plans/2026-09-08-indexed-hash-histogram-plan.md
+++ b/docs/plans/2026-09-08-indexed-hash-histogram-plan.md
@@ -812,3 +812,35 @@ query timed out in 3140.29ms. Both include explicit timestamp bounds, so
 null timestamps cannot change the count. This strengthens the evidence
 that histogram routing adds work for this narrow query. Exact SQL and
 results are saved in `production-histogram-ordinary-comparison.json`.
+
+
+### Combined narrow-query fixes — 2026-09-09 08:15 UTC
+
+No-coverage admission passed complete local signoff and was pushed as
+`7a112910` in PR #234. Before merge, master advanced to `a56f0be8` with
+a substantial read-path refactor. That upstream change was merged locally.
+
+A separate checkout reproduced the remaining daily-sort problem: 20,000
+out-of-window keys exhausted the 32 MiB query pool with spill disabled.
+Filtering the captured visibility input before the sort made the same test
+pass, including the expected count 63 and zero retained reservations. This
+filter preserves physical lineage and relies on timestamp being an immutable
+key. The two fixes are now combined for a fresh local signoff and one release.
+Production serves `21a458c`; these fixes are not deployed yet.
+
+
+### Goal audit — 2026-09-09 08:19 UTC
+
+The previous goal turn made concrete progress: admission was pushed in PR
+#234 after full local signoff, and a resource regression proved the need to
+filter narrow windows before sorting. The filter passed that regression.
+Both fixes and upstream `a56f0be8` are now under a fresh local signoff.
+Formatting and Clippy have passed; the full test build is running. No
+production performance claim is justified yet.
+
+The next release must pass the combined local checks, merge, deploy, and
+repeat the saved ordinary-SQL/histogram comparison. Coverage convergence,
+partial-coverage latency, full SQL 3/7/30-day benchmarks, repeated broader
+reviews, and CPU/memory profiles remain open. Benchmark preparation now
+targets real SQL planning and Delta visibility, with independent expected
+bucket counts. Next audit: 08:49 UTC.

--- a/docs/plans/evidence/2026-09-08-hashes/production-automatic-index-coverage-followup.json
+++ b/docs/plans/evidence/2026-09-08-hashes/production-automatic-index-coverage-followup.json
@@ -1,0 +1,33 @@
+{
+  "recorded_at": "2026-09-09T07:57:41.018709+00:00",
+  "image": "413f1ef",
+  "task": "d4a6ys7pcwt6dyeo8lllz5k5m",
+  "stats": [
+    [
+      "maintenance",
+      "tantivy_uncovered_files",
+      "2380"
+    ],
+    [
+      "maintenance",
+      "tantivy_oversized_skipped",
+      "0"
+    ],
+    [
+      "scan",
+      "tantivy_backfill_built",
+      "0"
+    ],
+    [
+      "tantivy",
+      "histogram_snapshots",
+      "4"
+    ],
+    [
+      "tantivy",
+      "histogram_unique_partitions",
+      "0"
+    ]
+  ],
+  "elapsed_ms": 265.35
+}

--- a/docs/plans/evidence/2026-09-08-hashes/production-automatic-index-first-probe.json
+++ b/docs/plans/evidence/2026-09-08-hashes/production-automatic-index-first-probe.json
@@ -1,0 +1,76 @@
+{
+  "recorded_at": "2026-09-09T07:40:48.750355+00:00",
+  "service_image": "ghcr.io/monoscope-tech/timefusion:413f1ef",
+  "queries": [
+    {
+      "name": "hash_histogram_one_second",
+      "sql": "SELECT time_bucket('1 hour',timestamp), count(*) FROM otel_logs_and_spans WHERE project_id='00000000-0000-0000-0000-000000000000' AND timestamp >= TIMESTAMP '2026-09-02 08:04:30' AND timestamp < TIMESTAMP '2026-09-02 08:04:31' AND hashes @> ARRAY['err:e03848c6'] GROUP BY 1",
+      "error_type": "QueryCanceled",
+      "elapsed_ms": 3113.41
+    },
+    {
+      "name": "known_event_control",
+      "sql": "SELECT id FROM otel_logs_and_spans WHERE project_id='00000000-0000-0000-0000-000000000000' AND timestamp >= TIMESTAMP '2026-09-02 08:04:30' AND timestamp < TIMESTAMP '2026-09-02 08:04:31' AND id='1da21fbb-1d78-555f-ae88-a10edfc3afdf' AND hashes @> ARRAY['err:e03848c6'] LIMIT 1",
+      "rows": [
+        [
+          "1da21fbb-1d78-555f-ae88-a10edfc3afdf"
+        ]
+      ],
+      "elapsed_ms": 1091.47
+    }
+  ],
+  "stats_before": [
+    [
+      "maintenance",
+      "tantivy_uncovered_files",
+      "2391"
+    ],
+    [
+      "maintenance",
+      "tantivy_oversized_skipped",
+      "0"
+    ],
+    [
+      "scan",
+      "tantivy_backfill_built",
+      "0"
+    ],
+    [
+      "tantivy",
+      "histogram_snapshots",
+      "0"
+    ],
+    [
+      "tantivy",
+      "histogram_unique_partitions",
+      "0"
+    ]
+  ],
+  "stats_after": [
+    [
+      "maintenance",
+      "tantivy_uncovered_files",
+      "2391"
+    ],
+    [
+      "maintenance",
+      "tantivy_oversized_skipped",
+      "0"
+    ],
+    [
+      "scan",
+      "tantivy_backfill_built",
+      "0"
+    ],
+    [
+      "tantivy",
+      "histogram_snapshots",
+      "0"
+    ],
+    [
+      "tantivy",
+      "histogram_unique_partitions",
+      "0"
+    ]
+  ]
+}

--- a/docs/plans/evidence/2026-09-08-hashes/production-automatic-index-repeat-probe.json
+++ b/docs/plans/evidence/2026-09-08-hashes/production-automatic-index-repeat-probe.json
@@ -1,0 +1,41 @@
+{
+  "recorded_at": "2026-09-09T07:41:55.078333+00:00",
+  "sql": "SELECT time_bucket('1 hour',timestamp), count(*) FROM otel_logs_and_spans WHERE project_id='00000000-0000-0000-0000-000000000000' AND timestamp >= TIMESTAMP '2026-09-02 08:04:30' AND timestamp < TIMESTAMP '2026-09-02 08:04:31' AND hashes @> ARRAY['err:e03848c6'] GROUP BY 1",
+  "samples": [
+    {
+      "rows": [
+        [
+          "2026-09-02 08:00:00+00:00",
+          1
+        ]
+      ],
+      "elapsed_ms": 367.2
+    },
+    {
+      "error_type": "QueryCanceled",
+      "elapsed_ms": 3119.62
+    }
+  ],
+  "stats": [
+    [
+      "maintenance",
+      "tantivy_uncovered_files",
+      "2391"
+    ],
+    [
+      "scan",
+      "tantivy_backfill_built",
+      "0"
+    ],
+    [
+      "tantivy",
+      "histogram_snapshots",
+      "0"
+    ],
+    [
+      "tantivy",
+      "histogram_unique_partitions",
+      "0"
+    ]
+  ]
+}

--- a/docs/plans/evidence/2026-09-08-hashes/production-histogram-ordinary-comparison.json
+++ b/docs/plans/evidence/2026-09-08-hashes/production-histogram-ordinary-comparison.json
@@ -1,0 +1,23 @@
+{
+  "recorded_at": "2026-09-09T07:57:59.064524+00:00",
+  "image": "413f1ef",
+  "samples": [
+    {
+      "name": "ordinary_count_timestamp",
+      "sql": "SELECT time_bucket('1 hour',timestamp), count(timestamp) FROM otel_logs_and_spans WHERE project_id='00000000-0000-0000-0000-000000000000' AND timestamp >= TIMESTAMP '2026-09-02 08:04:30' AND timestamp < TIMESTAMP '2026-09-02 08:04:31' AND hashes @> ARRAY['err:e03848c6'] GROUP BY 1",
+      "rows": [
+        [
+          "2026-09-02 08:00:00+00:00",
+          1
+        ]
+      ],
+      "elapsed_ms": 314.46
+    },
+    {
+      "name": "histogram_count_star",
+      "sql": "SELECT time_bucket('1 hour',timestamp), count(*) FROM otel_logs_and_spans WHERE project_id='00000000-0000-0000-0000-000000000000' AND timestamp >= TIMESTAMP '2026-09-02 08:04:30' AND timestamp < TIMESTAMP '2026-09-02 08:04:31' AND hashes @> ARRAY['err:e03848c6'] GROUP BY 1",
+      "error_type": "QueryCanceled",
+      "elapsed_ms": 3140.29
+    }
+  ]
+}

--- a/src/database/histogram.rs
+++ b/src/database/histogram.rs
@@ -309,6 +309,24 @@ impl CapturedHistogram {
                 memory_plan,
             ])?
         };
+        // Timestamp is part of the immutable key, so out-of-window rows
+        // cannot defeat an in-window version. Filter before retaining sort rows.
+        let (start, end) = self.window.bounds();
+        let input: Arc<dyn datafusion::physical_plan::ExecutionPlan> = if start > lo || end < hi {
+            use datafusion::{
+                common::ScalarValue,
+                logical_expr::Operator,
+                physical_expr::expressions::{Column, binary, lit},
+            };
+            let schema = input.schema();
+            let timestamp = Arc::new(Column::new_with_schema("timestamp", &schema)?);
+            let data_type = schema.field_with_name("timestamp")?.data_type();
+            let bound = |value, op| -> Result<_> { Ok(binary(timestamp.clone(), op, lit(ScalarValue::Int64(Some(value)).cast_to(data_type)?), &schema)?) };
+            let predicate = binary(bound(start, Operator::GtEq)?, Operator::And, bound(end, Operator::Lt)?, &schema)?;
+            Arc::new(datafusion::physical_plan::filter::FilterExec::try_new(predicate, input)?)
+        } else {
+            input
+        };
         let masks = stream_winner_masks(input, source_rows, &self.keys, self.tiebreak.as_deref(), self.tombstone.as_deref(), self.context.clone()).await?;
         let mask_bytes = masks.iter().map(|mask| mask.inner().capacity()).try_fold(0_usize, usize::checked_add).context("histogram mask size overflow")?;
         let _mask_owner = self.cache.reserve(mask_bytes, self.context.memory_pool())?;
@@ -913,7 +931,12 @@ mod tests {
         let wide_window = HistogramWindow::new(wide_timestamp, wide_timestamp + 1, 1_000_000, 0, 2)?;
         let pool: Arc<dyn datafusion::execution::memory_pool::MemoryPool> =
             Arc::new(datafusion::execution::memory_pool::GreedyMemoryPool::new(32 * 1024 * 1024));
-        let runtime = datafusion::execution::runtime_env::RuntimeEnvBuilder::new().with_memory_pool(pool.clone()).build_arc()?;
+        let runtime = datafusion::execution::runtime_env::RuntimeEnvBuilder::new()
+            .with_memory_pool(pool.clone())
+            .with_disk_manager_builder(
+                datafusion::execution::disk_manager::DiskManagerBuilder::default().with_mode(datafusion::execution::disk_manager::DiskManagerMode::Disabled),
+            )
+            .build_arc()?;
         let wide_context = datafusion::prelude::SessionContext::new_with_config_rt(Default::default(), runtime).task_ctx();
         let wide = db.capture_histogram(&project, table, wide_window, Some(&membership), 64 * 1024 * 1024, wide_context.clone()).await?;
         let Err(error) = wide.count().await else { anyhow::bail!("wide hashes must exceed the old decoded budget") };
@@ -922,12 +945,27 @@ mod tests {
         assert_eq!(result.counts.values().sum::<u64>(), 64);
         assert_eq!(result.scanned_sources, 0, "wide hashes stay in the index during version resolution");
         db.insert_records_batch(&project, table, vec![json_to_batch_for(table, vec![wide_row(1, "b")])?], true, None).await?;
-        let partial = db.capture_histogram(&project, table, wide_window, Some(&membership), 64 * 1024 * 1024, wide_context).await?;
+        let partial = db.capture_histogram(&project, table, wide_window, Some(&membership), 64 * 1024 * 1024, wide_context.clone()).await?;
         let result = partial.count_streaming().await?;
         assert_eq!(result.counts.values().sum::<u64>(), 63, "an unindexed replacement must suppress its indexed old version");
         assert_eq!(result.scanned_sources, 1);
         assert_eq!(wide.count_streaming().await?.counts.values().sum::<u64>(), 64, "later writes cannot replace captured sources");
         assert_eq!(pool.reserved(), 0, "streaming query reservations must release after counting");
+        // Irrelevant keys in the same day must not consume the query's sort
+        // budget. Keep a partial index and the same one-microsecond window.
+        let outside_timestamp = wide_timestamp.div_euclid(DAY_MICROS) * DAY_MICROS + (wide_timestamp.rem_euclid(DAY_MICROS) + 1) % DAY_MICROS;
+        let records = (0..20_000)
+            .map(|id| {
+                let mut record = wide_row(id, "outside");
+                record["id"] = serde_json::json!(format!("outside-{id}-{}", "x".repeat(2048)));
+                record["timestamp"] = serde_json::json!(outside_timestamp);
+                record
+            })
+            .collect();
+        db.insert_records_batch(&project, table, vec![json_to_batch_for(table, records)?], true, None).await?;
+        let narrow = db.capture_histogram(&project, table, wide_window, Some(&membership), 64 * 1024 * 1024, wide_context).await?;
+        assert_eq!(narrow.count_streaming().await?.counts.values().sum::<u64>(), 63, "out-of-window keys must not force a daily sort or spill");
+        assert_eq!(pool.reserved(), 0);
         // Removing the superseded physical row makes the partition unique.
         // The same Parquet paths now have a different DV identity.
         let mut table_guard = table_ref.write().await;

--- a/src/database/histogram.rs
+++ b/src/database/histogram.rs
@@ -642,6 +642,21 @@ impl super::Database {
         let Some(query) = crate::tantivy::planner::match_query(plan) else { return Ok(None) };
         let captured =
             self.capture_histogram(&query.project, &query.table, query.window, Some(&query.membership), 64 * 1024 * 1024, session.task_ctx()).await?;
+        // With no usable element index, ordinary SQL can prune a narrow time
+        // window without sorting daily visibility or starting a daily proof.
+        let columns = query.membership.columns();
+        let has_index = captured.partitions.values().try_fold(false, |found, files| -> Result<bool> {
+            Ok(found
+                || captured
+                    .manifest
+                    .histogram_entries(&captured.root, files)?
+                    .iter()
+                    .flatten()
+                    .any(|entry| columns.iter().all(|column| entry.entry.element_fields.contains(*column))))
+        })?;
+        if !has_index {
+            return Ok(None);
+        }
         drop(captured.seed_missing_proof(self));
         let result = captured.count_streaming().await?;
         for error in &result.index_errors {

--- a/tests/suite/tantivy_e2e_test.rs
+++ b/tests/suite/tantivy_e2e_test.rs
@@ -18,7 +18,7 @@
 
 use std::{path::PathBuf, sync::Arc};
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use arrow::array::{Array, RecordBatch};
 use datafusion::{arrow::array::AsArray, execution::context::SessionContext};
 use serde_json::json;
@@ -81,6 +81,7 @@ async fn build_db(test_id: &str, tantivy_enabled: bool) -> Result<(Database, Ses
         layer = layer.with_tantivy_indexer(s.clone().callback());
         let cache_root = cfg_arc.core.timefusion_data_dir.clone();
         let search = Arc::new(TantivySearchService::new(obj_store, cache_root, Arc::new(cfg_arc.tantivy.clone())));
+        s.with_reader(&search);
         db = db.with_tantivy_search(search).with_tantivy_indexer(s.clone());
         svc = Some(s);
     }
@@ -218,19 +219,46 @@ async fn mutable_index_filter_cannot_resurrect_an_uncovered_version() -> Result<
     // Direct writes bypass index construction. The update is appended through
     // the buffer, whose flush creates the only indexed file.
     db.insert_records_batch(&project, table, vec![json_to_batch_for(table, vec![row("changed", "a")])?], true, None).await?;
+    let unindexed_sql = format!(
+        "SELECT time_bucket('1 second', timestamp), count(*) FROM {table} WHERE project_id='{project}' AND timestamp >= TIMESTAMP '{}' AND timestamp < TIMESTAMP '{}' AND array_has(hashes, 'a') GROUP BY 1",
+        now.format("%Y-%m-%d %H:%M:%S%.6f"),
+        (now + chrono::Duration::microseconds(1)).format("%Y-%m-%d %H:%M:%S%.6f")
+    );
+    let before = db.tantivy_search().unwrap().stats.histogram_snapshots.load(std::sync::atomic::Ordering::Relaxed);
+    let result = ctx.sql(&unindexed_sql).await?.collect().await?;
+    assert_eq!(result.iter().flat_map(|batch| batch.column(1).as_primitive::<arrow::datatypes::Int64Type>().values()).sum::<i64>(), 1);
+    assert_eq!(
+        db.tantivy_search().unwrap().stats.histogram_snapshots.load(std::sync::atomic::Ordering::Relaxed),
+        before,
+        "without usable indexes, narrow SQL must avoid whole-day histogram visibility work"
+    );
     let mut newer = vec![row("changed", "b")];
     newer.extend((0..9).map(|i| row(&format!("filler-{i}"), "b")));
     db.insert_records_batch(&project, table, vec![json_to_batch_for(table, newer)?], false, None).await?;
     db.buffered_layer().unwrap().flush_all_now().await?;
     let svc = svc.unwrap();
     let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
-    loop {
+    let manifest = loop {
         let manifest = timefusion::tantivy::load_manifest(svc.object_store.as_ref(), table, &project).await?;
         if manifest.entries.values().any(|entry| entry.index.is_some()) {
-            break;
+            break manifest;
         }
         anyhow::ensure!(tokio::time::Instant::now() < deadline, "index publication timed out");
         tokio::task::yield_now().await;
+    };
+    let result = ctx.sql(&unindexed_sql).await?.collect().await?;
+    assert_eq!(result.iter().map(RecordBatch::num_rows).sum::<usize>(), 0, "the newer nonmatching version must suppress the old match");
+    assert_eq!(
+        db.tantivy_search().unwrap().stats.histogram_snapshots.load(std::sync::atomic::Ordering::Relaxed),
+        before,
+        "a flush index without physical ordinals cannot accelerate the histogram"
+    );
+    // Backfill only the newer file, preserving the uncovered older version.
+    let table_ref = db.resolve_table(&project, table).await?;
+    let store = table_ref.read().await.log_store().object_store(None);
+    for uri in manifest.entries.values().flat_map(|entry| &entry.covered_files) {
+        let relative = timefusion::tantivy::search::parquet_rel_of_uri(uri).context("missing relative Parquet path")?;
+        svc.build_index_for_file(table, &project, relative, uri, store.clone()).await?;
     }
     let result = db
         .tantivy_search()


### PR DESCRIPTION
Narrow hash histograms could sort an entire day of visibility rows. In production, a one-second histogram timed out at 3.14 seconds while equivalent ordinary SQL returned the expected count in 314 ms.

The planner now uses ordinary SQL when no captured physical-ordinal index covers the membership columns. With usable partial coverage, it filters visibility to the requested timestamp window before sorting. Timestamp belongs to the immutable key, so excluded rows cannot defeat included versions. Both behaviors are automatic and introduce no configuration flags.

The SQL regression covers no index, unusable flush ordinals, and a real backfilled newer file alongside an uncovered older version. Its fixture now uses production reader wiring. A second regression adds 20,000 large out-of-window keys to a one-microsecond query: the old sort exhausted a 32 MiB pool with spill disabled; the filtered plan returns the expected count 63 and releases all reservations. DVs, physical ordinals, memory authority, and version ordering remain intact.

Validation: both regressions failed before their fixes and passed afterward. The narrow-window fixture passed in 11.253s (nextest `fcb19cf2-f9f5-40d3-8472-088ae28495d6`). After integrating upstream read-path refactor `a56f0be8`, full local `make ci-signoff` passed formatting, Clippy, all 1,483 tests, ten doctests, PostgreSQL smoke, and all 63 e2e tests. Every check is attested locally; no check remains for GitHub and no failed check was attested. Full-suite nextest: `0db7b705-7f3b-46d1-8001-84369ca1084b`; e2e: `9b29b1d3-b5b7-4a0c-9482-049da39bc1ca`.

Two scoped rs-distill and rs-evasion passes reviewed each fix and corrected the fixture limitations. Evidence and review details are in `docs/plans/2026-09-08-indexed-hash-histogram-plan.md` and `docs/plans/2026-09-08-histogram-rust-review.md`. Production latency validation, further file/row-group pruning, and wider query profiling remain open.
