### PR TITLE
Distill server, tantivy and platform modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8403,6 +8403,7 @@ dependencies = [
  "foyer",
  "fs4 0.13.1",
  "futures",
+ "hex",
  "include_dir",
  "insta",
  "instrumented-object-store",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ uuid = { version = "1.17", features = ["v4", "serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_arrow = { version = "0.14", features = ["arrow-58"] }
 serde_json = "1.0.141"
+hex = "0.4"
 serde_with = "3.14"
 serde_yaml = "0.9"
 async-trait = "0.1.86"
@@ -104,7 +105,7 @@ bincode = { version = "2.0", features = ["serde"] }
 walrus-rust = { path = "vendor/walrus-rust" }
 thiserror = "2.0"
 strum = { version = "0.27", features = ["derive"] }
-derive_more = { version = "2", features = ["debug", "display"] }
+derive_more = { version = "2", features = ["debug", "display", "deref", "deref_mut"] }
 # Official datafusion-contrib/datafusion-variant — supports DataFusion 54 / arrow
 # 58.3 as of #62. We carry no local changes, so use upstream directly (pinned).
 datafusion-variant = { git = "https://github.com/datafusion-contrib/datafusion-variant.git", rev = "9e1c84698150eaef7b640f50f907dd8e585174f5" }

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,6 +11,11 @@ fn read_parsed<T>(path: &str, parse: impl FnOnce(&str) -> Option<T>) -> Option<T
     std::fs::read_to_string(path).ok().and_then(|s| parse(&s))
 }
 
+/// `None` for unset or unparseable — every env knob here treats both the same.
+fn env_parse<T: std::str::FromStr>(name: &str) -> Option<T> {
+    std::env::var(name).ok()?.parse().ok()
+}
+
 fn parse_cgroup_v2_memory_max(content: &str) -> Option<usize> {
     content.trim().parse().ok()
 }
@@ -76,7 +81,7 @@ fn detect_memory_limit_bytes() -> usize {
 /// exists (see `detect_memory_limit_bytes`) — a containerized deployment can
 /// never be resized by env var.
 fn env_memory_override_bytes() -> Option<usize> {
-    std::env::var("TIMEFUSION_MEMORY_LIMIT_GB").ok()?.parse::<usize>().ok().filter(|gb| *gb > 0).map(|gb| gb * GIB)
+    env_parse::<usize>("TIMEFUSION_MEMORY_LIMIT_GB").filter(|gb| *gb > 0).map(|gb| gb * GIB)
 }
 
 /// `TIMEFUSION_MEMORY_BUDGET_GB`: sizes the whole tree BELOW the cgroup limit.
@@ -92,7 +97,7 @@ fn env_memory_override_bytes() -> Option<usize> {
 /// Only ever LOWERS the effective limit — an over-large value is clamped,
 /// never honoured.
 fn env_memory_budget_bytes() -> Option<usize> {
-    std::env::var("TIMEFUSION_MEMORY_BUDGET_GB").ok()?.parse::<f64>().ok().filter(|gb| *gb > 0.0).map(|gb| (gb * GIB as f64) as usize)
+    env_parse::<f64>("TIMEFUSION_MEMORY_BUDGET_GB").filter(|gb| *gb > 0.0).map(|gb| (gb * GIB as f64) as usize)
 }
 
 fn detect_memory_limit_clamped() -> usize {
@@ -146,7 +151,7 @@ pub enum BudgetProfile {
 
 /// Anything unrecognised (including unset) is the server profile.
 fn profile_from_env() -> BudgetProfile {
-    std::env::var("TIMEFUSION_BUDGET_PROFILE").ok().and_then(|v| v.parse().ok()).unwrap_or_default()
+    env_parse("TIMEFUSION_BUDGET_PROFILE").unwrap_or_default()
 }
 
 // 0.20, down from 0.25: sampled pool usage sat at 0 while the 70% memory
@@ -258,14 +263,6 @@ const REPAIR_REWRITE_TARGET_FILES: usize = 2;
 /// 1.79 is the passing point, not a midpoint guess — the cliff is between these
 /// two rungs and this takes the safe side of it.
 const SAFE_DECODED_PER_POOL_BYTE: f64 = 1.79;
-/// Heavy maintenance's minimum share of the maintenance pool. 0.40, up from
-/// 0.25 — a REBALANCE inside the existing pool (total unchanged), following
-/// the workload: hot-tail packing (light share) converged once unstarved,
-/// while the dedup queue kept growing, so heavy is where the backlog lives.
-/// 0.40 specifically because `light_optimize_k` divides light's share by
-/// `PER_SORT_BUDGET_BYTES`; going lower still yields the same K for packing
-/// while buying heavy little, since heavy's concurrency is bounded by
-/// rewrite permits, not bytes.
 /// Heavy maintenance's slice of the whole maintenance pool. 0.30 is what the
 /// old `0.40 of the residual` came to before the coordinator's share grew; see
 /// `heavy_share_bytes` for why it is no longer expressed against the residual.
@@ -325,47 +322,30 @@ impl DerivedBudget {
     }
 
     fn from_limits_with_profile(memory_limit_bytes: usize, cores: usize, profile: BudgetProfile) -> Self {
-        if profile == BudgetProfile::MaintenanceCli {
-            // No queries/ingest: token slices for query pool and foyer, the
-            // full writer-reserve cap (delta-rs output buffers are real in a
-            // CLI), rest to maintenance. An 8 GiB pod derives ~6 GiB of
-            // sort/spill instead of the 1 GiB floor.
-            let query_pool_bytes = (memory_limit_bytes as f64 * 0.08) as usize;
-            let ingest_buffer_bytes = (memory_limit_bytes as f64 * 0.02) as usize;
-            let foyer_memory_bytes = (memory_limit_bytes as f64 * 0.02) as usize;
-            let writer_reserve_bytes = (HEAVY_REWRITE_PERMITS * OPTIMIZE_MERGE_TASKS * WRITER_RESERVE_PER_TASK_BYTES).min(memory_limit_bytes / 10);
-            let reserved = query_pool_bytes + ingest_buffer_bytes + foyer_memory_bytes + writer_reserve_bytes;
-            let maintenance_pool_bytes = memory_limit_bytes.saturating_sub(reserved).max(MAINTENANCE_FLOOR_BYTES);
-            return Self {
-                memory_limit_bytes,
-                cores,
-                query_pool_bytes,
-                ingest_buffer_bytes,
-                foyer_memory_bytes,
-                writer_reserve_bytes,
-                maintenance_pool_bytes,
-                profile,
-            };
-        }
-        // Fixed fraction, not the old TIMEFUSION_MEMORY_FRACTION knob: that
-        // 0.75 was calibrated against a hand-set limit and, applied to the
-        // real cgroup, would crush maintenance to K=1 — the drift-class bug
-        // this tree exists to kill. 0.20 of the real limit is ~1.25x the old
-        // effective pool.
-        let query_pool_bytes = (memory_limit_bytes as f64 * QUERY_POOL_FRACTION) as usize;
-        let ingest_buffer_bytes = (memory_limit_bytes as f64 * INGEST_BUFFER_FRACTION) as usize;
-        let foyer_memory_bytes = (memory_limit_bytes as f64 * FOYER_MEMORY_FRACTION) as usize;
+        let share = |fraction: f64| (memory_limit_bytes as f64 * fraction) as usize;
+        // Server fractions are fixed, not the old TIMEFUSION_MEMORY_FRACTION
+        // knob: that 0.75 was calibrated against a hand-set limit and, applied
+        // to the real cgroup, would crush maintenance to K=1 — the drift-class
+        // bug this tree exists to kill. 0.20 of the real limit is ~1.25x the
+        // old effective pool. The last term is UNTRACKED-CONSUMER SLACK, carved
+        // out BEFORE maintenance takes the remainder: without it the tree hands
+        // maintenance everything left and consumers no pool tracks (parquet
+        // decode, giant-INSERT parse ASTs, allocator overhead) push the box over
+        // the cgroup limit — every subsystem behaved "legally", the sum was the
+        // bug. 15% covers the measured untracked peak; the resulting maintenance
+        // shrink was proven harmless (512MB bins sort+spill fine on smaller pools).
+        //
+        // MaintenanceCli has no queries/ingest: token slices for query pool and
+        // foyer, no slack, rest to maintenance — an 8 GiB pod derives ~6 GiB of
+        // sort/spill instead of the 1 GiB floor.
+        let (query_pool_bytes, ingest_buffer_bytes, foyer_memory_bytes, untracked_slack_bytes) = match profile {
+            BudgetProfile::MaintenanceCli => (share(0.08), share(0.02), share(0.02), 0),
+            BudgetProfile::Server => (share(QUERY_POOL_FRACTION), share(INGEST_BUFFER_FRACTION), share(FOYER_MEMORY_FRACTION), share(UNTRACKED_SLACK_FRACTION)),
+        };
         // Capped at 10% of the limit: the full 6 GiB reserve on an 8 GiB dev
         // box budgeted 142% of the container — the drift class this tree kills.
+        // (delta-rs output buffers are real in a CLI too, so the cap is shared.)
         let writer_reserve_bytes = (HEAVY_REWRITE_PERMITS * OPTIMIZE_MERGE_TASKS * WRITER_RESERVE_PER_TASK_BYTES).min(memory_limit_bytes / 10);
-        // UNTRACKED-CONSUMER SLACK, carved out BEFORE maintenance takes the
-        // remainder. Without it the tree hands maintenance everything left,
-        // and consumers no pool tracks (parquet decode, giant-INSERT parse
-        // ASTs, allocator overhead) push the box over the cgroup limit —
-        // every subsystem behaved "legally", the sum was the bug. 15% covers
-        // the measured untracked peak; the resulting maintenance shrink was
-        // proven harmless (512MB bins sort+spill fine on smaller pools).
-        let untracked_slack_bytes = (memory_limit_bytes as f64 * UNTRACKED_SLACK_FRACTION) as usize;
         let reserved = query_pool_bytes + ingest_buffer_bytes + foyer_memory_bytes + writer_reserve_bytes + untracked_slack_bytes;
         let maintenance_pool_bytes = memory_limit_bytes.saturating_sub(reserved).max(MAINTENANCE_FLOOR_BYTES);
         Self { memory_limit_bytes, cores, query_pool_bytes, ingest_buffer_bytes, foyer_memory_bytes, writer_reserve_bytes, maintenance_pool_bytes, profile }
@@ -644,7 +624,7 @@ impl DerivedBudget {
     /// `TIMEFUSION_COORDINATOR_JOB_WORKERS=1` restores the old serialized
     /// behavior.
     pub fn coordinator_jobs(&self) -> usize {
-        std::env::var("TIMEFUSION_COORDINATOR_JOB_WORKERS").ok().and_then(|v| v.parse::<usize>().ok()).filter(|n| *n > 0).unwrap_or_else(|| {
+        env_parse::<usize>("TIMEFUSION_COORDINATOR_JOB_WORKERS").filter(|n| *n > 0).unwrap_or_else(|| {
             let mem_bound = self.maintenance_pool_bytes / (512 * 1024 * 1024);
             // cores/3 (cap 16): jobs are only useful up to the inner
             // rewrite/sort permit pool (HEAVY_REWRITE_PERMITS) — going wider
@@ -715,35 +695,35 @@ impl DerivedBudget {
         const BASELINE_FILES: f64 = 200.0;
         (BASELINE_FILES * (self.ingest_buffer_bytes as f64 / BASELINE_BUFFER_BYTES as f64)).round().max(BASELINE_FILES) as usize
     }
-}
 
-/// Startup log of the whole derived tree so a misread cgroup limit is
-/// immediately visible (doc §4 hard requirement). `hot_project_count` uses
-/// prod's current 11 as the illustrative K.
-pub fn log_derived_budget(b: &DerivedBudget) {
-    tracing::info!(
-        profile = ?b.profile,
-        detected_limit_gb = detect_memory_limit_clamped() / GIB,
-        effective_limit_gb = b.memory_limit_bytes / GIB,
-        cores = b.cores,
-        query_pool_gb = b.query_pool_bytes() / GIB,
-        ingest_buffer_gb = b.buffer_max_bytes() / GIB,
-        cache_memory_gb = b.foyer_memory_bytes() / GIB,
-        foyer_memory_gb = b.object_cache_memory_bytes() / GIB,
-        logical_count_memory_gb = b.logical_count_memory_bytes() / GIB,
-        writer_reserve_gb = b.writer_reserve_bytes() / GIB,
-        maintenance_pool_gb = b.maintenance_pool_bytes() / GIB,
-        coordinator_share_gb = b.coordinator_share_bytes() / GIB,
-        heavy_share_gb = b.heavy_share_bytes() / GIB,
-        light_share_gb = b.light_share_bytes() / GIB,
-        rewrite_permits = b.rewrite_permits(),
-        optimize_merge_tasks = b.optimize_merge_tasks(),
-        light_optimize_k_at_11_hot_projects = b.light_optimize_k(11),
-        memory_brake_limit_gb = b.memory_brake_limit_bytes() / GIB,
-        wal_flush_byte_threshold_gb = b.wal_flush_byte_threshold() / GIB as u64,
-        wal_flush_file_threshold = b.wal_flush_file_threshold(),
-        "self-sizing budget tree derived at startup"
-    );
+    /// Startup log of the whole derived tree so a misread cgroup limit is
+    /// immediately visible (doc §4 hard requirement). `hot_project_count` uses
+    /// prod's current 11 as the illustrative K.
+    pub fn log(&self) {
+        tracing::info!(
+            profile = ?self.profile,
+            detected_limit_gb = detect_memory_limit_clamped() / GIB,
+            effective_limit_gb = self.memory_limit_bytes / GIB,
+            cores = self.cores,
+            query_pool_gb = self.query_pool_bytes() / GIB,
+            ingest_buffer_gb = self.buffer_max_bytes() / GIB,
+            cache_memory_gb = self.foyer_memory_bytes() / GIB,
+            foyer_memory_gb = self.object_cache_memory_bytes() / GIB,
+            logical_count_memory_gb = self.logical_count_memory_bytes() / GIB,
+            writer_reserve_gb = self.writer_reserve_bytes() / GIB,
+            maintenance_pool_gb = self.maintenance_pool_bytes() / GIB,
+            coordinator_share_gb = self.coordinator_share_bytes() / GIB,
+            heavy_share_gb = self.heavy_share_bytes() / GIB,
+            light_share_gb = self.light_share_bytes() / GIB,
+            rewrite_permits = self.rewrite_permits(),
+            optimize_merge_tasks = self.optimize_merge_tasks(),
+            light_optimize_k_at_11_hot_projects = self.light_optimize_k(11),
+            memory_brake_limit_gb = self.memory_brake_limit_bytes() / GIB,
+            wal_flush_byte_threshold_gb = self.wal_flush_byte_threshold() / GIB as u64,
+            wal_flush_file_threshold = self.wal_flush_file_threshold(),
+            "self-sizing budget tree derived at startup"
+        );
+    }
 }
 
 /// Load config from environment variables.
@@ -769,9 +749,9 @@ pub fn init_config() -> Result<&'static AppConfig, envy::Error> {
     if let Some(cfg) = CONFIG.get() {
         return Ok(cfg);
     }
-    // `&mut` is autotune's API (cross-module), so the mutation stays here.
+    // `&mut` is autotune's API, so the mutation stays here.
     let mut cfg = load_config_from_env()?;
-    crate::config::apply(&mut cfg);
+    apply(&mut cfg);
     let _ = CONFIG.set(cfg);
     Ok(config())
 }
@@ -796,8 +776,8 @@ pub fn set_config_for_test(cfg: AppConfig) {
 }
 
 /// Whether the operator has opted into open auth for local dev via
-/// `TIMEFUSION_ALLOW_INSECURE_AUTH=true`.
-/// paths gate their fail-secure defaults on this flag.
+/// `TIMEFUSION_ALLOW_INSECURE_AUTH=true`. Auth paths gate their fail-secure
+/// defaults on this flag.
 pub fn is_insecure_auth_allowed() -> bool {
     std::env::var("TIMEFUSION_ALLOW_INSECURE_AUTH").is_ok_and(|v| v.eq_ignore_ascii_case("true"))
 }
@@ -1132,7 +1112,7 @@ impl TantivyConfig {
     }
     /// Floored at 1: a zero-capacity LRU would make every open a cold open.
     pub fn reader_cache_entries(&self) -> NonZeroUsize {
-        NonZeroUsize::new(self.timefusion_tantivy_reader_cache_entries.max(1)).expect("max(1) is non-zero")
+        NonZeroUsize::new(self.timefusion_tantivy_reader_cache_entries).unwrap_or(NonZeroUsize::MIN)
     }
     /// Floored at 1: zero concurrency would deadlock the per-index fan-out.
     pub fn search_concurrency(&self) -> usize {
@@ -1504,11 +1484,6 @@ pub struct BufferConfig {
     /// a writer that committed after the last snapshot was written.
     #[serde_inline_default(8)]
     pub timefusion_delta_scan_depth: usize,
-    /// Decline a flush whose batch set is provably already committed (the
-    /// duplicates WAL replay manufactures after an unclean exit — see
-    /// `docs/plans/2026-09-02-stop-manufacturing-duplicates.md`). Off until
-    /// staging proves it: the skip only fires after an unclean restart, which
-    /// cannot be induced on the read-only prod host.
     /// Reject a compaction candidate that would push the merged output's UNION
     /// SPAN past this many dedup bins. **0 disables it, which is the default.**
     ///
@@ -3071,16 +3046,6 @@ pub struct MemoryConfig {
     /// this makes the window usable while that happens.
     #[serde_inline_default(1024)]
     pub timefusion_read_sort_unordered_leg_max_mb: u64,
-    /// Selected bytes above which a single scan is REFUSED outright, rather than admitted
-    /// into the gate above. **0 disables it, and 0 is the default.**
-    ///
-    /// The gate bounds how many wide scans decode concurrently; it has never bounded how
-    /// much any one of them decodes, and `wide_scan_oversize_total` was pure observation.
-    /// That gap is a distinct failure mode from a slow query: on 2026-08-18 one scan
-    /// selected 514 files / 32.8 GB and, while it ran, NEW CONNECTIONS TIMED OUT — the box
-    /// became unreachable, so every other tenant paid for one query. Refusing it instead
-    /// costs one client an error naming the limit and what to do about it.
-    ///
     /// Cross-connection plan-cache capacity (unique canonical/shape templates).
     /// 256 thrashed in prod (evicting ~half every ~60s); 1024 holds the working
     /// set with room to spare. Each entry is one LogicalPlan (~KBs).
@@ -3680,9 +3645,6 @@ mod tests {
 use sysinfo::Disks;
 use tracing::{info, warn};
 
-const MB: usize = 1024 * 1024;
-const GB: usize = 1024 * MB;
-
 const RAM_FRACTION_FOYER_META: f64 = 0.02;
 const DISK_FRACTION_FOYER: f64 = 0.40;
 const DISK_FRACTION_FOYER_META: f64 = 0.02;
@@ -3717,9 +3679,9 @@ pub fn apply(config: &mut AppConfig) {
     // ONE memory source: the derived budget tree's cgroup-clamped detection. A
     // second (sysinfo) reading here once let the oversubscription audit warn
     // against a different denominator than the budgets were derived from.
-    let total_ram_mb = config.derived.memory_limit_bytes() / MB;
+    let total_ram_mb = config.derived.memory_limit_bytes() / MIB;
 
-    let cpus = crate::config::detect_cores();
+    let cpus = detect_cores();
 
     // Probe free space on the data dir's mount point. Falls back to "unknown"
     // (no disk-derived overrides) if the mount can't be located.
@@ -3750,13 +3712,13 @@ pub fn apply(config: &mut AppConfig) {
     tune(
         "TIMEFUSION_BUFFER_MAX_MEMORY_MB",
         &mut config.buffer.timefusion_buffer_max_memory_mb,
-        (config.derived.buffer_max_bytes() / MB).max(MIN_BUFFER_MB),
+        (config.derived.buffer_max_bytes() / MIB).max(MIN_BUFFER_MB),
         "MB",
     );
     tune(
         "TIMEFUSION_FOYER_MEMORY_MB",
         &mut config.cache.timefusion_foyer_memory_mb,
-        (config.derived.object_cache_memory_bytes() / MB).clamp(MIN_FOYER_MEM_MB, MAX_FOYER_MEM_MB),
+        (config.derived.object_cache_memory_bytes() / MIB).clamp(MIN_FOYER_MEM_MB, MAX_FOYER_MEM_MB),
         "MB",
     );
     tune(
@@ -3830,8 +3792,8 @@ pub fn apply(config: &mut AppConfig) {
     // so take the overage back from the residual claimant that absorbed it.
     let mut audit = budget_audit(config, total_ram_mb);
     if audit.oversubscribed() {
-        let overage = audit.committed_mb.saturating_sub(audit.warn_at_mb) * MB;
-        let reclaimed = config.derived.reclaim_maintenance_pool(overage) / MB;
+        let overage = audit.committed_mb.saturating_sub(audit.warn_at_mb) * MIB;
+        let reclaimed = config.derived.reclaim_maintenance_pool(overage) / MIB;
         audit = budget_audit(config, total_ram_mb);
         warn!(
             "bootstrap.phase=budget_reclaim reclaimed_mb={reclaimed} from the maintenance pool              (it is the residual claimant, so it is what absorbed the unreserved MemBuffer overshoot,              tantivy peak and metadata cache) — maintenance_pool now {}mb, committed {}mb vs warn_at {}mb",
@@ -3908,17 +3870,17 @@ pub fn boot_budget_audit() -> Option<&'static BudgetAudit> {
 /// The light-optimize slice is deliberately NOT added: it is carved *out of*
 /// `maintenance_pool_bytes()`, so counting it again would double-count.
 pub fn budget_audit(config: &AppConfig, total_ram_mb: usize) -> BudgetAudit {
-    let foyer_mb = if config.cache.is_disabled() { 0 } else { (config.cache.memory_size_bytes() + config.cache.metadata_memory_size_bytes()) / MB };
+    let foyer_mb = if config.cache.is_disabled() { 0 } else { (config.cache.memory_size_bytes() + config.cache.metadata_memory_size_bytes()) / MIB };
     // Peak tantivy writer heap: one writer per in-flight flush.
     let tantivy_peak_mb =
-        if config.tantivy.indexed_tables().is_empty() { 0 } else { crate::tantivy::WRITER_HEAP_BYTES * config.buffer.flush_parallelism() / MB };
+        if config.tantivy.indexed_tables().is_empty() { 0 } else { crate::tantivy::WRITER_HEAP_BYTES * config.buffer.flush_parallelism() / MIB };
     // Mirror `BufferedWriteLayer::max_memory_bytes`: the configured knob is
     // reduced by foyer + tantivy (which are counted separately below, so using
     // the raw knob here would double-count them), then admission runs to a 120%
     // hard ceiling (HARD_LIMIT_HEADROOM_DIVISOR).
     let mem_buffer_hard_mb = config.buffer.max_memory_mb().saturating_sub(foyer_mb + tantivy_peak_mb).max(64) * 6 / 5;
-    let query_pool_mb = config.derived.query_pool_bytes() / MB;
-    let maintenance_pool_mb = config.derived.maintenance_pool_bytes() / MB;
+    let query_pool_mb = config.derived.query_pool_bytes() / MIB;
+    let maintenance_pool_mb = config.derived.maintenance_pool_bytes() / MIB;
     let df_metadata_cache_mb = config.cache.timefusion_df_metadata_cache_mb;
     BudgetAudit {
         query_pool_mb,
@@ -3942,7 +3904,7 @@ fn available_disk_for(path: &std::path::Path) -> Option<usize> {
         .iter()
         .filter(|d| canonical.starts_with(d.mount_point()))
         .max_by_key(|d| d.mount_point().as_os_str().len())
-        .map(|d| (d.available_space() / GB as u64) as usize)
+        .map(|d| (d.available_space() / GIB as u64) as usize)
 }
 
 #[cfg(test)]
@@ -3977,8 +3939,8 @@ mod autotune_tests {
 
         // The container limit, not the 188GB host: this is what the kernel kills on.
         let a = budget_audit(&cfg, 24 * 1024);
-        assert_eq!(a.query_pool_mb, cfg.derived.query_pool_bytes() / MB);
-        assert_eq!(a.maintenance_pool_mb, cfg.derived.maintenance_pool_bytes() / MB, "was missing entirely");
+        assert_eq!(a.query_pool_mb, cfg.derived.query_pool_bytes() / MIB);
+        assert_eq!(a.maintenance_pool_mb, cfg.derived.maintenance_pool_bytes() / MIB, "was missing entirely");
         assert_eq!(a.foyer_mb, 4560);
         // MemBuffer's ceiling is on its EFFECTIVE budget (knob − foyer −
         // tantivy peak), then x1.2 — not the raw knob, which would count foyer
@@ -4008,7 +3970,7 @@ mod autotune_tests {
         assert!(before.oversubscribed(), "fixture must start oversubscribed: {before:?}");
 
         let overage = before.committed_mb.saturating_sub(before.warn_at_mb);
-        let reclaimed = cfg.derived.reclaim_maintenance_pool(overage * MB) / MB;
+        let reclaimed = cfg.derived.reclaim_maintenance_pool(overage * MIB) / MIB;
         let after = budget_audit(&cfg, ram_mb);
 
         assert!(reclaimed > 0, "something must actually be surrendered");
@@ -4022,7 +3984,7 @@ mod autotune_tests {
         // negative — a 1 GB maintenance pool still sorts and spills.
         let floored = cfg.derived.reclaim_maintenance_pool(usize::MAX);
         assert!(cfg.derived.maintenance_pool_bytes() >= 1024 * 1024 * 1024, "must not reclaim below the floor");
-        assert!(floored <= after.maintenance_pool_mb * MB);
+        assert!(floored <= after.maintenance_pool_mb * MIB);
     }
 
     #[test]

--- a/src/database/compact.rs
+++ b/src/database/compact.rs
@@ -451,11 +451,11 @@ impl Database {
             .collect())
     }
 
-    /// `[min, max]` event time (micros) of a file from its raw Add stats JSON.
+    /// `[min, max]` event time (micros) of a file from its parsed Add stats.
     /// Timestamp stats serialize as RFC3339 strings (epoch numbers accepted for
-    /// long-typed columns).
-    pub(crate) fn event_time_range_from_stats(stats: &str) -> Option<(i64, i64)> {
-        let stats: serde_json::Value = serde_json::from_str(stats).ok()?;
+    /// long-typed columns). Takes the parsed `Value` so a caller that also wants
+    /// `numRecords` out of the same blob parses it exactly once.
+    pub(crate) fn event_time_range_from_stats(stats: &serde_json::Value) -> Option<(i64, i64)> {
         let get = |key: &str| {
             let v = &stats[key]["timestamp"];
             v.as_str().and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok()).map(|d| d.timestamp_micros()).or_else(|| v.as_i64())

--- a/src/database/maintain.rs
+++ b/src/database/maintain.rs
@@ -3257,7 +3257,7 @@ impl Database {
             }
         }
 
-        let _journal_guard = self.rollup_journal_lock.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _journal_guard = crate::support::lock(&self.rollup_journal_lock);
         let mut journal = self.journal();
         if journal.state(&key) == Some(TaskState::Running) {
             self.rollup_slice_coverage.insert(
@@ -3879,7 +3879,7 @@ impl Database {
         // recent-slice, dependency, and project fairness.
         let cycle = crate::maintenance_coordinator::operation_cycle(coverage_is_short());
         let start = self.maintenance_schedule_cursor.fetch_add(1, std::sync::atomic::Ordering::Relaxed) % cycle.len();
-        let mut attempted = [false; 6];
+        let mut attempted = [false; <crate::maintenance_coordinator::Operation as strum::EnumCount>::COUNT];
         for offset in 0..cycle.len() {
             let operation = cycle[(start + offset) % cycle.len()];
             let index = operation as usize;
@@ -3943,14 +3943,7 @@ impl Database {
             // through three rewrite paths. It is also the ONE spelling of the
             // operation's name: the work counters below read it rather than
             // re-deriving it via `{operation:?}`, so the two cannot drift.
-            let label: &'static str = match operation {
-                Operation::Dedup => "Dedup",
-                Operation::BaseRollup => "BaseRollup",
-                Operation::DerivedRollup => "DerivedRollup",
-                Operation::HotPacking => "HotPacking",
-                Operation::SealedConsolidation => "SealedConsolidation",
-                Operation::Repair => "Repair",
-            };
+            let label: &'static str = operation.into();
             let work = UNIT_OPERATION.scope(label, async {
                 match operation {
                     Operation::Dedup => self.run_coordinator_dedup_once().await,
@@ -4023,7 +4016,7 @@ impl Database {
     }
 
     pub(crate) fn invalidate_rollup_hours(&self, project_id: &str, source: &str, date: &str, hours: u32) -> std::io::Result<()> {
-        let _journal_guard = self.rollup_journal_lock.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _journal_guard = crate::support::lock(&self.rollup_journal_lock);
         let source_key = (project_id.to_string(), source.to_string(), date.to_string());
         // The mutation tells us exactly which hours became dirty. Expanding a
         // project's first observed hour to the full day creates 456 durable
@@ -4090,7 +4083,7 @@ impl Database {
         if get_schema(source).is_none_or(|schema| schema.rollups.is_empty()) {
             return Ok(());
         }
-        let _journal_guard = self.rollup_journal_lock.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _journal_guard = crate::support::lock(&self.rollup_journal_lock);
         let keys: Vec<_> =
             self.rollup_source_epochs.iter().filter(|entry| entry.key().0 == project_id && entry.key().1 == source).map(|entry| entry.key().clone()).collect();
         for key in &keys {
@@ -5197,7 +5190,7 @@ impl Database {
                 masked.map(|_| Self::partition_dv_state(&table, project_id, &format!("date={date}"))).transpose()?,
             )
         };
-        let fp = partition_file_fp(post.clone());
+        let fp = partition_file_fp(&post);
         // DV-visibility guard, masked arm only: the URI fp cannot see a foreign
         // same-path DV commit (DML DELETE/UPDATE write DVs too), so compare the
         // live (path, dv_unique_id) set instead — fail-closed, like fp_moved.
@@ -5205,7 +5198,7 @@ impl Database {
         if dv_moved {
             metrics::counter!(scan_metric_names::CERT_SLICE_DV_MOVED).increment(1);
         }
-        if slice_pass_dirty(dropped, masked.is_some(), post.is_empty(), partition_file_fp(pre.to_vec()) != fp, dv_moved) {
+        if slice_pass_dirty(dropped, masked.is_some(), post.is_empty(), partition_file_fp(pre) != fp, dv_moved) {
             metrics::counter!(scan_metric_names::CERT_SLICE_DIRTY).increment(1);
             if self.dedup_slice_coverage.remove(&key).is_some() {
                 self.persist_slice_coverage();
@@ -5353,8 +5346,8 @@ impl Database {
             let table = table_ref.read().await;
             Self::partition_files_by_pid(&table, &format!("date={date}"))?.remove(project_id).unwrap_or_default()
         };
-        let fp_post = partition_file_fp(post.clone());
-        if dropped == 0 && complete && !post.is_empty() && partition_file_fp(pre.to_vec()) == fp_post {
+        let fp_post = partition_file_fp(&post);
+        if dropped == 0 && complete && !post.is_empty() && partition_file_fp(pre) == fp_post {
             // Re-certifying at the SAME fingerprint continues the existing
             // certification rather than starting a new one: the sweep re-proved a
             // partition nothing had touched. Keeping the original `since` is what
@@ -5486,7 +5479,7 @@ impl Database {
                 // `!cert.stale` is required, not decorative: a slice-derived
                 // certification proves one time window, never the day, and its
                 // fingerprint can still match the live partition.
-                Some(cert) if !cert.stale && cert.fp == partition_file_fp(files) => {
+                Some(cert) if !cert.stale && cert.fp == partition_file_fp(&files) => {
                     certified_any = true;
                     certified_dates.insert(date.to_string());
                     continue;
@@ -5832,7 +5825,7 @@ impl Database {
             // under continuous ingest; this per-partition check does (sealed
             // lookback days, and today between flushes).
             let fp_key = (pid.clone(), table_name.to_string(), date.to_string());
-            let current_fp = partition_file_fp(cur_files.clone());
+            let current_fp = partition_file_fp(cur_files);
             if !cur_files.is_empty() && self.dedup_clean_fp.get(&fp_key).map(|entry| entry.value().fp) == Some(current_fp) {
                 continue;
             }
@@ -5942,7 +5935,7 @@ impl Database {
         if !self.config.maintenance.timefusion_dedup_certification_persist {
             return;
         }
-        let _persist = self.dedup_certification_persist_lock.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _persist = crate::support::lock(&self.dedup_certification_persist_lock);
         let mut entries: Vec<_> = self
             .dedup_slice_coverage
             .iter()
@@ -5972,7 +5965,7 @@ impl Database {
         if !self.config.maintenance.timefusion_dedup_certification_persist {
             return;
         }
-        let _persist = self.dedup_certification_persist_lock.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _persist = crate::support::lock(&self.dedup_certification_persist_lock);
         let now_ms = crate::storage::now_unix_ms();
         let mut entries: Vec<_> = self
             .dedup_clean_fp
@@ -6421,7 +6414,7 @@ impl Database {
                 // clean without a commit, and a commit moves the fingerprint.
                 // Re-probing it is pure waste, and at 64 probes a pass it would be
                 // most of the budget.
-                let (file_count, fp) = (files.len(), partition_file_fp(files));
+                let (file_count, fp) = (files.len(), partition_file_fp(&files));
                 let known_dirty = self.dedup_probe_declined.get(&key).is_some_and(|entry| *entry.value() == fp);
                 if uncertified && !known_dirty {
                     let entry = by_project.entry(project).or_insert_with(|| (0usize, Vec::new()));
@@ -6628,7 +6621,7 @@ impl Database {
                         // commit moves the fingerprint, so re-probing it before then
                         // is pure waste — at 64 probes a pass it would crowd out
                         // every candidate that has never been examined.
-                        self.dedup_probe_declined.insert((project.clone(), table_name.to_string(), date.clone()), partition_file_fp(pre.clone()));
+                        self.dedup_probe_declined.insert((project.clone(), table_name.to_string(), date.clone()), partition_file_fp(&pre));
                         metrics::counter!(scan_metric_names::CERT_PROBE_DECLINED).increment(1);
                         // HOW dirty, not just that it is dirty — this decides the
                         // removal mechanism and cannot be measured from outside,
@@ -8313,7 +8306,7 @@ impl Database {
     /// a write failure costs re-probing, never correctness.
     pub(crate) fn persist_verified_sorted(&self, paths: &[String]) {
         use std::io::Write;
-        let _guard = self.repair_verified_lock.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _guard = crate::support::lock(&self.repair_verified_lock);
         let file_path = self.repair_verified_path();
         let write = crate::support::without_blocking_the_worker(|| -> std::io::Result<()> {
             if let Some(dir) = file_path.parent() {
@@ -8378,7 +8371,7 @@ impl Database {
     /// it has grown past [`REPAIR_VERIFIED_PERSIST_CAP`]. Newest entries win: the
     /// tail of the file is the most recently probed.
     pub fn load_verified_sorted(&self) {
-        let _guard = self.repair_verified_lock.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _guard = crate::support::lock(&self.repair_verified_lock);
         let (kept, dropped) = self.truncate_verified_file_locked();
         for path in &kept {
             self.repair_verified_sorted.insert(path.clone());
@@ -8398,7 +8391,7 @@ impl Database {
         // entry indistinguishable from a pre-upgrade one and lose its resume to
         // the legacy age gate forever (see `resume_guarded`).
         let entry = StagedIntent { instance: Some(crate::observability::instance_id().to_owned()), ..entry };
-        let _manifest_guard = self.staged_intent_manifest_lock.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _manifest_guard = crate::support::lock(&self.staged_intent_manifest_lock);
         let path = self.staged_intent_path();
         let write = crate::support::without_blocking_the_worker(|| -> std::io::Result<()> {
             if let Some(dir) = path.parent() {
@@ -8416,7 +8409,7 @@ impl Database {
     /// after the wave commits or after its staged parquet is cleaned up, i.e.
     /// once the entry can no longer describe an orphan.
     fn clear_staged_intent(&self, wave_ids: &[&str]) {
-        let _manifest_guard = self.staged_intent_manifest_lock.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _manifest_guard = crate::support::lock(&self.staged_intent_manifest_lock);
         let path = self.staged_intent_path();
         // Read the whole manifest, re-encode every surviving entry, rewrite it —
         // once per committed wave, from an async maintenance task.
@@ -8465,7 +8458,7 @@ impl Database {
         use std::sync::atomic::Ordering::Relaxed;
         let stats = crate::observability::maintenance_stats();
         let contents = {
-            let _manifest_guard = self.staged_intent_manifest_lock.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+            let _manifest_guard = crate::support::lock(&self.staged_intent_manifest_lock);
             let Ok(contents) = std::fs::read_to_string(self.staged_intent_path()) else {
                 stats.rollup_resume_no_intent.fetch_add(1, Relaxed);
                 return Ok(false);
@@ -8598,7 +8591,7 @@ impl Database {
             return None;
         }
         let contents = {
-            let _manifest_guard = self.staged_intent_manifest_lock.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+            let _manifest_guard = crate::support::lock(&self.staged_intent_manifest_lock);
             std::fs::read_to_string(self.staged_intent_path()).ok()?
         };
         let wanted: HashSet<&str> = files.iter().map(String::as_str).collect();
@@ -8712,7 +8705,7 @@ impl Database {
         use object_store::ObjectStoreExt;
         let path = self.staged_intent_path();
         let contents = {
-            let _manifest_guard = self.staged_intent_manifest_lock.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+            let _manifest_guard = crate::support::lock(&self.staged_intent_manifest_lock);
             let Ok(contents) = std::fs::read_to_string(&path) else { return };
             contents
         };

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -2075,8 +2075,9 @@ const DEDUP_SCAN_NAME: &str = "__dedup_src";
 /// proof of which file set was proved clean, so changing the hasher silently
 /// invalidates every certification and resets hard-won coverage to zero. Not
 /// part of the XXH3 sweep.
-fn partition_file_fp(mut files: Vec<String>) -> u64 {
+fn partition_file_fp(files: &[String]) -> u64 {
     use std::hash::{Hash, Hasher};
+    let mut files = files.to_vec();
     files.sort();
     let mut h = std::collections::hash_map::DefaultHasher::new();
     files.hash(&mut h);
@@ -3282,7 +3283,7 @@ impl Database {
     /// worker. That is exactly what these two numbers measure.
     fn journal(&self) -> crate::observability::Watched<std::sync::MutexGuard<'_, crate::maintenance_coordinator::TaskJournal>> {
         let wait = crate::observability::BlockWatch::new("journal_lock_wait");
-        let guard = self.maintenance_tasks.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let guard = crate::support::lock(&self.maintenance_tasks);
         drop(wait);
         crate::observability::Watched::new("journal_hold", guard)
     }
@@ -4914,7 +4915,7 @@ impl Database {
                     runtime.block_on(async move {
                         let journal = Arc::clone(&db.maintenance_tasks);
                         match tokio::task::spawn_blocking(move || -> Result<(usize, usize)> {
-                            let mut journal = journal.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+                            let mut journal = crate::support::lock(&journal);
                             let discarded = journal.migrate_bootstrap_backlog();
                             let migrated = journal.migrate_derived_slices();
                             // One-shot: collapse the fine-grained sealed backfill
@@ -8005,11 +8006,10 @@ impl TailAdd {
     /// previously trusted those accessors and silently selected nothing, so it now parses the raw
     /// stats JSON instead.
     fn from_stats(path: String, size: i64, is_sorted_run: bool, has_dv: bool, stats: Option<&str>) -> Self {
-        let range = stats.and_then(Database::event_time_range_from_stats);
-        // Re-parses the blob `event_time_range_from_stats` just parsed — fine at
-        // planner frequency; a single-parse API means a compact.rs signature change.
-        let rows = stats.and_then(|s| serde_json::from_str::<serde_json::Value>(s).ok()).and_then(|v| v.get("numRecords").and_then(serde_json::Value::as_u64));
-        Self { path, size, is_sorted_run, event_range: range, rows, has_dv }
+        let stats = stats.and_then(|s| serde_json::from_str::<serde_json::Value>(s).ok());
+        let event_range = stats.as_ref().and_then(Database::event_time_range_from_stats);
+        let rows = stats.as_ref().and_then(|v| v.get("numRecords").and_then(serde_json::Value::as_u64));
+        Self { path, size, is_sorted_run, event_range, rows, has_dv }
     }
 }
 
@@ -12355,9 +12355,9 @@ mod writer_properties_tests {
         let a = vec!["p/date=2026-07-01/f1.parquet".to_string(), "p/date=2026-07-01/f2.parquet".to_string()];
         let mut b = a.clone();
         b.reverse();
-        assert_eq!(partition_file_fp(a.clone()), partition_file_fp(b), "order must not matter");
+        assert_eq!(partition_file_fp(&a), partition_file_fp(&b), "order must not matter");
         let c = vec![a[0].clone()];
-        assert_ne!(partition_file_fp(a), partition_file_fp(c), "content must matter");
+        assert_ne!(partition_file_fp(&a), partition_file_fp(&c), "content must matter");
 
         let day = 86_400_000_000i64;
         assert_eq!(window_dates(0, 0).map(|d| d.len()), Some(1));
@@ -21445,12 +21445,12 @@ mod tests {
             let guard = table.read().await;
             Database::partition_files_by_pid(&guard, &format!("date={day}"))?.remove(&key.0).unwrap_or_default()
         };
-        db.dedup_probe_declined.insert(key.clone(), partition_file_fp(files));
+        db.dedup_probe_declined.insert(key.clone(), partition_file_fp(&files));
         assert!(!candidate().await, "and is skipped once declined at that exact file set");
 
         // A commit moves the fingerprint, so it must be examined again — otherwise
         // a date that was cleaned up would stay permanently unprovable.
-        db.dedup_probe_declined.insert(key, partition_file_fp(vec!["some-other-file.parquet".to_owned()]));
+        db.dedup_probe_declined.insert(key, partition_file_fp(&["some-other-file.parquet".to_owned()]));
         assert!(candidate().await, "a changed file set makes it a candidate again");
         Ok(())
     }

--- a/src/dml.rs
+++ b/src/dml.rs
@@ -73,7 +73,7 @@ pub(crate) fn delta_session_from(session: &SessionState) -> Arc<dyn Session> {
     // Same nullability-widened file set as `Database::create_session_context`
     // (2026-07-31, 7d68f01): a DML plan reading those files must not trip the
     // physical-vs-logical aggregate schema check either.
-    let cfg = cfg.set_bool("datafusion.execution.skip_physical_aggregate_schema_check", true);
+    let mut cfg = cfg.set_bool("datafusion.execution.skip_physical_aggregate_schema_check", true);
     // A MERGE-UPDATE re-reads and rewrites WHOLE wide otel rows, so it is the
     // most decode-expensive read in the system — and it was the only one still
     // on DataFusion's 8192-row default. The query and maintenance sessions have
@@ -81,7 +81,6 @@ pub(crate) fn delta_session_from(session: &SessionState) -> Arc<dyn Session> {
     // was missed, and a dump taken mid-burst on 2026-08-13 put 38.3 GiB (57% of
     // live heap) back in exactly the stack that work had cut —
     // `extend_from_dictionary` under `ByteArrayDecoder::read`.
-    let mut cfg = cfg;
     let _ = cfg.options_mut().set("datafusion.execution.batch_size", crate::database::WIDE_ROW_DECODE_BATCH_SIZE);
     Arc::new(
         SessionStateBuilder::new()
@@ -688,10 +687,11 @@ impl DisplayAs for DmlExec {
             DisplayFormatType::Default | DisplayFormatType::Verbose => {
                 write!(f, "{}: table={}, project_id={}", self.name(), self.table_name, self.project_id)?;
                 if self.op_type == DmlOperation::Update && !self.assignments.is_empty() {
-                    write!(f, ", assignments=[{}]", self.assignments.iter().map(|(col, expr)| format!("{} = {}", col, expr)).collect::<Vec<_>>().join(", "))?;
+                    use itertools::Itertools;
+                    write!(f, ", assignments=[{}]", self.assignments.iter().map(|(col, expr)| format!("{col} = {expr}")).format(", "))?;
                 }
-                if let Some(ref pred) = self.predicate {
-                    write!(f, ", predicate={}", pred)?;
+                if let Some(pred) = &self.predicate {
+                    write!(f, ", predicate={pred}")?;
                 }
                 Ok(())
             }
@@ -1021,14 +1021,13 @@ async fn perform_version_append(
         // columns are identity columns, never version-mutable. Skipped above
         // a cap so a giant source can't build a pathological expression.
         if src.batch.num_rows() <= MOR_KEY_PUSHDOWN_ROWS {
-            for (t, s) in &src.join_keys {
-                let idx = src.schema.index_of(s)?;
-                let arr = src.batch.column(idx);
+            builder = src.join_keys.iter().try_fold(builder, |builder, (t, s)| {
+                let arr = src.batch.column(src.schema.index_of(s)?);
                 let mut vals = (0..arr.len()).map(|i| datafusion::common::ScalarValue::try_from_array(arr, i)).collect::<Result<Vec<_>>>()?;
                 vals.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
                 vals.dedup();
-                builder = builder.filter(Expr::Column(Column::from_name(t)).in_list(vals.into_iter().map(lit).collect(), false))?;
-            }
+                builder.filter(Expr::Column(Column::from_name(t)).in_list(vals.into_iter().map(lit).collect(), false))
+            })?;
         }
         let mem = MemTable::try_new(src.schema.clone(), vec![vec![src.batch.clone()]])?;
         let src_plan = LogicalPlanBuilder::scan(MOR_SOURCE, provider_as_source(Arc::new(mem)), None)?.build()?;
@@ -1120,22 +1119,19 @@ async fn perform_update_with_buffer(
     // last-write-wins hold.
     if is_version_append(table_name) {
         let append_span = tracing::trace_span!(parent: span, "mor.update");
-        let rounds = match source {
-            Some(src) => crate::dml::split_source_rounds(src)?.into_iter().map(Some).collect(),
+        // `split_source_rounds` preserves successive applications for duplicate
+        // keys. Keys are disjoint within each round, so bounded sequential
+        // chunks preserve semantics and keep pushdown enabled.
+        let chunks: Vec<Option<UpdateSource>> = match source {
+            Some(src) => crate::dml::split_source_rounds(src)?.into_iter().flat_map(|round| bounded_mor_source_chunks(round).into_iter().map(Some)).collect(),
             None => vec![None],
         };
         let mut total = 0u64;
-        for round in rounds {
-            // `split_source_rounds` preserves successive applications for
-            // duplicate keys. Keys are disjoint within each round, so bounded
-            // sequential chunks preserve semantics and keep pushdown enabled.
-            let chunks = round.map_or_else(|| vec![None], |source| bounded_mor_source_chunks(source).into_iter().map(Some).collect());
-            for chunk in chunks {
-                total +=
-                    perform_version_append(database, buffered_layer, table_name, project_id, predicate.clone(), &assignments, chunk.as_ref(), false, &session)
-                        .instrument(append_span.clone())
-                        .await?;
-            }
+        // Sequential awaits accumulating with `?`: ordered and fallible.
+        for chunk in chunks {
+            total += perform_version_append(database, buffered_layer, table_name, project_id, predicate.clone(), &assignments, chunk.as_ref(), false, &session)
+                .instrument(append_span.clone())
+                .await?;
         }
         return Ok(total);
     }
@@ -1197,13 +1193,8 @@ fn bounded_mor_source_chunks(source: UpdateSource) -> Vec<UpdateSource> {
         chunks = rows.div_ceil(MOR_KEY_PUSHDOWN_ROWS),
         "bounded merge-on-read source to preserve complete-key pushdown"
     );
-    (0..rows)
-        .step_by(MOR_KEY_PUSHDOWN_ROWS)
-        .map(|offset| UpdateSource {
-            batch: source.batch.slice(offset, (rows - offset).min(MOR_KEY_PUSHDOWN_ROWS)),
-            schema: source.schema.clone(),
-            join_keys: source.join_keys.clone(),
-        })
+    chunk_rows(&source.batch, MOR_KEY_PUSHDOWN_ROWS)
+        .map(|batch| UpdateSource { batch, schema: source.schema.clone(), join_keys: source.join_keys.clone() })
         .collect()
 }
 
@@ -2130,11 +2121,17 @@ fn clamp_decomposed(d: &mut DecomposedPredicate, watermark_micros: i64) -> Clamp
 /// rest (prod 2026-07-19: same-key multi-tag hash enrichment lost tags / errored).
 /// Returns one round for the common no-duplication case.
 pub(crate) fn split_source_rounds(source: UpdateSource) -> Result<Vec<UpdateSource>> {
-    let key_indices: Vec<usize> = source.join_keys.iter().map(|(_, s)| source.schema.index_of(s)).collect::<std::result::Result<_, _>>()?;
-    Ok(split_rounds(&source.batch, &key_indices)?
+    Ok(split_rounds_on_keys(&source.batch, &source.join_keys)?
         .into_iter()
         .map(|batch| UpdateSource { batch, schema: source.schema.clone(), join_keys: source.join_keys.clone() })
         .collect())
+}
+
+/// [`split_rounds`] keyed by the SOURCE-side names of `join_keys`, resolved
+/// against `batch`'s own schema.
+fn split_rounds_on_keys(batch: &RecordBatch, join_keys: &[(String, String)]) -> Result<Vec<RecordBatch>> {
+    let key_indices: Vec<usize> = join_keys.iter().map(|(_, s)| batch.schema().index_of(s)).collect::<std::result::Result<_, _>>()?;
+    split_rounds(batch, &key_indices)
 }
 
 /// Split `batch` into merge rounds: exact-duplicate rows are dropped, and
@@ -2309,8 +2306,7 @@ pub async fn redrive_dml_quarantine(db: &Arc<crate::database::Database>, dir: &s
             ok += 1;
             continue;
         }
-        let key_indices: Result<Vec<usize>> = meta.join_keys.iter().map(|(_, s)| Ok(merged.schema().index_of(s)?)).collect();
-        let rounds = match key_indices.and_then(|idx| split_rounds(&merged, &idx)) {
+        let rounds = match split_rounds_on_keys(&merged, &meta.join_keys) {
             Ok(r) => r,
             Err(e) => {
                 warn!("dml redrive: round split failed for {path:?}: {e}; leaving parked");
@@ -2532,8 +2528,9 @@ fn fold_groups(groups: Vec<(GroupKey, PendingGroup)>, custom_storage: &HashSet<(
         m
     });
     let unfolded = |members: Vec<Member>| members.into_iter().map(|(k, g, _)| (k, g)).collect::<Vec<_>>();
-    unfolded(ineligible)
+    ineligible
         .into_iter()
+        .map(|(k, g, _)| (k, g))
         .chain(buckets.into_iter().flat_map(|((table_name, shape_fp), mut members)| {
             if members.len() == 1 {
                 return unfolded(members);
@@ -2766,8 +2763,7 @@ impl DmlCoalescer {
             if merged.num_rows() == 0 {
                 continue;
             }
-            let key_indices: Result<Vec<usize>> = group.join_keys.iter().map(|(_, s)| Ok(merged.schema().index_of(s)?)).collect();
-            let rounds = match key_indices.and_then(|idx| split_rounds(&merged, &idx)) {
+            let rounds = match split_rounds_on_keys(&merged, &group.join_keys) {
                 Ok(r) => r,
                 Err(e) => {
                     park_group("round split", &e, std::slice::from_ref(&merged));

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,7 @@ use std::sync::Arc;
 use anyhow::Context;
 use datafusion_postgres::ServerOptions;
 use dotenv::dotenv;
+use itertools::Itertools;
 use timefusion::{
     config::{self, AppConfig},
     database::{Database, RecompressOutcome},
@@ -65,17 +66,14 @@ fn main() -> anyhow::Result<()> {
     server::raise_file_limit();
 
     let subcommand = std::env::args().nth(1);
-    if subcommand.as_deref() == Some("healthcheck") {
-        return run_pgwire_healthcheck();
-    }
-    if subcommand.as_deref() == Some("encrypt-secret") {
-        return config::run_cli();
-    }
-    // Replays a prod maintenance journal through the real scheduler on virtual
-    // time — must stay config/bucket-free, that's what lets it answer
-    // scheduler questions without a deploy.
-    if subcommand.as_deref() == Some("sim") {
-        return run_sim_cli();
+    match subcommand.as_deref() {
+        Some("healthcheck") => return run_pgwire_healthcheck(),
+        Some("encrypt-secret") => return config::run_cli(),
+        // Replays a prod maintenance journal through the real scheduler on
+        // virtual time — must stay config/bucket-free, that's what lets it
+        // answer scheduler questions without a deploy.
+        Some("sim") => return run_sim_cli(),
+        _ => {}
     }
 
     // Maintenance CLIs get the maintenance-heavy budget shape (the server shape
@@ -208,6 +206,41 @@ fn pgwire_ready_at(addr: std::net::SocketAddr) -> anyhow::Result<()> {
     anyhow::bail!("PGWire returned unexpected response tag {:?}", tag[0] as char)
 }
 
+/// Argument cursor shared by every subcommand CLI below. Two-token flags need
+/// lookahead, so `next()` yields the flag and `value`/`parse` pull the token
+/// after it; a struct rather than a closure keeps the borrow from overlapping
+/// the `next()` that drives the loop.
+struct Args(std::iter::Skip<std::env::Args>);
+
+impl Args {
+    fn new() -> Self {
+        Self(std::env::args().skip(2))
+    }
+
+    fn value(&mut self, flag: &str) -> anyhow::Result<String> {
+        self.0.next().with_context(|| format!("{flag} needs a value"))
+    }
+
+    fn parse<T>(&mut self, flag: &str, what: &str) -> anyhow::Result<T>
+    where
+        T: std::str::FromStr,
+        T::Err: std::error::Error + Send + Sync + 'static,
+    {
+        self.value(flag)?.parse().with_context(|| format!("{flag} must be {what}"))
+    }
+
+    fn hours_micros(&mut self, flag: &str) -> anyhow::Result<i64> {
+        Ok((self.parse::<f64>(flag, "a number")? * 3_600_000_000.0) as i64)
+    }
+}
+
+impl Iterator for Args {
+    type Item = String;
+    fn next(&mut self) -> Option<String> {
+        self.0.next()
+    }
+}
+
 fn init_cli_tracing() {
     let _ = tracing_subscriber::fmt()
         .with_env_filter(tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")))
@@ -233,7 +266,7 @@ fn run_sim_cli() -> anyhow::Result<()> {
     if std::env::var_os("TIMEFUSION_DEDUP_CONTIGUITY_RANK").is_some() {
         timefusion::config::init_config().map_err(|e| anyhow::anyhow!("kill-switch env set but config failed to load: {e}"))?;
     }
-    let mut it = std::env::args().skip(2);
+    let mut it = Args::new();
     let usage = "usage: timefusion sim <journal.json|data-dir|synth:whale> [--hours N] [--workers N] [--streams N] [--scale F] [--seed N] [--no-mint] [--mint] [--debris-slice-minutes N] [--floorless] [--guard-off] [--json]";
     let input = it.next().context(usage)?;
     let mut cfg = SimConfig::default();
@@ -242,21 +275,14 @@ fn run_sim_cli() -> anyhow::Result<()> {
     let mut mint = false;
     let mut debris_slice = 1i64;
     while let Some(a) = it.next() {
-        let mut value = |name: &str| -> anyhow::Result<String> { it.next().with_context(|| format!("{name} needs a value")) };
         match a.as_str() {
-            "--hours" => cfg.horizon_micros = (value("--hours")?.parse::<f64>().context("--hours must be a number")? * 3_600_000_000.0) as i64,
-            "--workers" => cfg.workers = value("--workers")?.parse().context("--workers must be an integer")?,
-            "--streams" => cfg.streams = Some(value("--streams")?.parse().context("--streams must be an integer")?),
-            "--scale" => cfg.duration_scale = value("--scale")?.parse().context("--scale must be a number")?,
-            "--seed" => cfg.seed = u64::from_str_radix(value("--seed")?.trim_start_matches("0x"), 16).context("--seed must be hex")?,
-            "--restarts-every-hours" => {
-                cfg.restart_every_micros =
-                    (value("--restarts-every-hours")?.parse::<f64>().context("--restarts-every-hours must be a number")? * 3_600_000_000.0) as i64
-            }
-            "--restart-at-hours" => {
-                cfg.restart_at_micros =
-                    Some((value("--restart-at-hours")?.parse::<f64>().context("--restart-at-hours must be a number")? * 3_600_000_000.0) as i64)
-            }
+            "--hours" => cfg.horizon_micros = it.hours_micros("--hours")?,
+            "--workers" => cfg.workers = it.parse("--workers", "an integer")?,
+            "--streams" => cfg.streams = Some(it.parse("--streams", "an integer")?),
+            "--scale" => cfg.duration_scale = it.parse("--scale", "a number")?,
+            "--seed" => cfg.seed = u64::from_str_radix(it.value("--seed")?.trim_start_matches("0x"), 16).context("--seed must be hex")?,
+            "--restarts-every-hours" => cfg.restart_every_micros = it.hours_micros("--restarts-every-hours")?,
+            "--restart-at-hours" => cfg.restart_at_micros = Some(it.hours_micros("--restart-at-hours")?),
             "--no-mint" => cfg.mint_frontier = false,
             // `synth:whale` disables minting by default (below). `--mint`
             // turns arrivals back on, which is what makes `--streams` — and so
@@ -264,7 +290,7 @@ fn run_sim_cli() -> anyhow::Result<()> {
             "--mint" => mint = true,
             // The bin-width axis: same total debris work as `600 / n` units of
             // `n` minutes. See `synthetic_whale_queue`.
-            "--debris-slice-minutes" => debris_slice = value("--debris-slice-minutes")?.parse().context("--debris-slice-minutes must be an integer")?,
+            "--debris-slice-minutes" => debris_slice = it.parse("--debris-slice-minutes", "an integer")?,
             // The floorless control, and the pre-69e6503 behaviour, for
             // `synth:whale`.
             "--floorless" => floorless = true,
@@ -281,15 +307,11 @@ fn run_sim_cli() -> anyhow::Result<()> {
         anyhow::ensure!(shape == "whale", "the only synthetic queue is `synth:whale`");
         // `--streams` scales the INGESTING streams discovered in a real
         // journal. A synthetic queue has none and sets `mint_frontier = false`
-        // below, so the flag was silently inert — while the summary line still
-        // printed the count it was given. A "10x" run reported 260 streams and
-        // modelled 1x: `--streams 26` and `--streams 260` produced BYTE-IDENTICAL
-        // reports at the same seed (2026-09-04). Refuse it rather than answer a
-        // capacity question with the baseline.
-        // Without minting there are no arrivals, so extra streams change
-        // nothing: `--streams 26` and `--streams 260` produced BYTE-IDENTICAL
-        // reports at the same seed (2026-09-04) while the summary line still
-        // printed the count it was given — a "10x" run that modelled 1x.
+        // below, so without minting there are no arrivals and the flag is
+        // silently inert: `--streams 26` and `--streams 260` produced
+        // BYTE-IDENTICAL reports at the same seed (2026-09-04) while the summary
+        // line still printed the count it was given — a "10x" run that modelled
+        // 1x. Refuse it rather than answer a capacity question with the baseline.
         anyhow::ensure!(
             cfg.streams.is_none() || mint,
             "--streams needs arrivals to scale: pass --mint (a synthetic queue disables minting by default), or use a real journal."
@@ -319,13 +341,10 @@ fn run_sim_cli() -> anyhow::Result<()> {
         "coarsen: subsumed {} fused {} | candidates {} blocked {} over_budget {}",
         report.coarsen_subsumed, report.coarsen_fused, report.coarsen_candidates, report.coarsen_blocked, report.coarsen_over_budget
     );
-    let mut completions = report.completions.iter().collect::<Vec<_>>();
-    completions.sort();
-    println!("completions: {}", completions.iter().map(|(op, n)| format!("{op}={n}")).collect::<Vec<_>>().join(" "));
+    let tally = |counts: &std::collections::HashMap<String, u64>| counts.iter().sorted().map(|(op, n)| format!("{op}={n}")).join(" ");
+    println!("completions: {}", tally(&report.completions));
     if !report.timeouts.is_empty() {
-        let mut timeouts = report.timeouts.iter().collect::<Vec<_>>();
-        timeouts.sort();
-        println!("timeouts:    {}", timeouts.iter().map(|(op, n)| format!("{op}={n}")).collect::<Vec<_>>().join(" "));
+        println!("timeouts:    {}", tally(&report.timeouts));
     }
     println!(
         "claims by data age: frontier={} mid_band(3-31d)={} privileged(>31d)={} | day-wide claims={}",
@@ -359,23 +378,23 @@ async fn run_unit_cli(cfg: &'static AppConfig) -> anyhow::Result<()> {
     let mut operation = timefusion::maintenance_coordinator::Operation::BaseRollup;
     let mut slice_hours: i64 = 24;
     let mut offset_hours: i64 = 0;
-    let mut it = std::env::args().skip(2);
+    let mut it = Args::new();
     while let Some(a) = it.next() {
-        let mut value = |name: &str| -> anyhow::Result<String> { it.next().with_context(|| format!("{name} needs a value")) };
         match a.as_str() {
-            "--source" => source = value("--source")?,
-            "--project" => project = Some(value("--project")?),
-            "--date" => date = Some(value("--date")?.parse().context("--date must be YYYY-MM-DD")?),
-            "--slice-hours" => slice_hours = value("--slice-hours")?.parse().context("--slice-hours must be an integer")?,
-            "--offset-hours" => offset_hours = value("--offset-hours")?.parse().context("--offset-hours must be an integer")?,
+            "--source" => source = it.value("--source")?,
+            "--project" => project = Some(it.value("--project")?),
+            "--date" => date = Some(it.parse("--date", "YYYY-MM-DD")?),
+            "--slice-hours" => slice_hours = it.parse("--slice-hours", "an integer")?,
+            "--offset-hours" => offset_hours = it.parse("--offset-hours", "an integer")?,
             "--op" => {
-                operation = match value("--op")?.as_str() {
-                    "base" => timefusion::maintenance_coordinator::Operation::BaseRollup,
-                    "derived" => timefusion::maintenance_coordinator::Operation::DerivedRollup,
-                    "dedup" => timefusion::maintenance_coordinator::Operation::Dedup,
-                    "hot" => timefusion::maintenance_coordinator::Operation::HotPacking,
-                    "sealed" => timefusion::maintenance_coordinator::Operation::SealedConsolidation,
-                    "repair" => timefusion::maintenance_coordinator::Operation::Repair,
+                use timefusion::maintenance_coordinator::Operation;
+                operation = match it.value("--op")?.as_str() {
+                    "base" => Operation::BaseRollup,
+                    "derived" => Operation::DerivedRollup,
+                    "dedup" => Operation::Dedup,
+                    "hot" => Operation::HotPacking,
+                    "sealed" => Operation::SealedConsolidation,
+                    "repair" => Operation::Repair,
                     other => anyhow::bail!("unknown --op {other}: base|derived|dedup|hot|sealed|repair"),
                 }
             }
@@ -402,13 +421,12 @@ async fn run_unit_cli(cfg: &'static AppConfig) -> anyhow::Result<()> {
 /// enrichment groups (see [`timefusion::dml::redrive_dml_quarantine`]).
 async fn run_redrive_dml_cli(cfg: &'static AppConfig) -> anyhow::Result<()> {
     init_cli_tracing();
-    // Two-token flags need lookahead into the arg iterator, so this stays a loop.
     let mut dir = cfg.core.wal_dir().join(timefusion::write::wal::QUARANTINE_DIR_NAME).join("dml");
     let mut dry_run = false;
-    let mut it = std::env::args().skip(2);
+    let mut it = Args::new();
     while let Some(a) = it.next() {
         match a.as_str() {
-            "--dir" => dir = it.next().map(std::path::PathBuf::from).context("--dir needs a value")?,
+            "--dir" => dir = it.value("--dir")?.into(),
             "--dry-run" => dry_run = true,
             other => anyhow::bail!("unknown argument: {other} (usage: timefusion redrive-dml [--dir PATH] [--dry-run])"),
         }
@@ -426,7 +444,7 @@ async fn async_main(cfg: &'static AppConfig) -> anyhow::Result<()> {
     // logging the tree at derivation time is silently swallowed — which is why
     // prod could carry TIMEFUSION_MEMORY_LIMIT_GB=26 while actually budgeting
     // 120 GiB with nothing on the box revealing the gap (2026-07-31).
-    config::log_derived_budget(&cfg.derived);
+    cfg.derived.log();
     support::init_from_env();
 
     // Start heap+CPU profiling (no-op unless --features profiling on Linux).
@@ -870,10 +888,10 @@ async fn run_migrate_columns_cli(cfg: &'static AppConfig) -> anyhow::Result<()> 
     let mut table = "otel_logs_and_spans".to_string();
     let mut adds: Vec<(String, String)> = Vec::new();
     let mut dry_run = false;
-    let mut it = std::env::args().skip(2);
+    let mut it = Args::new();
     while let Some(a) = it.next() {
         match a.as_str() {
-            "--table" => table = it.next().context("--table needs a value")?,
+            "--table" => table = it.value("--table")?,
             "--dry-run" => dry_run = true,
             "--add" => {
                 let spec = it.next().context("--add needs NAME:TYPE")?;
@@ -933,13 +951,11 @@ async fn run_retention_cli(cfg: &'static AppConfig) -> anyhow::Result<()> {
     let mut older_than_days: Option<i64> = None;
     let mut dry_run = false;
     let mut yes = false;
-    let mut it = std::env::args().skip(2);
+    let mut it = Args::new();
     while let Some(a) = it.next() {
         match a.as_str() {
-            "--table" => tables.extend(it.next().context("--table needs a value")?.split(',').map(str::to_owned)),
-            "--older-than-days" => {
-                older_than_days = Some(it.next().context("--older-than-days needs a value")?.parse().context("--older-than-days must be an integer")?)
-            }
+            "--table" => tables.extend(it.value("--table")?.split(',').map(str::to_owned)),
+            "--older-than-days" => older_than_days = Some(it.parse("--older-than-days", "an integer")?),
             "--dry-run" => dry_run = true,
             "--yes" => yes = true,
             other => anyhow::bail!("unknown argument: {other} (usage: timefusion retention --older-than-days N --table A[,B,...] [--dry-run] [--yes])"),
@@ -948,34 +964,25 @@ async fn run_retention_cli(cfg: &'static AppConfig) -> anyhow::Result<()> {
     let days = older_than_days.context("--older-than-days is required")?;
     anyhow::ensure!(days >= 7, "refusing a cutoff under 7 days — that is not retention, that is data loss");
     anyhow::ensure!(!tables.is_empty(), "--table is required; retention never guesses at a table list");
-    let cutoff = (chrono::Utc::now() - chrono::Duration::days(days)).date_naive();
+    let cutoff = (chrono::Utc::now() - chrono::Duration::days(days)).date_naive().to_string();
     let predicate = format!("date < '{cutoff}'");
 
     let db = Database::with_config(Arc::new(cfg.clone())).await?;
     println!("retention cutoff: {predicate}  (today - {days}d)\n");
 
     // Inventory first, from the same snapshot the delete will run against.
-    let mut plan: Vec<(String, usize, i64, usize)> = Vec::new();
+    let mut plan: Vec<(String, usize, i64)> = Vec::new();
     for t in &tables {
         let table_ref = db.get_or_create_unified_table(t).await?;
         let (old_files, old_bytes, total) = {
             let table = table_ref.read().await;
-            let mut old_files = 0usize;
-            let mut old_bytes = 0i64;
-            let mut total = 0usize;
-            for f in table.snapshot()?.log_data().iter() {
-                total += 1;
-                let path = f.path();
-                let Some(date) = path.split("date=").nth(1).and_then(|s| s.split('/').next()) else { continue };
-                if date < cutoff.to_string().as_str() {
-                    old_files += 1;
-                    old_bytes += f.size();
-                }
-            }
-            (old_files, old_bytes, total)
+            table.snapshot()?.log_data().iter().fold((0usize, 0i64, 0usize), |(files, bytes, total), f| {
+                let past_cutoff = f.path().split("date=").nth(1).and_then(|s| s.split('/').next()).is_some_and(|date| date < cutoff.as_str());
+                (files + past_cutoff as usize, bytes + if past_cutoff { f.size() } else { 0 }, total + 1)
+            })
         };
         println!("  {t:52} {old_files:>6}/{total:<6} files past cutoff, {:.2} GB", old_bytes as f64 / 1e9);
-        plan.push((t.clone(), old_files, old_bytes, total));
+        plan.push((t.clone(), old_files, old_bytes));
     }
     let (files, bytes): (usize, i64) = plan.iter().fold((0, 0), |(f, b), p| (f + p.1, b + p.2));
     println!("\nTOTAL: {files} files, {:.2} GB across {} table(s)", bytes as f64 / 1e9, plan.len());
@@ -986,7 +993,7 @@ async fn run_retention_cli(cfg: &'static AppConfig) -> anyhow::Result<()> {
     }
     anyhow::ensure!(yes, "pass --yes to commit the deletion (or --dry-run to stop here)");
 
-    for (t, old_files, _, _) in &plan {
+    for (t, old_files, _) in &plan {
         if *old_files == 0 {
             println!("  {t}: nothing past cutoff, skipping");
             continue;
@@ -1026,33 +1033,26 @@ async fn run_optimize_cli(cfg: &'static AppConfig) -> anyhow::Result<()> {
     let mut dedup = false;
     let mut recompress = false;
     let mut target_size_mb: Option<i64> = None;
-    // Two-token flags need lookahead into the arg iterator, so this stays a loop.
-    let mut it = std::env::args().skip(2);
+    let mut it = Args::new();
     while let Some(a) = it.next() {
         match a.as_str() {
-            "--table" => table = it.next().context("--table needs a value")?,
-            "--date" => only_date = Some(it.next().context("--date needs a value")?.parse().context("--date must be YYYY-MM-DD")?),
-            "--older-than-hours" => {
-                older_than_hours = it.next().context("--older-than-hours needs a value")?.parse().context("--older-than-hours must be an integer")?
-            }
+            "--table" => table = it.value("--table")?,
+            "--date" => only_date = Some(it.parse("--date", "YYYY-MM-DD")?),
+            "--older-than-hours" => older_than_hours = it.parse("--older-than-hours", "an integer")?,
             "--all" => all = true,
             "--dry-run" => dry_run = true,
-            "--project" => project = Some(it.next().context("--project needs a value")?),
-            "--concurrency" => concurrency = Some(it.next().context("--concurrency needs a value")?.parse().context("--concurrency must be an integer")?),
+            "--project" => project = Some(it.value("--project")?),
+            "--concurrency" => concurrency = Some(it.parse("--concurrency", "an integer")?),
             "--consolidate" => consolidate = true,
             "--dedup" => dedup = true,
             "--recompress" => recompress = true,
-            "--target-size-mb" => {
-                target_size_mb = Some(it.next().context("--target-size-mb needs a value")?.parse().context("--target-size-mb must be an integer")?)
-            }
+            "--target-size-mb" => target_size_mb = Some(it.parse("--target-size-mb", "an integer")?),
             other => anyhow::bail!(
                 "unknown argument: {other} (usage: timefusion optimize [--table T] [--date YYYY-MM-DD | --older-than-hours N | --all] [--project ID] [--concurrency N] [--consolidate [--target-size-mb N]] [--dedup] [--recompress] [--dry-run])"
             ),
         }
     }
-    if target_size_mb.is_some() && !consolidate {
-        anyhow::bail!("--target-size-mb only applies to --consolidate");
-    }
+    anyhow::ensure!(target_size_mb.is_none() || consolidate, "--target-size-mb only applies to --consolidate");
 
     let db = Database::with_config(Arc::new(cfg.clone())).await?;
     // Attach the tantivy sidecar service exactly like the server bootstrap.
@@ -1114,9 +1114,9 @@ async fn run_optimize_cli(cfg: &'static AppConfig) -> anyhow::Result<()> {
     // predicate to `date = '...' AND project_id = '...'`, which is what makes
     // the job small enough to run on an ordinary runner.
     if recompress {
+        let level = cfg.parquet.timefusion_zstd_compression_level;
+        let scope = project.as_deref().map_or(String::new(), |p| format!(" project={p}"));
         for d in &dates {
-            let level = cfg.parquet.timefusion_zstd_compression_level;
-            let scope = project.as_deref().map(|p| format!(" project={p}")).unwrap_or_default();
             match db.recompress_partition(&table_ref, &table, *d, level, project.as_deref()).await {
                 Ok(RecompressOutcome::Rewritten { files }) => println!("  recompress date={d}{scope}: rewritten from {files} file(s) (sorted footer restored)"),
                 Ok(RecompressOutcome::Skipped(why)) => println!("  recompress date={d}{scope}: SKIPPED — {why}"),
@@ -1218,20 +1218,16 @@ mod healthcheck_tests {
         addr
     }
 
-    #[test]
-    fn liveness_accepts_authentication_and_startup_error_only() {
-        assert!(pgwire_ready_at(one_response(vec![b'R'])).is_ok());
-        let error = |code: &[u8]| {
-            let mut payload = vec![b'C'];
-            payload.extend_from_slice(code);
-            payload.extend_from_slice(&[0, 0]);
-            let mut response = vec![b'E'];
-            response.extend_from_slice(&((payload.len() + 4) as u32).to_be_bytes());
-            response.extend_from_slice(&payload);
-            response
-        };
-        assert!(pgwire_ready_at(one_response(error(b"57P03"))).is_ok());
-        assert!(pgwire_ready_at(one_response(error(b"XX000"))).is_err());
+    fn error_frame(code: &[u8]) -> Vec<u8> {
+        let payload = [&b"C"[..], code, &[0, 0]].concat();
+        [&[b'E'][..], &((payload.len() + 4) as u32).to_be_bytes(), &payload[..]].concat()
+    }
+
+    #[test_case::test_case(vec![b'R'] => true ; "authentication request")]
+    #[test_case::test_case(error_frame(b"57P03") => true ; "starting-up error is alive enough")]
+    #[test_case::test_case(error_frame(b"XX000") => false ; "any other error is unhealthy")]
+    fn liveness_accepts_authentication_and_startup_error_only(response: Vec<u8>) -> bool {
+        pgwire_ready_at(one_response(response)).is_ok()
     }
 
     /// The probe and the Dockerfile are one budget split across two files, and

--- a/src/maintenance_coordinator.rs
+++ b/src/maintenance_coordinator.rs
@@ -6,7 +6,7 @@
 //! a unit whose decoded-byte reservation fits the configured ceiling.
 
 use std::{
-    collections::{BTreeMap, HashMap, HashSet, VecDeque},
+    collections::{BTreeMap, HashMap, HashSet},
     fs::{self, OpenOptions},
     io::{ErrorKind, Write},
     path::{Path, PathBuf},
@@ -15,11 +15,7 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 
-/// Lock without letting a poisoned mutex propagate: every mutex here guards
-/// plain data, so a panicking holder leaves it usable.
-fn lock<T>(mutex: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
-    mutex.lock().unwrap_or_else(std::sync::PoisonError::into_inner)
-}
+use crate::support::lock;
 
 pub const NORMAL_SLICE_MICROS: i64 = 10 * 60 * 1_000_000;
 pub const DAY_MICROS: i64 = 24 * 60 * 60 * 1_000_000;
@@ -234,7 +230,7 @@ const JOURNAL_VERSION: u32 = 1;
 const JOURNAL_COMPACT_BYTES: u64 = 64 * 1024 * 1024;
 static THROUGHPUT_SAMPLE: std::sync::OnceLock<Mutex<(i64, u64)>> = std::sync::OnceLock::new();
 
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize, strum::EnumCount, strum::IntoStaticStr)]
 #[serde(rename_all = "snake_case")]
 pub enum Operation {
     Dedup,
@@ -243,19 +239,6 @@ pub enum Operation {
     HotPacking,
     SealedConsolidation,
     Repair,
-}
-
-impl Operation {
-    const fn priority(self) -> u8 {
-        match self {
-            Self::Dedup => 0,
-            Self::BaseRollup => 1,
-            Self::DerivedRollup => 2,
-            Self::HotPacking => 3,
-            Self::SealedConsolidation => 4,
-            Self::Repair => 5,
-        }
-    }
 }
 
 /// The operation mix a maintenance worker rotates through. One definition for
@@ -3476,45 +3459,6 @@ impl TaskJournal {
     }
 }
 
-/// `(class, starved, operation priority, -width, benefit, recency)` -> project ->
-/// that project's queue. Ordered so smaller tuples run first; see `scheduling_class`.
-type ReadyGroups<'a> = BTreeMap<(u8, u8, u8, i64, i64, i64), HashMap<&'a str, VecDeque<&'a MaintenanceTask>>>;
-
-/// Deadline ordering with round-robin selection among projects at the same
-/// operation priority. This prevents one whale from consuming an entire pass.
-pub fn fair_ready_tasks<'a>(tasks: impl IntoIterator<Item = &'a MaintenanceTask>, now_micros: i64) -> Vec<&'a MaintenanceTask> {
-    let mut groups: ReadyGroups<'_> = BTreeMap::new();
-    for task in tasks {
-        if matches!(task.state, TaskState::Pending | TaskState::Retry) && task.deadline_micros <= now_micros {
-            let (class, starved, width_key, benefit_key, order_key) = scheduling_class(task, now_micros);
-            groups
-                .entry((class, starved, task.key.operation.priority(), width_key, benefit_key, order_key))
-                .or_default()
-                .entry(&task.key.project_id)
-                .or_default()
-                .push_back(task);
-        }
-    }
-    let mut ready = Vec::new();
-    for projects in groups.values_mut() {
-        let mut names: Vec<_> = projects.keys().copied().collect();
-        names.sort_unstable();
-        loop {
-            let mut progressed = false;
-            for name in &names {
-                if let Some(task) = projects.get_mut(name).and_then(VecDeque::pop_front) {
-                    ready.push(task);
-                    progressed = true;
-                }
-            }
-            if !progressed {
-                break;
-            }
-        }
-    }
-    ready
-}
-
 /// Keep the live finalized frontier ahead of historical debt. Within the
 /// frontier, newest eligible slices run first so sustained backfill cannot make
 /// the raw tail grow without bound; tasks in the same minute still rotate by
@@ -4326,8 +4270,7 @@ mod tests {
     /// at 2. Ageing does not cover it: both are starved, and width decides
     /// within the starved set.
     ///
-    /// Asserted on the WIDTH TERM of `scheduling_class` rather than on the order
-    /// `fair_ready_tasks` returns. The original fixture compared a recent split
+    /// Asserted on the WIDTH TERM of `scheduling_class` rather than on     /// `fair_ready_tasks` returns. The original fixture compared a recent split
     /// day against an older day-wide one and asserted the recent won; that has
     /// since become the wrong expectation for a reason unrelated to this fix —
     /// `starved` is now a per-day SLOPE past the 31-day horizon, so a 39-day
@@ -4717,14 +4660,6 @@ mod tests {
     }
 
     #[test]
-    fn scheduler_rotates_projects_within_a_deadline() {
-        let tasks =
-            [task("a", 0, 1, Operation::Dedup), task("a", 1, 2, Operation::Dedup), task("b", 0, 1, Operation::Dedup), task("b", 1, 2, Operation::Dedup)];
-        let order: Vec<_> = fair_ready_tasks(&tasks, 0).into_iter().map(|task| task.key.project_id.as_str()).collect();
-        assert_eq!(order, ["a", "b", "a", "b"]);
-    }
-
-    #[test]
     fn journal_claims_rotate_projects_instead_of_restarting_at_first() {
         let dir = tempfile::tempdir().expect("temp dir");
         let mut journal = TaskJournal::load(dir.path()).expect("journal");
@@ -4783,8 +4718,7 @@ mod tests {
         let now = 10 * 24 * 60 * 60 * 1_000_000;
         let old = task("old", 0, MIN_SLICE_MICROS, Operation::Dedup);
         let recent = task("recent", now - MIN_SLICE_MICROS, now, Operation::BaseRollup);
-        let ready = fair_ready_tasks([&old, &recent], now);
-        assert_eq!(ready.first().expect("ready task").key.project_id, "recent");
+        assert!(scheduling_class(&recent, now) < scheduling_class(&old, now), "a recent slice outranks overdue historical work");
     }
 
     #[test]
@@ -4793,19 +4727,7 @@ mod tests {
         let older_start = now - 12 * 60 * 60 * 1_000_000;
         let older = task("older", older_start, older_start + MIN_SLICE_MICROS, Operation::BaseRollup);
         let newest = task("newest", now - 2 * MIN_SLICE_MICROS, now - MIN_SLICE_MICROS, Operation::BaseRollup);
-        let ready = fair_ready_tasks([&older, &newest], now);
-        assert_eq!(ready.first().expect("ready task").key.project_id, "newest");
-    }
-
-    #[test]
-    fn frontier_minute_rotates_fairly_across_projects() {
-        let now = 10 * 24 * 60 * 60 * 1_000_000;
-        let start = now - 2 * MIN_SLICE_MICROS;
-        let a = task("a", start, start + MIN_SLICE_MICROS, Operation::BaseRollup);
-        let b = task("b", start, start + MIN_SLICE_MICROS, Operation::BaseRollup);
-        let c = task("c", start, start + MIN_SLICE_MICROS, Operation::BaseRollup);
-        let ready = fair_ready_tasks([&c, &a, &b], now);
-        assert_eq!(ready.iter().map(|task| task.key.project_id.as_str()).collect::<Vec<_>>(), ["a", "b", "c"]);
+        assert!(scheduling_class(&newest, now) < scheduling_class(&older, now));
     }
 
     #[test]
@@ -4815,8 +4737,7 @@ mod tests {
         correction.deadline_micros = now - 1;
         let mut frontier = task("frontier", now - 2 * MIN_SLICE_MICROS, now - MIN_SLICE_MICROS, Operation::BaseRollup);
         frontier.deadline_micros = now - 60 * 1_000_000;
-        let ready = fair_ready_tasks([&correction, &frontier], now);
-        assert_eq!(ready.first().expect("ready task").key.project_id, "frontier");
+        assert!(scheduling_class(&frontier, now) < scheduling_class(&correction, now));
     }
 
     #[test]
@@ -4824,8 +4745,7 @@ mod tests {
         let now = 10 * 24 * 60 * 60 * 1_000_000;
         let future = task("future", now + 24 * 60 * 60 * 1_000_000, now + 24 * 60 * 60 * 1_000_000 + MIN_SLICE_MICROS, Operation::BaseRollup);
         let frontier = task("frontier", now - 2 * MIN_SLICE_MICROS, now - MIN_SLICE_MICROS, Operation::BaseRollup);
-        let ready = fair_ready_tasks([&future, &frontier], now);
-        assert_eq!(ready.first().expect("ready task").key.project_id, "frontier");
+        assert!(scheduling_class(&frontier, now) < scheduling_class(&future, now));
     }
 
     /// Historical debt runs newest SLICE first, not oldest deadline first.
@@ -5072,8 +4992,7 @@ mod tests {
         older_slice.deadline_micros = now - 2 * 60 * 1_000_000;
         let mut newer_slice = task("b", base + MIN_SLICE_MICROS, base + 2 * MIN_SLICE_MICROS, Operation::BaseRollup);
         newer_slice.deadline_micros = now - 60 * 1_000_000;
-        let ready = fair_ready_tasks([&older_slice, &newer_slice], now);
-        assert_eq!(ready.first().expect("ready task").key.project_id, "b", "the more recent slice is the one a dashboard query needs");
+        assert!(scheduling_class(&newer_slice, now) < scheduling_class(&older_slice, now), "the more recent slice is the one a dashboard query needs");
     }
 
     #[test]

--- a/src/maintenance_sim.rs
+++ b/src/maintenance_sim.rs
@@ -720,7 +720,7 @@ pub fn run(mut journal: TaskJournal, cfg: &SimConfig, start_micros: i64) -> anyh
     // up to 12 full scans per wake event). One side effect is lost: the
     // skipped calls would have bumped `claim_tick`, so the sealed-reservation
     // parity shifts slightly — reservation SHARE over time is unchanged.
-    let mut none_until = [0i64; 6];
+    let mut none_until = [0i64; <Operation as strum::EnumCount>::COUNT];
     // Evaluated before any claim, so the initial cycle matches the journal's
     // seeded coverage.
     let mut coverage_short = coverage.coverage_is_short(now);

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -18,22 +18,24 @@
 
 use std::{
     sync::{
-        Arc, Mutex, OnceLock, Weak,
+        Arc, LazyLock, OnceLock, Weak,
         atomic::{AtomicU64, Ordering::Relaxed},
     },
     time::Duration,
 };
 
-static MAINTENANCE_RETRY_REASON: OnceLock<Mutex<String>> = OnceLock::new();
+// `parking_lot`, not `std`: these mutexes guard counters and summaries, where a
+// panic leaves no invariant worth propagating, so poison handling was pure noise.
+use parking_lot::Mutex;
+
+static MAINTENANCE_RETRY_REASON: LazyLock<Mutex<String>> = LazyLock::new(Mutex::default);
 
 pub fn set_maintenance_retry_reason(reason: &str) {
-    let mut current = MAINTENANCE_RETRY_REASON.get_or_init(|| Mutex::new(String::new())).lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-    current.clear();
-    current.push_str(reason);
+    *MAINTENANCE_RETRY_REASON.lock() = reason.to_owned();
 }
 
 pub fn maintenance_retry_reason() -> String {
-    MAINTENANCE_RETRY_REASON.get_or_init(|| Mutex::new(String::new())).lock().unwrap_or_else(std::sync::PoisonError::into_inner).clone()
+    MAINTENANCE_RETRY_REASON.lock().clone()
 }
 
 /// Retries counted per `(operation, reason)`.
@@ -43,7 +45,7 @@ pub fn maintenance_retry_reason() -> String {
 /// 14 completions and 472 retries?" on 2026-08-31 meant copying a 52 MB journal
 /// out of the prod container. `retry_or_split` writes the reason into the task,
 /// so the fleet-level histogram was the only thing missing.
-static MAINTENANCE_RETRIES: OnceLock<dashmap::DashMap<String, AtomicU64>> = OnceLock::new();
+static MAINTENANCE_RETRIES: LazyLock<dashmap::DashMap<String, AtomicU64>> = LazyLock::new(dashmap::DashMap::new);
 
 /// Work actually done per `(operation, metric)` — the counterpart to the retry
 /// histogram above, and the metric deploy 12 could not be judged on.
@@ -54,14 +56,13 @@ static MAINTENANCE_RETRIES: OnceLock<dashmap::DashMap<String, AtomicU64>> = Once
 /// per minute measures churn as readily as work, so the fleet needs a rate
 /// whose numerator is work (`rows_dropped`) and whose denominator is capacity
 /// (`worker_secs`).
-static MAINTENANCE_WORK: OnceLock<dashmap::DashMap<String, AtomicU64>> = OnceLock::new();
+static MAINTENANCE_WORK: LazyLock<dashmap::DashMap<String, AtomicU64>> = LazyLock::new(dashmap::DashMap::new);
 
 /// Bounded on purpose: a retry reason can carry error text (`"dedup: Not enough
 /// memory ..."`), so the map stops accepting new keys once it is full rather
 /// than growing with distinct error strings.
-fn add_bounded(map: &OnceLock<dashmap::DashMap<String, AtomicU64>>, key: String, amount: u64) {
+fn add_bounded(map: &dashmap::DashMap<String, AtomicU64>, key: String, amount: u64) {
     const MAX_KEYS: usize = 128;
-    let map = map.get_or_init(dashmap::DashMap::new);
     if let Some(count) = map.get(&key) {
         count.fetch_add(amount, Relaxed);
     } else if map.len() < MAX_KEYS {
@@ -69,8 +70,8 @@ fn add_bounded(map: &OnceLock<dashmap::DashMap<String, AtomicU64>>, key: String,
     }
 }
 
-fn counter_rows(map: &OnceLock<dashmap::DashMap<String, AtomicU64>>, prefix: &str) -> Vec<(String, u64)> {
-    map.get().map(|map| map.iter().map(|entry| (format!("{prefix}.{}", entry.key()), entry.value().load(Relaxed))).collect()).unwrap_or_default()
+fn counter_rows(map: &dashmap::DashMap<String, AtomicU64>, prefix: &str) -> Vec<(String, u64)> {
+    map.iter().map(|entry| (format!("{prefix}.{}", entry.key()), entry.value().load(Relaxed))).collect()
 }
 
 pub fn count_maintenance_retry(operation: &str, reason: &str) {
@@ -219,7 +220,7 @@ struct LocalHistograms(dashmap::DashMap<String, Mutex<metrics_util::storage::Sum
 
 impl LocalHistograms {
     fn quantile(&self, name: &str, p: f64) -> Option<f64> {
-        self.0.get(name)?.lock().unwrap_or_else(std::sync::PoisonError::into_inner).quantile(p)
+        self.0.get(name)?.lock().quantile(p)
     }
 }
 
@@ -230,13 +231,7 @@ struct LocalHistogramHandle {
 
 impl metrics::HistogramFn for LocalHistogramHandle {
     fn record(&self, value: f64) {
-        self.histograms
-            .0
-            .entry(self.name.clone())
-            .or_insert_with(|| Mutex::new(metrics_util::storage::Summary::with_defaults()))
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .add(value);
+        self.histograms.0.entry(self.name.clone()).or_insert_with(|| Mutex::new(metrics_util::storage::Summary::with_defaults())).lock().add(value);
     }
 }
 
@@ -269,8 +264,26 @@ impl metrics::Recorder for LocalRecorder {
     }
 }
 
+impl LocalRecorder {
+    fn new() -> Self {
+        Self { histograms: Arc::new(LocalHistograms(dashmap::DashMap::new())), registry: Arc::new(CounterGaugeRegistry::atomic()) }
+    }
+}
+
 static LOCAL_HISTOGRAMS: OnceLock<Arc<LocalHistograms>> = OnceLock::new();
 static LOCAL_REGISTRY: OnceLock<Arc<CounterGaugeRegistry>> = OnceLock::new();
+
+/// Installs `recorder` as the global `metrics` recorder — a no-op if one is
+/// already installed (a second `init_metrics()`, or a test against a booted
+/// server) — and on success publishes `local`'s handles for in-process readback.
+/// `local` is either `recorder` itself or one of its fanout arms, so the two
+/// share the same `Arc`s and readback sees every write.
+fn publish_local(local: LocalRecorder, recorder: impl metrics::Recorder + Sync + 'static) {
+    if metrics::set_global_recorder(recorder).is_ok() {
+        let _ = LOCAL_HISTOGRAMS.set(local.histograms);
+        let _ = LOCAL_REGISTRY.set(local.registry);
+    }
+}
 
 /// Read back a quantile (0.0-1.0) for a name recorded via `metrics::histogram!()`.
 /// `None` if metrics weren't initialized or the name has never recorded a value.
@@ -297,12 +310,8 @@ pub fn gauge_value(name: &'static str) -> f64 {
 /// A no-op if a recorder is already installed (e.g. the test runs against a fully bootstrapped
 /// server) — matches `init_metrics()`'s own idempotence.
 pub fn init_local_metrics_for_test() {
-    let local_histograms = Arc::new(LocalHistograms(dashmap::DashMap::new()));
-    let local_registry = Arc::new(CounterGaugeRegistry::atomic());
-    if metrics::set_global_recorder(LocalRecorder { histograms: local_histograms.clone(), registry: local_registry.clone() }).is_ok() {
-        let _ = LOCAL_HISTOGRAMS.set(local_histograms);
-        let _ = LOCAL_REGISTRY.set(local_registry);
-    }
+    let local = LocalRecorder::new();
+    publish_local(local.clone(), local);
 }
 
 /// Initialize OTel metrics. Idempotent (subsequent calls are no-ops).
@@ -343,16 +352,12 @@ pub fn init_metrics(
     // `histogram_quantile()`/`counter_value()`/`gauge_value()`.
     // Idempotent-guarded by the METRICS OnceLock above; ignore "already installed"
     // from a second init_metrics() call (tests, embedded use).
-    let local_histograms = Arc::new(LocalHistograms(dashmap::DashMap::new()));
-    let local_registry = Arc::new(CounterGaugeRegistry::atomic());
+    let local = LocalRecorder::new();
     let fanout = metrics_util::layers::FanoutBuilder::default()
-        .add_recorder(LocalRecorder { histograms: local_histograms.clone(), registry: local_registry.clone() })
+        .add_recorder(local.clone())
         .add_recorder(metrics_exporter_opentelemetry::Recorder::with_meter(meter.clone()))
         .build();
-    if metrics::set_global_recorder(fanout).is_ok() {
-        let _ = LOCAL_HISTOGRAMS.set(local_histograms);
-        let _ = LOCAL_REGISTRY.set(local_registry);
-    }
+    publish_local(local, fanout);
 
     // Observable gauges polled from snapshot_stats() each export cycle. We
     // build one shared snapshot per export by stashing the Weak; if the
@@ -393,6 +398,14 @@ pub fn init_metrics(
         (counter $($rest:tt)+) => { layer_metric!(@build u64_observable_counter, $($rest)+) };
     }
 
+    /// Same shape for gauges whose source is a process-global atomic (no Weak,
+    /// no snapshot) — `$read` is evaluated once per export cycle.
+    macro_rules! atomic_gauge {
+        ($id:literal, $desc:literal, $read:expr) => {
+            meter.u64_observable_gauge($id).with_description($desc).with_callback(|obs| obs.observe($read, &[])).build();
+        };
+    }
+
     layer_metric!(gauge "timefusion.mem_buffer.pressure_pct", "MemBuffer memory pressure as percentage of max", |s| s.pressure_pct as u64);
     layer_metric!(gauge "timefusion.mem_buffer.estimated_bytes", "MemBuffer estimated heap residency in bytes", |s| s.mem_estimated_bytes as u64);
     layer_metric!(gauge "timefusion.mem_buffer.rows", "Total rows in MemBuffer across all projects/tables", |s| s.mem_total_rows as u64);
@@ -413,38 +426,36 @@ pub fn init_metrics(
     // Extracted-index disk cache, as of the last reap. Shares a volume with
     // the WAL, so a plateau at the configured budget is healthy and a climb
     // past it means the reap cron has stopped running.
-    meter
-        .u64_observable_gauge("timefusion.tantivy.cache_disk_bytes")
-        .with_description("Bytes under <data_dir>/tantivy_cache as of the most recent reap; 0 until the first one runs")
-        .with_callback(|obs| obs.observe(TANTIVY_CACHE_BYTES.load(std::sync::atomic::Ordering::Relaxed), &[]))
-        .build();
+    atomic_gauge!(
+        "timefusion.tantivy.cache_disk_bytes",
+        "Bytes under <data_dir>/tantivy_cache as of the most recent reap; 0 until the first one runs",
+        TANTIVY_CACHE_BYTES.load(Relaxed)
+    );
 
     // Runtime scheduling lag — see `spawn_runtime_lag_sampler`. `last` is the
     // current state; `max` is the high-water mark for the process lifetime, so
     // a spike that has since recovered is still visible after the fact.
-    meter
-        .u64_observable_gauge("timefusion.runtime.scheduling_lag_ms")
-        .with_description(
-            "How late a 500ms timer task actually woke — nonzero means workers are starved, which is what a missed health probe looks like from inside",
-        )
-        .with_callback(|obs| obs.observe(RUNTIME_LAG_LAST_MS.load(Relaxed), &[]))
-        .build();
-    meter
-        .u64_observable_gauge("timefusion.runtime.scheduling_lag_max_ms")
-        .with_description("Worst scheduling lag this process lifetime; survives the spike so a post-mortem can still see it")
-        .with_callback(|obs| obs.observe(RUNTIME_LAG_MAX_MS.load(Relaxed), &[]))
-        .build();
+    atomic_gauge!(
+        "timefusion.runtime.scheduling_lag_ms",
+        "How late a 500ms timer task actually woke — nonzero means workers are starved, which is what a missed health probe looks like from inside",
+        RUNTIME_LAG_LAST_MS.load(Relaxed)
+    );
+    atomic_gauge!(
+        "timefusion.runtime.scheduling_lag_max_ms",
+        "Worst scheduling lag this process lifetime; survives the spike so a post-mortem can still see it",
+        RUNTIME_LAG_MAX_MS.load(Relaxed)
+    );
 
-    meter
-        .u64_observable_gauge("timefusion.rollup.maintenance.pending_dirty_partitions")
-        .with_description("Source partitions with durable rollup invalidations awaiting maintenance")
-        .with_callback(|obs| obs.observe(maintenance_stats().rollup_dirty_partitions.load(Relaxed), &[]))
-        .build();
-    meter
-        .u64_observable_gauge("timefusion.rollup.maintenance.oldest_invalidation_age_seconds")
-        .with_description("Age of the oldest durable rollup invalidation")
-        .with_callback(|obs| obs.observe(maintenance_stats().rollup_oldest_invalidation_age_secs.load(Relaxed), &[]))
-        .build();
+    atomic_gauge!(
+        "timefusion.rollup.maintenance.pending_dirty_partitions",
+        "Source partitions with durable rollup invalidations awaiting maintenance",
+        maintenance_stats().rollup_dirty_partitions.load(Relaxed)
+    );
+    atomic_gauge!(
+        "timefusion.rollup.maintenance.oldest_invalidation_age_seconds",
+        "Age of the oldest durable rollup invalidation",
+        maintenance_stats().rollup_oldest_invalidation_age_secs.load(Relaxed)
+    );
 
     // Index lag: how far behind ingest the newest published tantivy index is.
     // Computed as max(0, now - newest_max_timestamp). Surfaces the post-flush
@@ -510,10 +521,10 @@ pub fn record_flush(success: bool) {
 /// Last observed size of the tantivy extracted-index disk cache. Written by
 /// the reap cron, read by the `cache_disk_bytes` gauge callback — the walk it
 /// comes from is far too expensive to run per scrape.
-static TANTIVY_CACHE_BYTES: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+static TANTIVY_CACHE_BYTES: AtomicU64 = AtomicU64::new(0);
 
 pub fn record_tantivy_cache_bytes(bytes: u64) {
-    TANTIVY_CACHE_BYTES.store(bytes, std::sync::atomic::Ordering::Relaxed);
+    TANTIVY_CACHE_BYTES.store(bytes, Relaxed);
 }
 
 /// When this process started, as seen from inside it.
@@ -524,13 +535,13 @@ pub fn record_tantivy_cache_bytes(bytes: u64) {
 /// (2026-08-23: a tantivy accrual "fix" was credited twice to what was purely
 /// process age). `docker service ps` answers this from outside, but nothing
 /// pairs it with the numbers themselves; `timefusion_stats` now does.
-static PROCESS_START: std::sync::LazyLock<std::time::Instant> = std::sync::LazyLock::new(std::time::Instant::now);
+static PROCESS_START: LazyLock<std::time::Instant> = LazyLock::new(std::time::Instant::now);
 
 /// Pin the process-start instant. Idempotent; call as early as possible in
 /// every entry point (`main`, `bootstrap`) — the first force wins, so a late
 /// first call would under-report uptime for the whole process lifetime.
 pub fn mark_process_start() {
-    std::sync::LazyLock::force(&PROCESS_START);
+    LazyLock::force(&PROCESS_START);
 }
 
 pub fn process_uptime_secs() -> u64 {
@@ -544,7 +555,7 @@ pub fn process_uptime_secs() -> u64 {
 /// restart would claim to be the same process — the one answer that turns
 /// "somebody else staged this" into "we are still staging it".
 pub fn instance_id() -> &'static str {
-    static INSTANCE_ID: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| uuid::Uuid::new_v4().to_string());
+    static INSTANCE_ID: LazyLock<String> = LazyLock::new(|| uuid::Uuid::new_v4().to_string());
     &INSTANCE_ID
 }
 
@@ -614,7 +625,7 @@ struct SectionStat {
 /// awaits that gave the worker back. Reading one as the other is how "blocked"
 /// and "slow" get confused, which is the exact confusion this plan exists to
 /// resolve.
-static SECTION_STATS: std::sync::LazyLock<dashmap::DashMap<(&'static str, &'static str), SectionStat>> = std::sync::LazyLock::new(dashmap::DashMap::new);
+static SECTION_STATS: LazyLock<dashmap::DashMap<(&'static str, &'static str), SectionStat>> = LazyLock::new(dashmap::DashMap::new);
 
 fn record_section(component: &'static str, name: &'static str, elapsed: Duration) {
     let entry = SECTION_STATS.entry((component, name)).or_default();
@@ -704,7 +715,10 @@ pub fn section_stats() -> Vec<((&'static str, &'static str), u64, u64, u64)> {
 
 /// Holds `inner` while a [`BlockWatch`] times it. Derefs to `inner`, so a
 /// `MutexGuard` wrapped in one is used exactly like the guard.
+#[derive(derive_more::Deref, derive_more::DerefMut)]
 pub struct Watched<T> {
+    #[deref]
+    #[deref_mut]
     inner: T,
     _watch: BlockWatch,
 }
@@ -712,19 +726,6 @@ pub struct Watched<T> {
 impl<T> Watched<T> {
     pub fn new(name: &'static str, inner: T) -> Self {
         Self { inner, _watch: BlockWatch::new(name) }
-    }
-}
-
-impl<T> std::ops::Deref for Watched<T> {
-    type Target = T;
-    fn deref(&self) -> &T {
-        &self.inner
-    }
-}
-
-impl<T> std::ops::DerefMut for Watched<T> {
-    fn deref_mut(&mut self) -> &mut T {
-        &mut self.inner
     }
 }
 
@@ -831,26 +832,15 @@ sum_recorders! {
     record_dangling_removed(n => reconcile_dangling_removed mirror MAINTENANCE_STATS.dangling_removed);
 }
 
-/// One commit-path operation abandoned by its bound. `op` is a fixed set of
-/// static labels (bounded cardinality by construction — never a table or
-/// project id, which belong on the accompanying warn's span attributes).
 /// One dashboard aggregate answered from a configured rollup.
 pub fn record_rollup_hit(mode: &'static str, grain: &str) {
     let stats = maintenance_stats();
-    if mode == "hybrid" { &stats.rollup_hits_hybrid } else { &stats.rollup_hits_full }.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    if mode == "hybrid" { &stats.rollup_hits_hybrid } else { &stats.rollup_hits_full }.fetch_add(1, Relaxed);
     if let Some(m) = METRICS.get() {
         m.rollup_hits.add(1, &[KeyValue::new("mode", mode), KeyValue::new("grain", grain.to_string())]);
     }
 }
 
-/// One dashboard aggregate that fell through to a raw scan.
-///
-/// Takes the REASON, not its label: the match below is exhaustive, so a new
-/// variant fails the build instead of landing in a catch-all bucket. It
-/// previously matched on the string and four of the thirteen reasons had no
-/// arm, so `missing_project`, `unbounded_time`, `non_decomposable` and
-/// `rewrite_schema_mismatch` were indistinguishable in prod — 29 misses that
-/// could not be diagnosed without a deploy.
 /// True on the first, and then every `ROLLUP_MISS_SAMPLE`th, miss under `key` —
 /// for logging one refused plan with context. Misses run at several per second
 /// on a busy node, so the counter is what you alert on and this is what you
@@ -871,16 +861,23 @@ pub fn record_rollup_hit(mode: &'static str, grain: &str) {
 /// 2026-08-17 — still prints only ~2.5 lines/min, the same order as before.
 pub fn sample_rollup_miss(key: &'static str) -> bool {
     const ROLLUP_MISS_SAMPLE: u64 = 64;
-    static SEEN: std::sync::OnceLock<dashmap::DashMap<&'static str, u64>> = std::sync::OnceLock::new();
-    let mut seen = SEEN.get_or_init(dashmap::DashMap::new).entry(key).or_insert(0);
-    *seen += 1;
-    (*seen - 1).is_multiple_of(ROLLUP_MISS_SAMPLE)
+    static SEEN: LazyLock<dashmap::DashMap<&'static str, AtomicU64>> = LazyLock::new(dashmap::DashMap::new);
+    // `fetch_add` returns the count BEFORE the increment, so a key's first miss always samples.
+    SEEN.entry(key).or_default().fetch_add(1, Relaxed).is_multiple_of(ROLLUP_MISS_SAMPLE)
 }
 
+/// One dashboard aggregate that fell through to a raw scan.
+///
+/// Takes the REASON, not its label: the match below is exhaustive, so a new
+/// variant fails the build instead of landing in a catch-all bucket. It
+/// previously matched on the string and four of the thirteen reasons had no
+/// arm, so `missing_project`, `unbounded_time`, `non_decomposable` and
+/// `rewrite_schema_mismatch` were indistinguishable in prod — 29 misses that
+/// could not be diagnosed without a deploy.
 pub fn record_rollup_miss(reason: crate::rollup::MissReason) {
     use crate::rollup::MissReason as R;
     let stats = maintenance_stats();
-    stats.rollup_misses_total.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    stats.rollup_misses_total.fetch_add(1, Relaxed);
     match reason {
         R::NotBuilt => &stats.rollup_miss_not_built,
         R::StaleCoverage => &stats.rollup_miss_stale_coverage,
@@ -902,12 +899,15 @@ pub fn record_rollup_miss(reason: crate::rollup::MissReason) {
         R::UnwalkableSource => &stats.rollup_miss_unwalkable_source,
         R::MeasureNotStored => &stats.rollup_miss_measure_not_stored,
     }
-    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    .fetch_add(1, Relaxed);
     if let Some(m) = METRICS.get() {
         m.rollup_misses.add(1, &[KeyValue::new("reason", reason.label())]);
     }
 }
 
+/// One commit-path operation abandoned by its bound. `op` is a fixed set of
+/// static labels (bounded cardinality by construction — never a table or
+/// project id, which belong on the accompanying warn's span attributes).
 pub fn record_commit_timeout(op: &'static str) {
     if let Some(m) = METRICS.get() {
         m.commit_lock_timeouts.add(1, &[KeyValue::new("op", op)]);
@@ -934,7 +934,7 @@ macro_rules! atomic_stats {
                 vec![$((
                     $component,
                     atomic_stats!(@key $field $(, $key)?),
-                    self.$field.load(std::sync::atomic::Ordering::Relaxed),
+                    self.$field.load(Relaxed),
                 ),)+]
             }
         }
@@ -1006,8 +1006,6 @@ atomic_stats! {
         /// single metadata walk found work for; `completed` counts bins that landed.
         /// ALERT when completed lags planned for N consecutive ticks — that's the
         /// "8 of 11 hot projects never reached" shape (prod 2026-07-29).
-        // planned vs completed is the per-tick coverage check: a persistent
-        // gap means hot projects are going uncompacted (prod 2026-07-29).
         light_optimize_projects_planned as "light_optimize_projects_planned_total",
         light_optimize_projects_completed as "light_optimize_projects_completed_total",
         light_optimize_bins_committed as "light_optimize_bins_committed_total",
@@ -1249,9 +1247,8 @@ atomic_stats! {
         /// `TAG_SOURCE_ROWS` existed. Every read refuses them `stale_coverage` and no
         /// rule can ever rescue them, so this is the size of the backlog that has to
         /// republish before wide dashboards route. Set from the whole recovery pass,
-        /// hourly, so it reads 0 only when there genuinely are none.
-        // The republish backlog that gates wide-window routing. Watch it fall;
-        // `rollup_stale_no_witness` per query falls with it.
+        /// hourly, so it reads 0 only when there genuinely are none. Watch it
+        /// fall; `rollup_stale_no_witness` per query falls with it.
         rollup_witnessless_slices,
         /// Contiguous sealed days of rollup coverage, counting back from yesterday,
         /// minimised over every (project, declared tier).
@@ -1477,20 +1474,16 @@ atomic_stats! {
         /// row-preserving by construction, so this must be ZERO forever; nonzero
         /// means a truncated staging that would have DROPPED rows, or a broken
         /// assumption. PAGE if > 0.
-        // MUST stay 0 — nonzero = a staged repair whose rows didn't add up.
         repair_resume_row_mismatch as "repair_resume_row_mismatch_total",
         /// Cron ticks skipped because the previous run of the same job was still
         /// in flight. A steadily growing value = a wedged/overlong job body.
         cron_ticks_skipped,
         /// Cron fires actually dispatched (all jobs). Frozen while uptime grows =
         /// the scheduler is dead (2026-07-14 outage signature).
-        // Fired frozen while uptime grows = scheduler dead (2026-07-14
-        // outage); skipped growing = a job body is wedged or overlong.
         cron_ticks_fired,
         /// Cron runs that exceeded the long-running warning threshold. Slow but
-        /// progressing work is allowed to finish; this is for observability.
-        // Runs exceeding the long-running warning threshold. Slow progress
-        // is allowed; sustained nonzero with no completion = wedged.
+        /// progressing work is allowed to finish; sustained nonzero with no
+        /// completion = wedged.
         cron_long_running as "cron_long_running_total",
         /// Ingest-time client-retry dedup: rows DROPPED because their exact
         /// client-visible content was provably already committed
@@ -1898,27 +1891,18 @@ mod imp {
     /// (2026-08-03, twice). Boot moves the newest few into `prekill-<pid-seq>/`;
     /// only the 3 newest archives are kept.
     fn archive_prekill_dumps(dir: &std::path::Path) {
-        let mut dumps: Vec<(std::time::SystemTime, PathBuf)> = std::fs::read_dir(dir)
-            .into_iter()
-            .flatten()
-            .flatten()
-            .filter(|e| e.file_name().to_str().is_some_and(|n| n.starts_with("jeprof") && n.ends_with(".heap")))
-            .filter_map(|e| Some((e.metadata().ok()?.modified().ok()?, e.path())))
-            .collect();
-        if dumps.is_empty() {
-            return;
-        }
-        dumps.sort_unstable_by_key(|(mtime, _)| std::cmp::Reverse(*mtime));
-        let stamp = dumps[0].0.duration_since(std::time::UNIX_EPOCH).map_or(0, |d| d.as_secs());
+        let dumps = newest_first(dir, |n| n.starts_with("jeprof") && n.ends_with(".heap"));
+        let Some((newest, _)) = dumps.first() else { return };
+        let stamp = newest.duration_since(std::time::UNIX_EPOCH).map_or(0, |d| d.as_secs());
         let arch = dir.join(format!("prekill-{stamp}"));
         if std::fs::create_dir_all(&arch).is_err() {
             return;
         }
-        for (_, p) in dumps.iter().take(5) {
+        dumps.iter().take(5).for_each(|(_, p)| {
             if let Some(name) = p.file_name() {
                 let _ = std::fs::rename(p, arch.join(name));
             }
-        }
+        });
         // The rest of the dead process's dumps are noise — drop them now so the
         // rolling pruner starts clean for this process.
         dumps.into_iter().skip(5).for_each(|(_, old)| {
@@ -1931,9 +1915,8 @@ mod imp {
             .filter(|e| e.file_name().to_str().is_some_and(|n| n.starts_with("prekill-")))
             .map(|e| e.path())
             .collect();
-        archives.sort();
-        let n = archives.len();
-        archives.into_iter().take(n.saturating_sub(3)).for_each(|old| {
+        archives.sort(); // `prekill-<unix secs>` sorts oldest-first by name
+        archives.into_iter().rev().skip(3).for_each(|old| {
             let _ = std::fs::remove_dir_all(&old);
         });
         info!("profiling: archived previous process's final heap dumps → {arch:?}");
@@ -1952,17 +1935,22 @@ mod imp {
     /// is monotonic across restarts, so newest-by-mtime always keeps the live
     /// process's files and evicts the stale ones.
     fn prune_old(dir: &std::path::Path, prefix: &str, keep: usize) {
-        let mut files: Vec<(std::time::SystemTime, PathBuf)> = std::fs::read_dir(dir)
+        newest_first(dir, |n| n.starts_with(prefix)).into_iter().skip(keep).for_each(|(_, old)| {
+            let _ = std::fs::remove_file(old);
+        });
+    }
+
+    /// `(mtime, path)` for every file in `dir` whose name satisfies `matches`, newest first.
+    fn newest_first(dir: &std::path::Path, matches: impl Fn(&str) -> bool) -> Vec<(std::time::SystemTime, PathBuf)> {
+        let mut files: Vec<_> = std::fs::read_dir(dir)
             .into_iter()
             .flatten()
             .flatten()
-            .filter(|e| e.file_name().to_str().is_some_and(|n| n.starts_with(prefix)))
+            .filter(|e| e.file_name().to_str().is_some_and(&matches))
             .filter_map(|e| Some((e.metadata().ok()?.modified().ok()?, e.path())))
             .collect();
-        files.sort_unstable_by_key(|(mtime, _)| std::cmp::Reverse(*mtime)); // newest first; `mut`: std sorts in place
-        files.into_iter().skip(keep).for_each(|(_, old)| {
-            let _ = std::fs::remove_file(old);
-        });
+        files.sort_unstable_by_key(|(mtime, _)| std::cmp::Reverse(*mtime)); // `mut`: std sorts in place
+        files
     }
 }
 

--- a/src/read/bloom_prune.rs
+++ b/src/read/bloom_prune.rs
@@ -40,13 +40,13 @@ use tracing::{debug, warn};
 
 /// IN-lists above this skip pruning — probing the registry per value must
 /// stay negligible next to the planning it saves.
-pub const MAX_NEEDLE_VALUES: usize = 64;
+pub(crate) const MAX_NEEDLE_VALUES: usize = 64;
 /// A file whose bloom payload exceeds this is recorded `no_bloom`: a bloom
 /// this dense prunes little and would bloat the blob (whale-file guard).
-pub const PER_FILE_BLOOM_CAP_BYTES: u64 = 4 * 1024 * 1024;
+pub(crate) const PER_FILE_BLOOM_CAP_BYTES: u64 = 4 * 1024 * 1024;
 /// Windows wider than this skip pruning — the per-date probe cost scales
 /// with the window while its value concentrates in point lookups.
-pub const MAX_PRUNE_DATES: usize = 92;
+pub(crate) const MAX_PRUNE_DATES: usize = 92;
 const SIDECAR_VERSION: u8 = 1;
 const BINCODE_CONFIG: bincode::config::Configuration = bincode::config::standard();
 

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -47,7 +47,7 @@ use datafusion::{
 };
 use futures::StreamExt;
 
-use crate::observability::arrow_err;
+use crate::{database::scan_metric_names, observability::arrow_err};
 
 /// Encoded Arrow keys, allocated only on first sight.
 type SeenSet = HashSet<Box<[u8]>, ahash::RandomState>;
@@ -202,7 +202,7 @@ pub(crate) fn skippable_certified_files<'a>(certified: impl IntoIterator<Item = 
     // One uncertified file without statistics has an unknown span, which
     // overlaps everything, so nothing in the scan can skip.
     if uncertified.iter().any(Option::is_none) {
-        metrics::counter!(crate::database::scan_metric_names::CERT_SKIP_BLOCKED_NO_STATS).increment(1);
+        metrics::counter!(scan_metric_names::CERT_SKIP_BLOCKED_NO_STATS).increment(1);
         return HashSet::new();
     }
     let (skippable, blocked): (Vec<_>, Vec<_>) =
@@ -211,8 +211,8 @@ pub(crate) fn skippable_certified_files<'a>(certified: impl IntoIterator<Item = 
     // certification is too SPARSE (a certified file still has an uncertified
     // neighbour, so contiguous runs are what pay), while the no-stats return
     // above says one file poisoned the whole scan regardless of coverage.
-    metrics::counter!(crate::database::scan_metric_names::CERT_SKIP_BLOCKED_OVERLAP).increment(blocked.len() as u64);
-    metrics::counter!(crate::database::scan_metric_names::CERT_SKIP_FILES).increment(skippable.len() as u64);
+    metrics::counter!(scan_metric_names::CERT_SKIP_BLOCKED_OVERLAP).increment(blocked.len() as u64);
+    metrics::counter!(scan_metric_names::CERT_SKIP_FILES).increment(skippable.len() as u64);
     skippable.into_iter().map(|(path, _)| path).collect()
 }
 
@@ -571,8 +571,8 @@ impl ExecutionPlan for DedupExec {
         // no footer `sorting_columns` and ONE unordered branch erases the ordering
         // the whole leg declares.
         metrics::counter!(match bound {
-            Some(_) => crate::database::scan_metric_names::DEDUP_BOUNDED_TOTAL,
-            None => crate::database::scan_metric_names::DEDUP_FULL_SET_TOTAL,
+            Some(_) => scan_metric_names::DEDUP_BOUNDED_TOTAL,
+            None => scan_metric_names::DEDUP_FULL_SET_TOTAL,
         })
         .increment(1);
         let key_idxs = dedup_key_idxs(&self.key_idxs);
@@ -941,8 +941,8 @@ impl Greatest {
             std::cmp::Ordering::Equal => {}
         }
         self.bytes = kept_bytes;
-        metrics::counter!(crate::database::scan_metric_names::DEDUP_WINNER_COMPACTIONS_TOTAL).increment(1);
-        metrics::counter!(crate::database::scan_metric_names::DEDUP_WINNER_COMPACTION_ROWS_DROPPED).increment(dropped as u64);
+        metrics::counter!(scan_metric_names::DEDUP_WINNER_COMPACTIONS_TOTAL).increment(1);
+        metrics::counter!(scan_metric_names::DEDUP_WINNER_COMPACTION_ROWS_DROPPED).increment(dropped as u64);
         Ok(())
     }
 
@@ -2668,12 +2668,7 @@ impl LogicalCountCache {
         // path; if their 64-bit file-set fingerprints happened to match, one
         // tenant could consume the other's exact-count index. Hex is injective
         // over UTF-8 bytes and contains no path separators.
-        use std::fmt::Write;
-        let mut encoded = String::with_capacity(value.len() * 2);
-        for byte in value.bytes() {
-            write!(encoded, "{byte:02x}").expect("writing to String cannot fail");
-        }
-        encoded
+        hex::encode(value)
     }
 
     fn path(&self, key: &CountPartition) -> PathBuf {

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -9,6 +9,7 @@ use deltalake::{
     kernel::{ArrayType, DataType as DeltaDataType, PrimitiveType, StructField},
 };
 use include_dir::{Dir, include_dir};
+use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
 /// One continuous-aggregate rollup, declared on the SOURCE table.
@@ -119,27 +120,23 @@ impl RollupSpec {
 
     fn validate(&self, source: &TableSchema) -> anyhow::Result<()> {
         const IDENTITY_FIELDS: [&str; 7] = ["project_id", "timestamp", "date", "id", "updated_at", "deleted", "rollup_generation"];
+        let target = self.table_name(&source.table_name);
         let field = |name: &str| source.fields.iter().find(|f| f.name == name);
         let is_ident = |name: &str| {
             let mut chars = name.chars();
             matches!(chars.next(), Some('a'..='z' | 'A'..='Z' | '_')) && chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
         };
 
-        anyhow::ensure!(self.grain_micros().is_some(), "rollup {}: invalid grain `{}`", self.table_name(&source.table_name), self.grain);
-        anyhow::ensure!(self.name.as_deref().is_none_or(is_ident), "rollup {}: name must be an SQL identifier", self.table_name(&source.table_name));
+        anyhow::ensure!(self.grain_micros().is_some(), "rollup {target}: invalid grain `{}`", self.grain);
+        anyhow::ensure!(self.name.as_deref().is_none_or(is_ident), "rollup {target}: name must be an SQL identifier");
         let mut names = HashSet::new();
         for dimension in &self.dimensions {
-            anyhow::ensure!(field(dimension).is_some(), "rollup {}: unknown dimension `{dimension}`", self.table_name(&source.table_name));
-            anyhow::ensure!(names.insert(dimension), "rollup {}: duplicate dimension `{dimension}`", self.table_name(&source.table_name));
-            anyhow::ensure!(
-                !IDENTITY_FIELDS.contains(&dimension.as_str()),
-                "rollup {}: dimension `{dimension}` collides with an identity field",
-                self.table_name(&source.table_name)
-            );
+            anyhow::ensure!(field(dimension).is_some(), "rollup {target}: unknown dimension `{dimension}`");
+            anyhow::ensure!(names.insert(dimension), "rollup {target}: duplicate dimension `{dimension}`");
+            anyhow::ensure!(!IDENTITY_FIELDS.contains(&dimension.as_str()), "rollup {target}: dimension `{dimension}` collides with an identity field");
         }
-        anyhow::ensure!(!self.measures.is_empty(), "rollup {}: needs at least one measure", self.table_name(&source.table_name));
+        anyhow::ensure!(!self.measures.is_empty(), "rollup {target}: needs at least one measure");
         if let Some(base) = &self.derive_from {
-            let target = self.table_name(&source.table_name);
             let base_spec = source
                 .rollups
                 .iter()
@@ -180,48 +177,35 @@ impl RollupSpec {
             }
         }
         for measure in &self.measures {
-            anyhow::ensure!(is_ident(&measure.name), "rollup {}: measure `{}` must be an SQL identifier", self.table_name(&source.table_name), measure.name);
-            anyhow::ensure!(names.insert(&measure.name), "rollup {}: duplicate or colliding measure `{}`", self.table_name(&source.table_name), measure.name);
+            let (name, agg) = (&measure.name, &measure.agg);
+            anyhow::ensure!(is_ident(name), "rollup {target}: measure `{name}` must be an SQL identifier");
+            anyhow::ensure!(names.insert(name), "rollup {target}: duplicate or colliding measure `{name}`");
             anyhow::ensure!(
-                matches!(measure.agg.as_str(), "count" | "sum" | "min" | "max" | "tdigest" | "hll" | "first"),
-                "rollup {}: unsupported aggregate `{}`",
-                self.table_name(&source.table_name),
-                measure.agg
+                matches!(agg.as_str(), "count" | "sum" | "min" | "max" | "tdigest" | "hll" | "first"),
+                "rollup {target}: unsupported aggregate `{agg}`"
             );
             // Refused at load rather than building a tier whose coarse buckets
             // are wrong — see `first_companion` for why the pair is needed.
             anyhow::ensure!(
-                measure.agg != "first" || self.first_companion(measure).is_some(),
-                "rollup {}: `first` measure `{}` needs a companion `{{agg: min, column: timestamp}}` measure carrying the same filter",
-                self.table_name(&source.table_name),
-                measure.name
+                agg != "first" || self.first_companion(measure).is_some(),
+                "rollup {target}: `first` measure `{name}` needs a companion `{{agg: min, column: timestamp}}` measure carrying the same filter"
             );
-            match (&measure.agg[..], measure.column.as_deref()) {
+            match (agg.as_str(), measure.column.as_deref()) {
                 ("count", None) => {}
-                ("count", Some(column)) | ("sum" | "min" | "max" | "hll" | "first", Some(column)) => {
-                    anyhow::ensure!(field(column).is_some(), "rollup {}: unknown column `{column}`", self.table_name(&source.table_name));
+                ("count" | "sum" | "min" | "max" | "hll" | "first", Some(column)) => {
+                    anyhow::ensure!(field(column).is_some(), "rollup {target}: unknown column `{column}`")
                 }
                 ("tdigest", Some(column)) => {
-                    let Some(data_type) = field(column).map(|f| f.data_type.as_str()) else {
-                        anyhow::bail!("rollup {}: unknown column `{column}`", self.table_name(&source.table_name))
-                    };
+                    let Some(data_type) = field(column).map(|f| f.data_type.as_str()) else { anyhow::bail!("rollup {target}: unknown column `{column}`") };
                     anyhow::ensure!(
                         matches!(data_type, "Int32" | "Int64" | "UInt32" | "UInt64" | "Float64"),
-                        "rollup {}: tdigest column `{column}` must be numeric",
-                        self.table_name(&source.table_name)
+                        "rollup {target}: tdigest column `{column}` must be numeric"
                     );
                 }
-                (_, None) => {
-                    anyhow::bail!("rollup {}: `{}` measure `{}` needs a source column", self.table_name(&source.table_name), measure.agg, measure.name)
-                }
-                (aggregate, Some(_)) => anyhow::bail!("rollup {}: unsupported aggregate `{aggregate}`", self.table_name(&source.table_name)),
+                (_, None) => anyhow::bail!("rollup {target}: `{agg}` measure `{name}` needs a source column"),
+                (aggregate, Some(_)) => anyhow::bail!("rollup {target}: unsupported aggregate `{aggregate}`"),
             }
-            anyhow::ensure!(
-                measure.filter.as_deref().is_none_or(|f| !f.trim().is_empty()),
-                "rollup {}: measure `{}` has an empty filter",
-                self.table_name(&source.table_name),
-                measure.name
-            );
+            anyhow::ensure!(measure.filter.as_deref().is_none_or(|f| !f.trim().is_empty()), "rollup {target}: measure `{name}` has an empty filter");
         }
         Ok(())
     }
@@ -249,32 +233,32 @@ impl RollupSpec {
             // A tier is rebuilt wholesale, never UPDATEd.
             mutable: false,
         };
-        let mut fields = vec![
-            plain("project_id", "Utf8", true),
-            plain("timestamp", "Timestamp(Microsecond, Some(\"UTC\"))", false),
-            plain("date", "Date32", false),
-            plain("id", "Utf8", false),
-            plain("updated_at", "Timestamp(Microsecond, Some(\"UTC\"))", false),
-            plain("deleted", "Boolean", true),
-            plain("rollup_generation", "Utf8", false),
-        ];
-        for d in &self.dimensions {
-            let f = src_field(d)?;
-            // Always nullable in the rollup: GROUP BY emits a NULL group for
-            // rows missing the dimension, even when the source column is not.
-            //
-            // `tantivy: None` explicitly, against the struct update: `kind` and
-            // `status_code` are tantivy-indexed on the source, so inheriting the
-            // config put every rollup tier into `indexed_set()` — 52% of the
-            // indexed file population — and turned a dimension equality into a
-            // `text_match` the prefilter then serves. Measured on prod
-            // 2026-08-24, same rows, 5 reps: `kind = 'server'` over a 2-day
-            // rollup window took 8.2-10.9s against 0.28-1.8s for an opaque
-            // control, and a routed 7d dashboard went 7.2s -> 14.5s when a
-            // dimension filter was added. The index is read, used, and a loss.
-            fields.push(FieldDef { nullable: true, tantivy: None, ..f });
-        }
-        for m in &self.measures {
+        let fields = [
+            ("project_id", "Utf8", true),
+            ("timestamp", "Timestamp(Microsecond, Some(\"UTC\"))", false),
+            ("date", "Date32", false),
+            ("id", "Utf8", false),
+            ("updated_at", "Timestamp(Microsecond, Some(\"UTC\"))", false),
+            ("deleted", "Boolean", true),
+            ("rollup_generation", "Utf8", false),
+        ]
+        .into_iter()
+        .map(|(name, data_type, nullable)| Ok(plain(name, data_type, nullable)))
+        // Dimensions are always nullable in the rollup: GROUP BY emits a NULL
+        // group for rows missing the dimension, even when the source column is
+        // not.
+        //
+        // `tantivy: None` explicitly, against the struct update: `kind` and
+        // `status_code` are tantivy-indexed on the source, so inheriting the
+        // config put every rollup tier into `indexed_set()` — 52% of the
+        // indexed file population — and turned a dimension equality into a
+        // `text_match` the prefilter then serves. Measured on prod 2026-08-24,
+        // same rows, 5 reps: `kind = 'server'` over a 2-day rollup window took
+        // 8.2-10.9s against 0.28-1.8s for an opaque control, and a routed 7d
+        // dashboard went 7.2s -> 14.5s when a dimension filter was added. The
+        // index is read, used, and a loss.
+        .chain(self.dimensions.iter().map(|d| Ok(FieldDef { nullable: true, tantivy: None, ..src_field(d)? })))
+        .chain(self.measures.iter().map(|m| {
             let ty = match (m.agg.as_str(), &m.column) {
                 ("count", _) => "Int64".to_string(),
                 // `src_field` for its error, not its type: a sketch column is
@@ -286,8 +270,9 @@ impl RollupSpec {
                 (a, None) => anyhow::bail!("rollup {}: `{a}` measure `{}` needs a source column", self.table_name(&source.table_name), m.name),
             };
             // A measure over an empty group is NULL, and count is never NULL.
-            fields.push(plain(&m.name, &ty, m.agg != "count"));
-        }
+            Ok(plain(&m.name, &ty, m.agg != "count"))
+        }))
+        .collect::<anyhow::Result<Vec<_>>>()?;
         Ok(TableSchema {
             table_name: self.table_name(&source.table_name),
             // Same partitioning as the source, so ProjectRoutingTable gives
@@ -484,12 +469,11 @@ impl TableSchema {
                 .find(|f| f.name == name)
                 .ok_or_else(|| anyhow::anyhow!("schema `{}`: {role} references unknown field `{}`", self.table_name, name))
         };
-        self.dedup_keys.iter().map(|k| ("dedup_keys", k)).chain(self.dedup_tiebreak.iter().map(|tb| ("dedup_tiebreak", tb))).try_for_each(
-            |(role, name)| -> anyhow::Result<()> {
-                anyhow::ensure!(field(role, name)?.data_type != "Variant", "schema `{}`: {role} cannot be a Variant column `{}`", self.table_name, name);
-                Ok(())
-            },
-        )?;
+        // A `for` with `?`: each item both fails fast and needs the `?` on
+        // `field(..)` inside the check itself.
+        for (role, name) in self.dedup_keys.iter().map(|k| ("dedup_keys", k)).chain(self.dedup_tiebreak.iter().map(|tb| ("dedup_tiebreak", tb))) {
+            anyhow::ensure!(field(role, name)?.data_type != "Variant", "schema `{}`: {role} cannot be a Variant column `{}`", self.table_name, name);
+        }
         if let Some(tc) = &self.tombstone_column {
             let f = field("tombstone_column", tc)?;
             // Nullable Boolean is load-bearing: NULL must be a legal "live"
@@ -502,6 +486,90 @@ impl TableSchema {
             self.table_name
         );
         Ok(())
+    }
+
+    pub fn fields(&self) -> anyhow::Result<Vec<FieldRef>> {
+        self.fields
+            .iter()
+            .map(|f| {
+                let field = Field::new(&f.name, parse_arrow_data_type(&f.data_type)?, f.nullable);
+                // Without the ExtensionType marker fresh tables (variant_bench)
+                // crash on the first INSERT — see `VARIANT_EXT_KEY`.
+                Ok(Arc::new(match f.data_type.as_str() {
+                    "Variant" => field.with_metadata(HashMap::from([(VARIANT_EXT_KEY.to_string(), VARIANT_EXT_VALUE.to_string())])),
+                    _ => field,
+                }) as FieldRef)
+            })
+            .collect()
+    }
+
+    pub fn columns(&self) -> anyhow::Result<Vec<StructField>> {
+        self.fields.iter().map(|f| Ok(StructField::new(&f.name, parse_delta_data_type(&f.data_type)?, f.nullable))).collect()
+    }
+
+    pub fn schema_ref(&self) -> SchemaRef {
+        // Partition columns move to the end to match Delta Lake's output order,
+        // order preserved within each group.
+        let all_fields = self.fields().unwrap_or_else(|e| panic!("Failed to build schema for table {}: {e:?}", self.table_name));
+        let partition_set = self.partition_set();
+        let (partition_fields, data_fields): (Vec<_>, Vec<_>) = all_fields.into_iter().partition(|f| partition_set.contains(f.name().as_str()));
+        Arc::new(Schema::new(data_fields.into_iter().chain(partition_fields).collect::<Vec<_>>()))
+    }
+
+    fn partition_set(&self) -> HashSet<&str> {
+        self.partitions.iter().map(String::as_str).collect()
+    }
+
+    pub fn sorting_columns(&self) -> Vec<SortingColumn> {
+        // Parquet data files omit partition columns (they live in the path), so
+        // the `SortingColumn.column_idx` the footer records must be the column's
+        // position among the *non-partition* fields — the physical parquet leaf
+        // order the reader (`ordering_from_parquet_metadata`) indexes into. Using
+        // the raw fields-list index over-counts by every partition column that
+        // precedes a sort key (e.g. `date` at field 0), so the footer points at
+        // the wrong column and the sort-order pushdown silently never fires.
+        // ...and a LEAF is not a FIELD. A Variant/struct column occupies as many
+        // parquet leaves as it has children, so counting fields under-shoots for
+        // every sort key that follows one. On a real prod file (97 leaves, 90
+        // fields) `resource___service___name` was recorded as leaf 76 — which is
+        // `attributes___user___email`. The reader then cannot find that name in
+        // the scan's schema, drops the entry, and the file advertises
+        // `[timestamp, id, level, status_code]`: an ordering the data does not
+        // have (within one timestamp, ids do not ascend across services). It
+        // also blocks the `SortPreservingMerge` that would remove the dedup
+        // rewrite's last sort. `timestamp` was correct only because nothing
+        // nested precedes it.
+        fn leaves(data_type: &ArrowDataType) -> i32 {
+            use arrow::datatypes::DataType::*;
+            match data_type {
+                Struct(fields) => fields.iter().map(|f| leaves(f.data_type())).sum(),
+                List(f) | LargeList(f) | FixedSizeList(f, _) | ListView(f) | LargeListView(f) => leaves(f.data_type()),
+                Map(entries, _) => leaves(entries.data_type()),
+                RunEndEncoded(_, values) => leaves(values.data_type()),
+                _ => 1,
+            }
+        }
+        let partition_set = self.partition_set();
+        let Ok(fields) = self.fields() else { return Vec::new() };
+        // Filter BEFORE the scan: partition columns live in the path, so they
+        // must not advance the leaf counter.
+        let leaf_of: HashMap<&str, i32> = self
+            .fields
+            .iter()
+            .zip(&fields)
+            .filter(|(d, _)| !partition_set.contains(d.name.as_str()))
+            .scan(0i32, |next, (declared, field)| {
+                let idx = *next;
+                *next += leaves(field.data_type());
+                Some((declared.name.as_str(), idx))
+            })
+            .collect();
+        self.sorting_columns
+            .iter()
+            .filter_map(|col| {
+                leaf_of.get(col.name.as_str()).map(|&column_idx| SortingColumn { column_idx, descending: col.descending, nulls_first: col.nulls_first })
+            })
+            .collect()
     }
 }
 
@@ -587,88 +655,6 @@ pub enum TantivyListMode {
     Elements,
 }
 
-impl TableSchema {
-    pub fn fields(&self) -> anyhow::Result<Vec<FieldRef>> {
-        self.fields
-            .iter()
-            .map(|f| {
-                let field = Field::new(&f.name, parse_arrow_data_type(&f.data_type)?, f.nullable);
-                // Without the ExtensionType marker fresh tables (variant_bench)
-                // crash on the first INSERT — see `VARIANT_EXT_KEY`.
-                Ok(Arc::new(match f.data_type.as_str() {
-                    "Variant" => field.with_metadata(HashMap::from([(VARIANT_EXT_KEY.to_string(), VARIANT_EXT_VALUE.to_string())])),
-                    _ => field,
-                }) as FieldRef)
-            })
-            .collect()
-    }
-
-    pub fn columns(&self) -> anyhow::Result<Vec<StructField>> {
-        self.fields.iter().map(|f| Ok(StructField::new(&f.name, parse_delta_data_type(&f.data_type)?, f.nullable))).collect()
-    }
-
-    pub fn schema_ref(&self) -> SchemaRef {
-        // Partition columns move to the end to match Delta Lake's output order,
-        // order preserved within each group.
-        let all_fields = self.fields().unwrap_or_else(|e| panic!("Failed to build schema for table {}: {e:?}", self.table_name));
-        let partition_set = self.partition_set();
-        let (partition_fields, data_fields): (Vec<_>, Vec<_>) = all_fields.into_iter().partition(|f| partition_set.contains(f.name().as_str()));
-        Arc::new(Schema::new(data_fields.into_iter().chain(partition_fields).collect::<Vec<_>>()))
-    }
-
-    fn partition_set(&self) -> HashSet<&str> {
-        self.partitions.iter().map(String::as_str).collect()
-    }
-
-    pub fn sorting_columns(&self) -> Vec<SortingColumn> {
-        // Parquet data files omit partition columns (they live in the path), so
-        // the `SortingColumn.column_idx` the footer records must be the column's
-        // position among the *non-partition* fields — the physical parquet leaf
-        // order the reader (`ordering_from_parquet_metadata`) indexes into. Using
-        // the raw fields-list index over-counts by every partition column that
-        // precedes a sort key (e.g. `date` at field 0), so the footer points at
-        // the wrong column and the sort-order pushdown silently never fires.
-        // ...and a LEAF is not a FIELD. A Variant/struct column occupies as many
-        // parquet leaves as it has children, so counting fields under-shoots for
-        // every sort key that follows one. On a real prod file (97 leaves, 90
-        // fields) `resource___service___name` was recorded as leaf 76 — which is
-        // `attributes___user___email`. The reader then cannot find that name in
-        // the scan's schema, drops the entry, and the file advertises
-        // `[timestamp, id, level, status_code]`: an ordering the data does not
-        // have (within one timestamp, ids do not ascend across services). It
-        // also blocks the `SortPreservingMerge` that would remove the dedup
-        // rewrite's last sort. `timestamp` was correct only because nothing
-        // nested precedes it.
-        let partition_set = self.partition_set();
-        let leaves = |data_type: &arrow_schema::DataType| -> usize {
-            fn count(data_type: &arrow_schema::DataType) -> usize {
-                use arrow_schema::DataType::*;
-                match data_type {
-                    Struct(fields) => fields.iter().map(|f| count(f.data_type())).sum(),
-                    List(f) | LargeList(f) | FixedSizeList(f, _) | ListView(f) | LargeListView(f) => count(f.data_type()),
-                    Map(entries, _) => count(entries.data_type()),
-                    RunEndEncoded(_, values) => count(values.data_type()),
-                    _ => 1,
-                }
-            }
-            count(data_type)
-        };
-        let Ok(fields) = self.fields() else { return Vec::new() };
-        let mut leaf_of: HashMap<&str, i32> = HashMap::new();
-        let mut next = 0usize;
-        for (declared, field) in self.fields.iter().zip(&fields).filter(|(d, _)| !partition_set.contains(d.name.as_str())) {
-            leaf_of.insert(declared.name.as_str(), next as i32);
-            next += leaves(field.data_type());
-        }
-        self.sorting_columns
-            .iter()
-            .filter_map(|col| {
-                leaf_of.get(col.name.as_str()).map(|idx| SortingColumn { column_idx: *idx, descending: col.descending, nulls_first: col.nulls_first })
-            })
-            .collect()
-    }
-}
-
 fn parse_arrow_data_type(s: &str) -> anyhow::Result<ArrowDataType> {
     Ok(match s {
         // Use Utf8View for better performance with zero-copy string operations
@@ -740,8 +726,8 @@ impl SchemaRegistry {
             .files()
             .filter(|f| f.path().extension().and_then(|s| s.to_str()) == Some("yaml"))
             .map(|file| {
-                let content = file.contents_utf8().expect("Schema file should be UTF-8");
-                let schema: TableSchema = serde_yaml::from_str(content).unwrap_or_else(|e| panic!("Failed to parse schema {:?}: {}", file.path(), e));
+                let schema: TableSchema = serde_yaml::from_str(file.contents_utf8().expect("Schema file should be UTF-8"))
+                    .unwrap_or_else(|e| panic!("Failed to parse schema {:?}: {}", file.path(), e));
                 schema.validate().unwrap_or_else(|e| panic!("Invalid schema {:?}: {}", file.path(), e));
                 schema.rollups.iter().try_for_each(|rollup| rollup.validate(&schema)).unwrap_or_else(|e| panic!("Invalid rollup on {:?}: {}", file.path(), e));
                 (schema.table_name.clone(), schema)
@@ -754,23 +740,22 @@ impl SchemaRegistry {
         // is depends on whether they group the same way — so say so, rather
         // than making the operator infer it from a name collision.
         for src in schemas.values() {
-            for (i, a) in src.rollups.iter().enumerate() {
-                if let Some(b) = src.rollups[i + 1..].iter().find(|b| b.table_name(&src.table_name) == a.table_name(&src.table_name)) {
-                    let name = a.table_name(&src.table_name);
-                    assert!(
-                        a.dimensions != b.dimensions,
-                        "{}: two rollups both generate `{name}` with the SAME dimensions. Same grain + same dimensions is the same GROUP BY, so \
-                         add the extra measures to the existing rollup instead of declaring a second one — a second table would duplicate every \
-                         identity and dimension column and make a query wanting both measures read two tables.",
-                        src.table_name
-                    );
-                    panic!(
-                        "{}: two rollups both generate `{name}` but group differently ({:?} vs {:?}). Different dimensions ARE different tables; \
-                         give one of them a `name:` to distinguish it.",
-                        src.table_name, a.dimensions, b.dimensions
-                    );
-                }
-            }
+            let Some((a, b)) = src.rollups.iter().tuple_combinations().find(|(a, b)| a.table_name(&src.table_name) == b.table_name(&src.table_name)) else {
+                continue;
+            };
+            let name = a.table_name(&src.table_name);
+            assert!(
+                a.dimensions != b.dimensions,
+                "{}: two rollups both generate `{name}` with the SAME dimensions. Same grain + same dimensions is the same GROUP BY, so \
+                 add the extra measures to the existing rollup instead of declaring a second one — a second table would duplicate every \
+                 identity and dimension column and make a query wanting both measures read two tables.",
+                src.table_name
+            );
+            panic!(
+                "{}: two rollups both generate `{name}` but group differently ({:?} vs {:?}). Different dimensions ARE different tables; \
+                 give one of them a `name:` to distinguish it.",
+                src.table_name, a.dimensions, b.dimensions
+            );
         }
         let synthesized: Vec<TableSchema> = schemas
             .values()
@@ -782,13 +767,11 @@ impl SchemaRegistry {
             })
             .collect();
         for r in synthesized {
-            let name = r.table_name.clone();
-            if schemas.insert(name.clone(), r).is_some() {
-                // A hand-written file under a generated name would silently win
-                // or lose depending on iteration order. (Same-source rollup
-                // collisions are already reported above, with a better message.)
-                panic!("rollup table `{name}` collides with a hand-written schema file of the same name");
-            }
+            // A hand-written file under a generated name would silently win or
+            // lose depending on iteration order. (Same-source rollup collisions
+            // are already reported above, with a better message.)
+            assert!(!schemas.contains_key(&r.table_name), "rollup table `{}` collides with a hand-written schema file of the same name", r.table_name);
+            schemas.insert(r.table_name.clone(), r);
         }
         // Migration aliases remain queryable while v3/v2 slice generations
         // shadow-build and canary. They are read-only schema aliases: source
@@ -800,9 +783,8 @@ impl SchemaRegistry {
             ("otel_metrics_rollup_metrics_1m_v2", "otel_metrics_rollup_metrics_1m_v1"),
             ("otel_metrics_rollup_metrics_1h_v2", "otel_metrics_rollup_metrics_1h_v1"),
         ] {
-            if let Some(mut schema) = schemas.get(current).cloned() {
-                schema.table_name = legacy.to_owned();
-                schemas.entry(legacy.to_owned()).or_insert(schema);
+            if let Some(schema) = schemas.get(current).cloned() {
+                schemas.entry(legacy.to_owned()).or_insert(TableSchema { table_name: legacy.to_owned(), ..schema });
             }
         }
         Self { schemas }
@@ -893,21 +875,22 @@ pub fn create_insert_compatible_schema(schema: &SchemaRef) -> SchemaRef {
     // the tag, bare Variant columns surface text OID 25 and strict drivers
     // (hasql) reject the row (expected jsonb 3802). vendor/arrow-pg maps the
     // tag to OID 3802 + the 0x01 binary jsonb version byte.
-    let fields: Vec<FieldRef> = schema
-        .fields()
-        .iter()
-        .map(|f| {
-            if is_variant_type(f.data_type()) {
-                Arc::new(
-                    Field::new(f.name(), ArrowDataType::Utf8View, f.is_nullable())
-                        .with_metadata(HashMap::from([("tf.pg_type".to_string(), "jsonb".to_string())])),
-                )
-            } else {
-                f.clone()
-            }
-        })
-        .collect();
-    Arc::new(Schema::new(fields))
+    Arc::new(Schema::new(
+        schema
+            .fields()
+            .iter()
+            .map(|f| {
+                if is_variant_type(f.data_type()) {
+                    Arc::new(
+                        Field::new(f.name(), ArrowDataType::Utf8View, f.is_nullable())
+                            .with_metadata(HashMap::from([("tf.pg_type".to_string(), "jsonb".to_string())])),
+                    )
+                } else {
+                    f.clone()
+                }
+            })
+            .collect::<Vec<FieldRef>>(),
+    ))
 }
 
 #[cfg(test)]
@@ -919,6 +902,19 @@ mod tests {
 
     fn parse_schema(extra: &str, fields: &str) -> TableSchema {
         serde_yaml::from_str(&format!("{BASE_YAML}{extra}{fields}")).expect("yaml parses")
+    }
+
+    fn source() -> &'static TableSchema {
+        get_schema("otel_logs_and_spans").expect("source schema")
+    }
+
+    fn measure(name: &str, agg: &str, column: Option<&str>, filter: Option<&str>) -> RollupMeasure {
+        RollupMeasure { name: name.into(), agg: agg.into(), column: column.map(str::to_owned), filter: filter.map(str::to_owned) }
+    }
+
+    /// A 1m rollup over `kind` — the shape every spec test varies one part of.
+    fn spec(name: &str, measures: Vec<RollupMeasure>) -> RollupSpec {
+        RollupSpec { grain: "1m".into(), name: Some(name.into()), dimensions: vec!["kind".into()], measures, derive_from: None }
     }
 
     #[test]
@@ -939,16 +935,7 @@ mod tests {
 
     #[test]
     fn synthesized_rollup_stores_a_generation_and_tdigest() {
-        let source = get_schema("otel_logs_and_spans").expect("source schema");
-        let spec = RollupSpec {
-            grain: "1m".into(),
-            name: Some("digest_test".into()),
-            dimensions: vec!["kind".into()],
-            measures: vec![RollupMeasure { name: "digest".into(), agg: "tdigest".into(), column: Some("duration".into()), filter: None }],
-            derive_from: None,
-        };
-
-        let rollup = spec.synthesize(source).expect("valid rollup");
+        let rollup = spec("digest_test", vec![measure("digest", "tdigest", Some("duration"), None)]).synthesize(source()).expect("valid rollup");
         assert_eq!(rollup.field_def("rollup_generation"), Some((ArrowDataType::Utf8View, false)));
         assert_eq!(rollup.field_def("digest"), Some((ArrowDataType::Binary, true)));
         // `kind` is tantivy-indexed on the source and must NOT inherit it here:
@@ -963,40 +950,24 @@ mod tests {
     /// is refused at load rather than building a tier whose buckets are wrong.
     #[test]
     fn a_first_measure_is_refused_without_its_companion() {
-        let source = get_schema("otel_logs_and_spans").expect("source schema");
-        let landing = |filter: Option<&str>| RollupMeasure {
-            name: "landing_url".into(),
-            agg: "first".into(),
-            column: Some("attributes___url___path".into()),
-            filter: filter.map(str::to_owned),
-        };
-        let companion = |name: &str, filter: Option<&str>| RollupMeasure {
-            name: name.into(),
-            agg: "min".into(),
-            column: Some("timestamp".into()),
-            filter: filter.map(str::to_owned),
-        };
-        let spec = |measures: Vec<RollupMeasure>| RollupSpec {
-            grain: "1m".into(),
-            name: Some("first_test".into()),
-            dimensions: vec!["kind".into()],
-            measures,
-            derive_from: None,
-        };
+        let source = source();
+        let landing = |filter: Option<&str>| measure("landing_url", "first", Some("attributes___url___path"), filter);
+        let companion = |filter: Option<&str>| measure("at", "min", Some("timestamp"), filter);
+        let spec = |measures| spec("first_test", measures);
 
         assert!(spec(vec![landing(None)]).validate(source).is_err(), "a `first` measure alone must not validate");
-        assert!(spec(vec![landing(None), companion("at", None)]).validate(source).is_ok(), "the companion makes it valid");
+        assert!(spec(vec![landing(None), companion(None)]).validate(source).is_ok(), "the companion makes it valid");
 
         // "earliest row" and "earliest row MATCHING the filter" are different
         // rows, and it is the second one whose value was stored -- so a
         // companion carrying a different filter cannot order this measure.
         let filter = "attributes___url___path <> ''";
-        assert!(spec(vec![landing(Some(filter)), companion("at", None)]).validate(source).is_err(), "the companion's filter must match the measure's");
-        assert!(spec(vec![landing(Some(filter)), companion("at", Some(filter))]).validate(source).is_ok());
+        assert!(spec(vec![landing(Some(filter)), companion(None)]).validate(source).is_err(), "the companion's filter must match the measure's");
+        assert!(spec(vec![landing(Some(filter)), companion(Some(filter))]).validate(source).is_ok());
 
         // The stored value keeps the source column's own type -- it IS a value
         // from that column, not a sketch over it.
-        let rollup = spec(vec![landing(None), companion("at", None)]).synthesize(source).expect("valid rollup");
+        let rollup = spec(vec![landing(None), companion(None)]).synthesize(source).expect("valid rollup");
         assert_eq!(rollup.field_def("landing_url").map(|(ty, _)| ty), Some(ArrowDataType::Utf8View));
     }
 
@@ -1018,33 +989,18 @@ mod tests {
     /// name) are all strings.
     #[test]
     fn an_hll_measure_stores_a_sketch_over_any_column_type() {
-        let source = get_schema("otel_logs_and_spans").expect("source schema");
-        let spec = |column: &str| RollupSpec {
-            grain: "1m".into(),
-            name: Some("hll_test".into()),
-            dimensions: vec!["kind".into()],
-            measures: vec![RollupMeasure { name: "traces".into(), agg: "hll".into(), column: Some(column.into()), filter: None }],
-            derive_from: None,
-        };
+        let sketch = |column: &str| spec("hll_test", vec![measure("traces", "hll", Some(column), None)]);
         for column in ["context___trace_id", "duration"] {
-            let rollup = spec(column).synthesize(source).expect("valid rollup");
+            let rollup = sketch(column).synthesize(source()).expect("valid rollup");
             assert_eq!(rollup.field_def("traces"), Some((ArrowDataType::Binary, true)), "column {column}");
         }
-        assert!(spec("no_such_column").synthesize(source).is_err(), "an unknown column must still be rejected");
+        assert!(sketch("no_such_column").synthesize(source()).is_err(), "an unknown column must still be rejected");
     }
 
     #[test]
     fn invalid_rollup_aggregate_fails_validation() {
-        let source = get_schema("otel_logs_and_spans").expect("source schema");
-        let spec = RollupSpec {
-            grain: "1m".into(),
-            name: None,
-            dimensions: vec![],
-            measures: vec![RollupMeasure { name: "bad".into(), agg: "median".into(), column: Some("duration".into()), filter: None }],
-            derive_from: None,
-        };
-
-        assert!(spec.validate(source).unwrap_err().to_string().contains("unsupported aggregate"));
+        let bad = spec("bad_agg", vec![measure("bad", "median", Some("duration"), None)]);
+        assert!(bad.validate(source()).unwrap_err().to_string().contains("unsupported aggregate"));
     }
 
     /// The tombstone column must be nullable Boolean (NULL = live, so no

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -70,7 +70,7 @@ pub async fn bootstrap(cfg: Arc<AppConfig>) -> Result<Bootstrapped> {
     tracing::info!("bootstrap.phase=buffered_write_layer_init elapsed_ms={}", t_layer.elapsed().as_millis());
 
     // The sidecar requires both indexed tables and object storage.
-    let bucket = cfg.aws.aws_s3_bucket.clone().unwrap_or_default();
+    let bucket = cfg.aws.aws_s3_bucket.as_deref().unwrap_or_default();
     if !cfg.tantivy.indexed_tables().is_empty() && !bucket.is_empty() {
         let storage_uri = format!("s3://{}/{}/tantivy", bucket, cfg.core.timefusion_table_prefix);
         let obj_store = db.create_object_store(&storage_uri, &cfg.aws.build_storage_options(None)).await?;
@@ -180,7 +180,7 @@ use datafusion_postgres::{
     hooks::{QueryHook, cursor::CursorStatementHook, set_show::SetShowHook, transactions::TransactionStatementHook},
     pgwire::{
         api::{
-            ClientInfo, ClientPortalStore, ErrorHandler, PgWireServerHandlers,
+            ClientInfo, ClientPortalStore, ErrorHandler, PgWireServerHandlers, Type,
             auth::{AuthSource, LoginInfo, Password, StartupHandler, cleartext::CleartextPasswordAuthStartupHandler},
             portal::Portal,
             query::{ExtendedQueryHandler, SimpleQueryHandler},
@@ -319,9 +319,6 @@ impl LoggingHandlerFactory {
                 .build(),
         )
     }
-    pub fn plan_cache(&self) -> Arc<PlanCacheHook> {
-        self.plan_cache.clone()
-    }
 }
 
 /// pgwire calls these factory methods **per connection**, so their cost is
@@ -429,8 +426,7 @@ fn client_statement_timeout(client: &(impl ClientInfo + ?Sized)) -> Option<std::
 /// dropping a future cannot, so the deadline only covers read-only statements.
 /// `classify_query` errs toward matching DML, which errs toward no timeout.
 fn statement_timeout_applies(query: &str) -> bool {
-    let (kind, _) = classify_query(query);
-    !matches!(kind, "DML" | "DDL")
+    !matches!(classify_query(query).0, "DML" | "DDL")
 }
 
 async fn run_with_statement_timeout<T>(
@@ -476,10 +472,6 @@ fn with_response_deadline(response: Response, deadline: Option<tokio::time::Inst
         }
         response => response,
     }
-}
-
-fn with_response_deadlines(responses: Vec<Response>, deadline: Option<tokio::time::Instant>) -> Vec<Response> {
-    responses.into_iter().map(|response| with_response_deadline(response, deadline)).collect()
 }
 
 /// Simple query handler with tracing
@@ -573,45 +565,29 @@ impl LoggingSimpleQueryHandler {
     /// Read recent Delta commit metadata without requiring direct object-store
     /// credentials on the operator's machine.
     async fn run_delta_history(&self, cmd: DeltaHistoryCmd) -> PgWireResult<Vec<Response>> {
-        use datafusion_postgres::pgwire::api::Type;
-
         let db = require_available(self.db.as_ref(), "DELTA HISTORY")?;
         let table_ref = db.get_or_create_unified_table(&cmd.table).await.map_err(|e| admin_err(format!("DELTA HISTORY: open table '{}': {e}", cmd.table)))?;
         let table = table_ref.read().await;
         let commits: Vec<_> = table.history(Some(cmd.limit)).await.map_err(|e| admin_err(format!("DELTA HISTORY '{}': {e}", cmd.table)))?.collect();
         drop(table);
 
-        let fields = Arc::new(
-            ["version", "timestamp_utc", "operation", "read_version", "is_blind_append", "operation_parameters", "commit_info"]
-                .into_iter()
-                .map(|name| FieldInfo::new(name.to_string(), None, None, Type::VARCHAR, FieldFormat::Text))
-                .collect::<Vec<_>>(),
-        );
-        let rows = commits.into_iter().map({
-            let fields = fields.clone();
-            move |commit| {
-                let mut encoder = DataRowEncoder::new(fields.clone());
-                let timestamp = commit.timestamp.and_then(chrono::DateTime::from_timestamp_millis).map(|v| v.to_rfc3339()).unwrap_or_default();
-                let read_version = commit.read_version.map(|v| v.to_string()).unwrap_or_default();
-                let version = commit.read_version.map(|v| (v + 1).to_string()).unwrap_or_default();
-                let operation = commit.operation.clone().unwrap_or_default();
-                let blind_append = commit.is_blind_append.map(|v| v.to_string()).unwrap_or_default();
-                let parameters = serde_json::to_string(&commit.operation_parameters).unwrap_or_default();
-                let info = serde_json::to_string(&commit).unwrap_or_default();
-                for value in [&version, &timestamp, &operation, &read_version, &blind_append, &parameters, &info] {
-                    encoder.encode_field(value)?;
-                }
-                Ok(encoder.take_row())
-            }
+        let rows = commits.into_iter().map(|commit| {
+            let timestamp = commit.timestamp.and_then(chrono::DateTime::from_timestamp_millis).map(|v| v.to_rfc3339()).unwrap_or_default();
+            let read_version = commit.read_version.map(|v| v.to_string()).unwrap_or_default();
+            let version = commit.read_version.map(|v| (v + 1).to_string()).unwrap_or_default();
+            let blind_append = commit.is_blind_append.map(|v| v.to_string()).unwrap_or_default();
+            let parameters = serde_json::to_string(&commit.operation_parameters).unwrap_or_default();
+            let info = serde_json::to_string(&commit).unwrap_or_default();
+            // Last, so the field can be moved out rather than cloned.
+            let operation = commit.operation.unwrap_or_default();
+            Ok(vec![version, timestamp, operation, read_version, blind_append, parameters, info])
         });
-        Ok(vec![Response::Query(QueryResponse::new(fields, stream::iter(rows)))])
+        Ok(text_response(["version", "timestamp_utc", "operation", "read_version", "is_blind_append", "operation_parameters", "commit_info"], rows))
     }
 
     /// Return every raw action in one Delta commit. This is an audit primitive:
     /// it reads the transaction log only and never constructs a transaction.
-    async fn run_delta_actions(&self, cmd: DeltaActionsCmd) -> PgWireResult<Vec<Response>> {
-        use datafusion_postgres::pgwire::api::Type;
-
+    async fn run_delta_actions(&self, cmd: DeltaVersionCmd) -> PgWireResult<Vec<Response>> {
         let db = require_available(self.db.as_ref(), "DELTA ACTIONS")?;
         let table_ref = db.get_or_create_unified_table(&cmd.table).await.map_err(|e| admin_err(format!("DELTA ACTIONS: open table '{}': {e}", cmd.table)))?;
         let log_store = table_ref.read().await.log_store();
@@ -620,44 +596,22 @@ impl LoggingSimpleQueryHandler {
             .await
             .map_err(|e| admin_err(format!("DELTA ACTIONS '{}' VERSION {}: {e}", cmd.table, cmd.version)))?
             .ok_or_else(|| admin_err(format!("DELTA ACTIONS '{}' VERSION {}: commit not found", cmd.table, cmd.version)))?;
-        let actions = bytes
-            .split(|byte| *byte == b'\n')
-            .filter(|line| !line.is_empty())
-            .map(|line| serde_json::from_slice::<deltalake::kernel::Action>(line).map_err(|e| admin_err(format!("decode Delta action: {e}"))))
-            .collect::<PgWireResult<Vec<_>>>()?;
-
-        let fields = Arc::new(
-            ["version", "action", "path", "size_bytes", "action_json"]
-                .into_iter()
-                .map(|name| FieldInfo::new(name.to_string(), None, None, Type::VARCHAR, FieldFormat::Text))
-                .collect::<Vec<_>>(),
-        );
-        let rows = actions.into_iter().map({
-            let fields = fields.clone();
-            move |action| {
-                let (kind, path, size) = match &action {
-                    deltalake::kernel::Action::Add(add) => ("add", add.path.as_str(), add.size.to_string()),
-                    deltalake::kernel::Action::Remove(remove) => ("remove", remove.path.as_str(), remove.size.map(|v| v.to_string()).unwrap_or_default()),
-                    deltalake::kernel::Action::CommitInfo(_) => ("commitInfo", "", String::new()),
-                    _ => ("other", "", String::new()),
-                };
-                let version = cmd.version.to_string();
-                let json = serde_json::to_string(&action).map_err(|e| admin_err(format!("encode Delta action: {e}")))?;
-                let mut encoder = DataRowEncoder::new(fields.clone());
-                for value in [&version, kind, path, &size, &json] {
-                    encoder.encode_field(&value)?;
-                }
-                Ok(encoder.take_row())
-            }
+        let rows = decode_commit_actions(&bytes)?.into_iter().map(move |action| {
+            let (kind, path, size) = match &action {
+                deltalake::kernel::Action::Add(add) => ("add", add.path.as_str(), add.size.to_string()),
+                deltalake::kernel::Action::Remove(remove) => ("remove", remove.path.as_str(), remove.size.map(|v| v.to_string()).unwrap_or_default()),
+                deltalake::kernel::Action::CommitInfo(_) => ("commitInfo", "", String::new()),
+                _ => ("other", "", String::new()),
+            };
+            let json = serde_json::to_string(&action).map_err(|e| admin_err(format!("encode Delta action: {e}")))?;
+            Ok(vec![cmd.version.to_string(), kind.to_string(), path.to_string(), size, json])
         });
-        Ok(vec![Response::Query(QueryResponse::new(fields, stream::iter(rows)))])
+        Ok(text_response(["version", "action", "path", "size_bytes", "action_json"], rows))
     }
 
     /// Reconstruct the full pre-commit Add actions for files removed by
     /// `version`. This is read-only and fails unless every removal has a source.
-    async fn run_delta_recovery_audit(&self, cmd: DeltaRecoveryAuditCmd) -> PgWireResult<Vec<Response>> {
-        use datafusion_postgres::pgwire::api::Type;
-
+    async fn run_delta_recovery_audit(&self, cmd: DeltaVersionCmd) -> PgWireResult<Vec<Response>> {
         let db = require_available(self.db.as_ref(), "DELTA RECOVERY AUDIT")?;
         let table_ref =
             db.get_or_create_unified_table(&cmd.table).await.map_err(|e| admin_err(format!("DELTA RECOVERY AUDIT: open table '{}': {e}", cmd.table)))?;
@@ -668,11 +622,7 @@ impl LoggingSimpleQueryHandler {
             .await
             .map_err(|e| admin_err(format!("DELTA RECOVERY AUDIT '{}' VERSION {}: {e}", cmd.table, cmd.version)))?
             .ok_or_else(|| admin_err(format!("DELTA RECOVERY AUDIT '{}' VERSION {}: commit not found", cmd.table, cmd.version)))?;
-        let removed = bytes
-            .split(|byte| *byte == b'\n')
-            .filter(|line| !line.is_empty())
-            .map(|line| serde_json::from_slice::<deltalake::kernel::Action>(line).map_err(|e| admin_err(format!("decode Delta action: {e}"))))
-            .collect::<PgWireResult<Vec<_>>>()?
+        let removed = decode_commit_actions(&bytes)?
             .into_iter()
             .filter_map(|action| match action {
                 deltalake::kernel::Action::Remove(remove) => Some(remove.path),
@@ -710,26 +660,12 @@ impl LoggingSimpleQueryHandler {
         }
         sources.sort_unstable_by(|a, b| a.path.cmp(&b.path));
 
-        let fields = Arc::new(
-            ["removed_by_version", "path", "size_bytes", "source_add_json"]
-                .into_iter()
-                .map(|name| FieldInfo::new(name.to_string(), None, None, Type::VARCHAR, FieldFormat::Text))
-                .collect::<Vec<_>>(),
-        );
-        let rows = sources.into_iter().map({
-            let fields = fields.clone();
-            move |add| {
-                let version = cmd.version.to_string();
-                let size = add.size.to_string();
-                let json = serde_json::to_string(&deltalake::kernel::Action::Add(add.clone())).map_err(|e| admin_err(format!("encode source Add: {e}")))?;
-                let mut encoder = DataRowEncoder::new(fields.clone());
-                for value in [&version, &add.path, &size, &json] {
-                    encoder.encode_field(value)?;
-                }
-                Ok(encoder.take_row())
-            }
+        let rows = sources.into_iter().map(move |add| {
+            let size = add.size.to_string();
+            let json = serde_json::to_string(&deltalake::kernel::Action::Add(add.clone())).map_err(|e| admin_err(format!("encode source Add: {e}")))?;
+            Ok(vec![cmd.version.to_string(), add.path, size, json])
         });
-        Ok(vec![Response::Query(QueryResponse::new(fields, stream::iter(rows)))])
+        Ok(text_response(["removed_by_version", "path", "size_bytes", "source_add_json"], rows))
     }
 }
 
@@ -761,47 +697,38 @@ pub(crate) fn parse_delta_history(query: &str) -> Result<Option<DeltaHistoryCmd>
     Ok(Some(DeltaHistoryCmd { table: table.to_string(), limit }))
 }
 
+/// `<table> VERSION <n>`, shared by `DELTA ACTIONS` and `DELTA RECOVERY AUDIT`.
 #[derive(Debug, PartialEq, Eq)]
-pub(crate) struct DeltaActionsCmd {
+pub(crate) struct DeltaVersionCmd {
     pub table: String,
     pub version: u64,
 }
 
-pub(crate) fn parse_delta_actions(query: &str) -> Result<Option<DeltaActionsCmd>, String> {
+fn parse_delta_version_cmd(rest: &str, command: &str) -> Result<DeltaVersionCmd, String> {
+    let usage = || format!("expected: {command} <table> VERSION <n>");
+    let mut parts = rest.split_whitespace();
+    let (Some(table), Some(keyword), Some(value), None) = (parts.next(), parts.next(), parts.next(), parts.next()) else {
+        return Err(usage());
+    };
+    if !keyword.eq_ignore_ascii_case("version") {
+        return Err(usage());
+    }
+    Ok(DeltaVersionCmd { table: table.to_string(), version: value.parse().map_err(|_| format!("invalid Delta version '{value}'"))? })
+}
+
+pub(crate) fn parse_delta_actions(query: &str) -> Result<Option<DeltaVersionCmd>, String> {
     let Some(rest) = strip_command(query, "delta") else { return Ok(None) };
     let Some(rest) = strip_keyword(rest, "actions", char::is_whitespace) else { return Ok(None) };
-    let mut parts = rest.split_whitespace();
-    let table = parts.next().ok_or("DELTA ACTIONS requires: DELTA ACTIONS <table> VERSION <n>")?;
-    let keyword = parts.next().ok_or("DELTA ACTIONS requires a VERSION")?;
-    let value = parts.next().ok_or("DELTA ACTIONS requires a numeric VERSION")?;
-    if !keyword.eq_ignore_ascii_case("version") || parts.next().is_some() {
-        return Err("expected: DELTA ACTIONS <table> VERSION <n>".to_string());
-    }
-    let version = value.parse::<u64>().map_err(|_| format!("invalid Delta version '{value}'"))?;
-    Ok(Some(DeltaActionsCmd { table: table.to_string(), version }))
+    parse_delta_version_cmd(rest, "DELTA ACTIONS").map(Some)
 }
 
-#[derive(Debug, PartialEq, Eq)]
-pub(crate) struct DeltaRecoveryAuditCmd {
-    pub table: String,
-    pub version: u64,
-}
-
-pub(crate) fn parse_delta_recovery_audit(query: &str) -> Result<Option<DeltaRecoveryAuditCmd>, String> {
+pub(crate) fn parse_delta_recovery_audit(query: &str) -> Result<Option<DeltaVersionCmd>, String> {
     let Some(rest) = strip_command(query, "delta") else { return Ok(None) };
     let Some(rest) = strip_keyword(rest, "recovery", char::is_whitespace) else { return Ok(None) };
     let Some(rest) = strip_keyword(rest.trim(), "audit", char::is_whitespace) else {
         return Err("DELTA RECOVERY supports only: DELTA RECOVERY AUDIT <table> VERSION <n>".to_string());
     };
-    let mut parts = rest.split_whitespace();
-    let table = parts.next().ok_or("DELTA RECOVERY AUDIT requires a table")?;
-    let keyword = parts.next().ok_or("DELTA RECOVERY AUDIT requires a VERSION")?;
-    let value = parts.next().ok_or("DELTA RECOVERY AUDIT requires a numeric VERSION")?;
-    if !keyword.eq_ignore_ascii_case("version") || parts.next().is_some() {
-        return Err("expected: DELTA RECOVERY AUDIT <table> VERSION <n>".to_string());
-    }
-    let version = value.parse::<u64>().map_err(|_| format!("invalid Delta version '{value}'"))?;
-    Ok(Some(DeltaRecoveryAuditCmd { table: table.to_string(), version }))
+    parse_delta_version_cmd(rest, "DELTA RECOVERY AUDIT").map(Some)
 }
 
 /// An intercepted `OPTIMIZE <table> WHERE date = 'YYYY-MM-DD'` admin command.
@@ -814,6 +741,32 @@ pub(crate) struct OptimizeCmd {
     /// busy day, which doesn't fit in-process next to serving load
     /// (2026-07-27: two OOMs). One (project, date) partition is a few GB.
     pub project_id: Option<String>,
+}
+
+/// Decode the newline-delimited action list of one Delta commit entry.
+fn decode_commit_actions(bytes: &[u8]) -> PgWireResult<Vec<deltalake::kernel::Action>> {
+    bytes
+        .split(|byte| *byte == b'\n')
+        .filter(|line| !line.is_empty())
+        .map(|line| serde_json::from_slice(line).map_err(|e| admin_err(format!("decode Delta action: {e}"))))
+        .collect()
+}
+
+/// The all-VARCHAR `Response::Query` shared by the read-only admin commands:
+/// `names` are the columns, and each row yields one already-formatted value per
+/// column (or an error to surface in place of that row).
+fn text_response<const N: usize>(names: [&str; N], rows: impl Iterator<Item = PgWireResult<Vec<String>>> + Send + 'static) -> Vec<Response> {
+    let fields: Arc<Vec<FieldInfo>> =
+        Arc::new(names.into_iter().map(|name| FieldInfo::new(name.to_string(), None, None, Type::VARCHAR, FieldFormat::Text)).collect());
+    let row_fields = fields.clone();
+    let rows = rows.map(move |values| {
+        let mut encoder = DataRowEncoder::new(row_fields.clone());
+        for value in values? {
+            encoder.encode_field(&value)?;
+        }
+        Ok(encoder.take_row())
+    });
+    vec![Response::Query(QueryResponse::new(fields, stream::iter(rows)))]
 }
 
 fn admin_err(msg: impl Into<String>) -> PgWireError {
@@ -1044,40 +997,41 @@ fn record_statement_latency(metrics: Option<&crate::database::ScanMetrics>, quer
     // Emitted here, inside the span, so a resource-exhaustion failure names the
     // query that caused it. Failures are rare relative to traffic; a retrying
     // client is a handful per minute.
+    const SLOW_QUERY_US: u64 = 1_000_000;
+    let slow = duration_us >= SLOW_QUERY_US;
+    if success && !slow {
+        return;
+    }
+    let (_, operation) = classify_query(query);
+    let (tables, project_id) = query_dimensions(query);
+    let (fingerprint, template) = (query_fingerprint(query), query_template(query));
     if !success {
-        let (_, op) = classify_query(query);
-        let (tbls, proj) = query_dimensions(query);
         warn!(
             event = "pgwire.failed_statement",
-            query.class = op,
-            query.fingerprint = %query_fingerprint(query),
-            query.template = %query_template(query),
-            query.tables = %tbls,
-            project.id = %proj,
+            query.class = operation,
+            query.fingerprint = %fingerprint,
+            query.template = %template,
+            query.tables = %tables,
+            project.id = %project_id,
             protocol,
             duration_us,
             "PostgreSQL statement failed"
         );
     }
-    const SLOW_QUERY_US: u64 = 1_000_000;
-    if duration_us < SLOW_QUERY_US {
-        return;
+    if slow {
+        info!(
+            event = "pgwire.slow_statement",
+            query.class = operation,
+            query.fingerprint = %fingerprint,
+            query.template = %template,
+            query.tables = %tables,
+            project.id = %project_id,
+            protocol,
+            duration_us,
+            success,
+            "slow PostgreSQL statement"
+        );
     }
-
-    let (_, operation) = classify_query(query);
-    let (tables, project_id) = query_dimensions(query);
-    info!(
-        event = "pgwire.slow_statement",
-        query.class = operation,
-        query.fingerprint = %query_fingerprint(query),
-        query.template = %query_template(query),
-        query.tables = %tables,
-        project.id = %project_id,
-        protocol,
-        duration_us,
-        success,
-        "slow PostgreSQL statement"
-    );
 }
 
 fn query_dimensions(query: &str) -> (String, &str) {
@@ -1139,7 +1093,7 @@ impl SimpleQueryHandler for LoggingSimpleQueryHandler {
         let result =
             run_with_statement_timeout(timeout, <DfSessionService as SimpleQueryHandler>::do_query(&self.inner, client, query).instrument(execute_span))
                 .await
-                .map(|(responses, deadline)| with_response_deadlines(responses, deadline));
+                .map(|(responses, deadline)| responses.into_iter().map(|response| with_response_deadline(response, deadline)).collect());
         record_statement_latency(self.scan_metrics.as_deref(), query, "simple", t0.elapsed().as_micros() as u64, result.is_ok());
         log_statement_failure("simple", &result);
         result
@@ -1191,7 +1145,7 @@ pub struct RewritingQueryParser {
 impl datafusion_postgres::pgwire::api::stmt::QueryParser for RewritingQueryParser {
     type Statement = <DfSessionService as ExtendedQueryHandler>::Statement;
 
-    async fn parse_sql<C>(&self, client: &C, sql: &str, types: &[Option<datafusion_postgres::pgwire::api::Type>]) -> PgWireResult<Self::Statement>
+    async fn parse_sql<C>(&self, client: &C, sql: &str, types: &[Option<Type>]) -> PgWireResult<Self::Statement>
     where
         C: ClientInfo + Unpin + Send + Sync,
     {
@@ -1199,7 +1153,7 @@ impl datafusion_postgres::pgwire::api::stmt::QueryParser for RewritingQueryParse
         self.inner.parse_sql(client, rewritten.as_deref().unwrap_or(sql), types).await
     }
 
-    fn get_parameter_types(&self, statement: &Self::Statement) -> PgWireResult<Vec<datafusion_postgres::pgwire::api::Type>> {
+    fn get_parameter_types(&self, statement: &Self::Statement) -> PgWireResult<Vec<Type>> {
         self.inner.get_parameter_types(statement)
     }
 

--- a/src/server/pg_compat.rs
+++ b/src/server/pg_compat.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, sync::Arc, time::Duration};
 use async_trait::async_trait;
 use datafusion::{
     arrow::{
-        array::{Array, ArrayRef, BooleanArray, Int32Array, RecordBatch, StringArray, StringBuilder},
+        array::{Array, ArrayRef, BooleanArray, Int32Array, RecordBatch, StringArray},
         datatypes::{DataType, Field, Schema, SchemaRef, TimeUnit},
     },
     catalog::{MemTable, SchemaProvider, TableFunctionImpl, TableProvider},
@@ -35,6 +35,7 @@ use datafusion_postgres::{
     },
 };
 use futures::stream;
+use itertools::Itertools;
 
 pub const PG_COMPAT_VERSION: &str = "16.6";
 pub const PG_COMPAT_VERSION_NUM: &str = "160006";
@@ -114,8 +115,7 @@ fn overlay_runtime_stat_views(ctx: &SessionContext) -> DFResult<()> {
     let catalog = ctx.catalog("datafusion").ok_or_else(|| DataFusionError::Internal("catalog 'datafusion' missing after pg_catalog setup".to_string()))?;
     let inner = catalog.schema("pg_catalog").ok_or_else(|| DataFusionError::Internal("schema 'pg_catalog' missing after setup".to_string()))?;
     let extra = RUNTIME_STAT_VIEWS.iter().map(|(name, spec)| Ok((*name, empty_pg_table(spec)?))).collect::<DFResult<HashMap<_, _>>>()?;
-    catalog.register_schema("pg_catalog", Arc::new(PgCatalogOverlay { inner, extra }))?;
-    Ok(())
+    catalog.register_schema("pg_catalog", Arc::new(PgCatalogOverlay { inner, extra })).map(|_| ())
 }
 
 fn empty_pg_table(spec: &str) -> DFResult<Arc<dyn TableProvider>> {
@@ -152,9 +152,7 @@ struct PgCatalogOverlay {
 #[async_trait]
 impl SchemaProvider for PgCatalogOverlay {
     fn table_names(&self) -> Vec<String> {
-        let mut names = self.inner.table_names();
-        names.extend(self.extra.keys().map(ToString::to_string));
-        names
+        self.inner.table_names().into_iter().chain(self.extra.keys().map(ToString::to_string)).collect()
     }
 
     async fn table(&self, name: &str) -> DFResult<Option<Arc<dyn TableProvider>>> {
@@ -183,11 +181,7 @@ pub fn effective_statement_timeout(client_timeout: Option<Duration>, max_stateme
     let client_timeout = client_timeout.filter(|timeout| !timeout.is_zero());
     let ceiling = max_statement_secs.max(if client_timeout.is_some() { batch_statement_secs } else { 0 });
     let server_timeout = (ceiling != 0).then(|| Duration::from_secs(ceiling));
-    match (client_timeout, server_timeout) {
-        (Some(client), Some(server)) => Some(client.min(server)),
-        (Some(timeout), None) | (None, Some(timeout)) => Some(timeout),
-        (None, None) => None,
-    }
+    [client_timeout, server_timeout].into_iter().flatten().min()
 }
 
 /// The configured batch ceiling, or 0 before the config singleton is
@@ -273,7 +267,7 @@ impl PgCompatibilityHook {
             })
             .collect::<Option<Vec<_>>>()?;
         aliases.iter().any(|alias| alias == ROLE_PROBE_ALIAS).then_some(())?;
-        aliases.into_iter().map(|alias| Some((alias.clone(), self.role_field(&alias)?))).collect()
+        aliases.into_iter().map(|alias| self.role_field(&alias).map(|field| (alias, field))).collect()
     }
 
     fn role_field(&self, alias: &str) -> Option<RoleField> {
@@ -325,12 +319,12 @@ impl QueryHook for PgCompatibilityHook {
     }
 
     async fn handle_extended_parse_query(
-        &self, statement: &Statement, _session_context: &SessionContext, _client: &(dyn ClientInfo + Send + Sync),
+        &self, statement: &Statement, _session_context: &SessionContext, client: &(dyn ClientInfo + Send + Sync),
     ) -> Option<PgWireResult<LogicalPlan>> {
         if let Some(fields) = self.role_probe(statement) {
             return Some(role_probe_plan(statement, &fields));
         }
-        self.show(statement, _client).map(|_| show_plan())
+        self.show(statement, client).map(|_| show_plan())
     }
 
     async fn handle_extended_query(
@@ -373,27 +367,25 @@ fn is_pg_roles(relation: &TableFactor) -> bool {
     matches!(relation, TableFactor::Table { name, .. } if name.to_string().to_ascii_lowercase().ends_with("pg_roles"))
 }
 
-fn role_probe_field_type(value: &RoleField) -> (Type, DataType) {
+fn role_probe_field_type(value: &RoleField) -> Type {
     match value {
-        RoleField::Oid(_) => (Type::INT4, DataType::Int32),
-        RoleField::Text(_) => (Type::VARCHAR, DataType::Utf8),
-        RoleField::Bool(_) => (Type::BOOL, DataType::Boolean),
+        RoleField::Oid(_) => Type::INT4,
+        RoleField::Text(_) => Type::VARCHAR,
+        RoleField::Bool(_) => Type::BOOL,
     }
 }
 
 fn role_probe_response(fields: &[(String, RoleField)]) -> PgWireResult<QueryResponse> {
     let infos = Arc::new(
-        fields.iter().map(|(name, value)| FieldInfo::new(name.clone(), None, None, role_probe_field_type(value).0, FieldFormat::Text)).collect::<Vec<_>>(),
+        fields.iter().map(|(name, value)| FieldInfo::new(name.clone(), None, None, role_probe_field_type(value), FieldFormat::Text)).collect::<Vec<_>>(),
     );
     let row = {
         let mut encoder = DataRowEncoder::new(Arc::clone(&infos));
-        for (_, value) in fields {
-            match value {
-                RoleField::Oid(oid) => encoder.encode_field(&Some(*oid))?,
-                RoleField::Text(text) => encoder.encode_field(&Some(text.as_str()))?,
-                RoleField::Bool(flag) => encoder.encode_field(&Some(*flag))?,
-            }
-        }
+        fields.iter().try_for_each(|(_, value)| match value {
+            RoleField::Oid(oid) => encoder.encode_field(&Some(*oid)),
+            RoleField::Text(text) => encoder.encode_field(&Some(text.as_str())),
+            RoleField::Bool(flag) => encoder.encode_field(&Some(*flag)),
+        })?;
         encoder.take_row()
     };
     Ok(QueryResponse::new(infos, stream::once(async move { Ok(row) })))
@@ -452,13 +444,7 @@ fn show_plan() -> PgWireResult<LogicalPlan> {
 }
 
 fn show_response(name: &str, value: &str) -> PgWireResult<QueryResponse> {
-    let fields = Arc::new(vec![FieldInfo::new(name.to_string(), None, None, Type::VARCHAR, FieldFormat::Text)]);
-    let row = {
-        let mut encoder = DataRowEncoder::new(Arc::clone(&fields));
-        encoder.encode_field(&Some(value))?;
-        encoder.take_row()
-    };
-    Ok(QueryResponse::new(fields, stream::once(async move { Ok(row) })))
+    role_probe_response(&[(name.to_string(), RoleField::Text(value.to_string()))])
 }
 
 fn register_identity_udfs(ctx: &SessionContext, role: &str, max_statement_secs: u64) {
@@ -532,19 +518,20 @@ impl ScalarUDFImpl for CurrentSettingUdf {
                     .ok_or_else(|| DataFusionError::Execution("current_setting missing_ok must be Boolean".to_string()))
             })
             .transpose()?;
-        let mut result = StringBuilder::new();
-        for index in 0..names.len() {
-            let name = (!names.is_null(index))
-                .then(|| ScalarValue::try_from_array(&names, index))
-                .transpose()?
-                .and_then(|value| crate::read::optimizers::extract_utf8_string(&value));
-            match name.and_then(|name| compatibility_setting(&name, self.max_statement_secs)) {
-                Some(value) => result.append_value(value),
-                None if missing_ok.is_some_and(|values| values.value(index)) => result.append_null(),
-                None => return Err(DataFusionError::Execution("unrecognized configuration parameter".to_string())),
-            }
-        }
-        Ok(ColumnarValue::Array(Arc::new(result.finish())))
+        let values = (0..names.len())
+            .map(|index| {
+                let name = (!names.is_null(index))
+                    .then(|| ScalarValue::try_from_array(&names, index))
+                    .transpose()?
+                    .and_then(|value| crate::read::optimizers::extract_utf8_string(&value));
+                match name.and_then(|name| compatibility_setting(&name, self.max_statement_secs)) {
+                    Some(value) => Ok(Some(value)),
+                    None if missing_ok.is_some_and(|values| values.value(index)) => Ok(None),
+                    None => Err(DataFusionError::Execution("unrecognized configuration parameter".to_string())),
+                }
+            })
+            .collect::<DFResult<Vec<_>>>()?;
+        Ok(ColumnarValue::Array(Arc::new(StringArray::from(values))))
     }
 }
 
@@ -625,27 +612,31 @@ impl PgShowAllSettingsFunction {
     fn batch(&self) -> DFResult<RecordBatch> {
         let rows: Vec<(&str, String)> =
             COMPATIBILITY_SETTING_NAMES.iter().filter_map(|name| compatibility_setting(name, self.max_statement_secs).map(|value| (*name, value))).collect();
+        let n = rows.len();
         let strings = |values: Vec<Option<String>>| Arc::new(StringArray::from(values)) as ArrayRef;
-        let settings: Vec<Option<String>> = rows.iter().map(|(_, value)| Some(value.clone())).collect();
-        let nulls = || vec![None; rows.len()];
+        let repeat = |value: &str| strings(vec![Some(value.to_string()); n]);
+        // Computed once and Arc-cloned at each use site rather than rebuilt per
+        // column: `nulls`/`settings` each recur 8/3 times below.
+        let nulls = strings(vec![None; n]);
+        let settings = strings(rows.iter().map(|(_, value)| Some(value.clone())).collect());
         let columns = vec![
             strings(rows.iter().map(|(name, _)| Some((*name).to_string())).collect()),
-            strings(settings.clone()),
-            strings(nulls()),
-            strings(nulls()),
-            strings(nulls()),
-            strings(nulls()),
-            strings(vec![Some("user".to_string()); rows.len()]),
+            Arc::clone(&settings),
+            Arc::clone(&nulls),
+            Arc::clone(&nulls),
+            Arc::clone(&nulls),
+            Arc::clone(&nulls),
+            repeat("user"),
             strings(rows.iter().map(|(_, value)| Some(if matches!(value.as_str(), "on" | "off") { "bool" } else { "string" }.to_string())).collect()),
-            strings(vec![Some("default".to_string()); rows.len()]),
-            strings(nulls()),
-            strings(nulls()),
-            strings(nulls()),
-            strings(settings.clone()),
-            strings(settings),
-            strings(nulls()),
-            Arc::new(Int32Array::from(vec![None::<i32>; rows.len()])) as ArrayRef,
-            Arc::new(BooleanArray::from(vec![Some(false); rows.len()])) as ArrayRef,
+            repeat("default"),
+            Arc::clone(&nulls),
+            Arc::clone(&nulls),
+            Arc::clone(&nulls),
+            Arc::clone(&settings),
+            settings,
+            nulls,
+            Arc::new(Int32Array::from(vec![None::<i32>; n])) as ArrayRef,
+            Arc::new(BooleanArray::from(vec![Some(false); n])) as ArrayRef,
         ];
         RecordBatch::try_new(Self::schema(), columns).map_err(Into::into)
     }
@@ -662,33 +653,27 @@ mod tests {
     use super::*;
     use datafusion::arrow::array::AsArray;
 
-    #[test]
-    fn effective_timeout_uses_the_smaller_nonzero_value() {
-        let secs = |n| Some(Duration::from_secs(n));
-        // Batch ceiling off: exactly the old min(client, server).
-        assert_eq!(effective_statement_timeout(None, 60, 0), secs(60));
-        assert_eq!(effective_statement_timeout(Some(Duration::ZERO), 60, 0), secs(60));
-        assert_eq!(effective_statement_timeout(secs(5), 60, 0), secs(5));
-        assert_eq!(effective_statement_timeout(secs(120), 60, 0), secs(60));
-        assert_eq!(effective_statement_timeout(None, 0, 0), None);
-    }
-
-    /// A session raises the cap only by ASKING, and never past the configured
-    /// batch ceiling. The silent case is the one that matters: a dashboard
-    /// connection that sets nothing must keep the interactive cap even while
-    /// batch work is allowed, or enabling this would lift the limit on all the
-    /// traffic it was meant to protect.
-    #[test]
-    fn only_a_session_that_asks_may_raise_past_the_interactive_cap() {
-        let secs = |n| Some(Duration::from_secs(n));
-        assert_eq!(effective_statement_timeout(None, 60, 600), secs(60), "silence must not raise anything");
-        assert_eq!(effective_statement_timeout(secs(300), 60, 600), secs(300), "asking within the batch ceiling is granted");
-        assert_eq!(effective_statement_timeout(secs(900), 60, 600), secs(600), "the batch ceiling still bounds the ask");
-        assert_eq!(effective_statement_timeout(secs(5), 60, 600), secs(5), "asking for less still gets less");
-        // A batch ceiling below the interactive cap cannot lower it -- that is
-        // what `max_statement_secs` is for, and a misconfiguration here must not
-        // quietly tighten every query.
-        assert_eq!(effective_statement_timeout(secs(120), 60, 30), secs(60));
+    /// With the batch ceiling off this is exactly `min(client, server)`.
+    ///
+    /// With it on, a session raises the cap only by ASKING, and never past the
+    /// configured batch ceiling. The silent case is the one that matters: a
+    /// dashboard connection that sets nothing must keep the interactive cap even
+    /// while batch work is allowed, or enabling this would lift the limit on all
+    /// the traffic it was meant to protect. A batch ceiling *below* the
+    /// interactive cap cannot lower it either -- that is what `max_statement_secs`
+    /// is for, and a misconfiguration must not quietly tighten every query.
+    #[test_case::test_case(None, 60, 0 => Some(60) ; "server cap applies when the client is silent")]
+    #[test_case::test_case(Some(0), 60, 0 => Some(60) ; "a zero client timeout means unlimited, so the server caps")]
+    #[test_case::test_case(Some(5), 60, 0 => Some(5) ; "the smaller client value wins")]
+    #[test_case::test_case(Some(120), 60, 0 => Some(60) ; "the server caps a larger ask")]
+    #[test_case::test_case(None, 0, 0 => None ; "no cap configured anywhere")]
+    #[test_case::test_case(None, 60, 600 => Some(60) ; "silence must not raise anything")]
+    #[test_case::test_case(Some(300), 60, 600 => Some(300) ; "asking within the batch ceiling is granted")]
+    #[test_case::test_case(Some(900), 60, 600 => Some(600) ; "the batch ceiling still bounds the ask")]
+    #[test_case::test_case(Some(5), 60, 600 => Some(5) ; "asking for less still gets less")]
+    #[test_case::test_case(Some(120), 60, 30 => Some(60) ; "a batch ceiling under the interactive cap cannot lower it")]
+    fn effective_timeout_is_the_smaller_nonzero_cap(client_secs: Option<u64>, max_statement_secs: u64, batch_statement_secs: u64) -> Option<u64> {
+        effective_statement_timeout(client_secs.map(Duration::from_secs), max_statement_secs, batch_statement_secs).map(|timeout| timeout.as_secs())
     }
 
     #[test]
@@ -1052,20 +1037,26 @@ impl StatsTableProvider {
         ];
 
         let m = crate::observability::maintenance_stats();
-        let mut maintenance = atomic_rows(m.stats_rows());
-        maintenance.push(("maintenance", "retry_reason".to_owned(), crate::observability::maintenance_retry_reason()));
-        // DERIVED, not hand-listed. `rollup_witnessless_slices` above is one
-        // number for a population that sat byte-identical across four hourly
-        // passes and a restart; these say why, in two dimensions that each sum to
-        // it. Iterating the bucket lists is the point: a reason added without a
-        // row is the bug class that cost 53% of prefilter skips their attribution
-        // on 2026-08-24, and it cannot happen here.
-        maintenance.extend(crate::database::rollup_unverifiable::gauge_rows().map(|(key, value)| ("maintenance", key, value.to_string())));
-        // Same reason, same shape: one row per (operation, retry reason) the
-        // process has actually seen, rather than a hand-kept list that a new
-        // reason silently misses.
-        maintenance.extend(crate::observability::maintenance_retry_rows().into_iter().map(|(key, value)| ("maintenance", key, value.to_string())));
-        maintenance.extend(crate::observability::maintenance_work_rows().into_iter().map(|(key, value)| ("maintenance", key, value.to_string())));
+        let maintenance: Vec<Row> = atomic_rows(m.stats_rows())
+            .into_iter()
+            .chain([("maintenance", "retry_reason".to_owned(), crate::observability::maintenance_retry_reason())])
+            // DERIVED, not hand-listed. `rollup_witnessless_slices` above is one
+            // number for a population that sat byte-identical across four hourly
+            // passes and a restart; these say why, in two dimensions that each sum to
+            // it. Iterating the bucket lists is the point: a reason added without a
+            // row is the bug class that cost 53% of prefilter skips their attribution
+            // on 2026-08-24, and it cannot happen here.
+            .chain(crate::database::rollup_unverifiable::gauge_rows().map(|(key, value)| ("maintenance", key, value.to_string())))
+            // Same reason, same shape: one row per (operation, retry reason) the
+            // process has actually seen, rather than a hand-kept list that a new
+            // reason silently misses.
+            .chain(
+                crate::observability::maintenance_retry_rows()
+                    .into_iter()
+                    .chain(crate::observability::maintenance_work_rows())
+                    .map(|(key, value)| ("maintenance", key, value.to_string())),
+            )
+            .collect();
 
         let plan_cache = crate::read::plan_cache::global().map_or_else(Vec::new, |pc| {
             let (hits, misses) = pc.counters();
@@ -1358,10 +1349,9 @@ impl StatsTableProvider {
 
         // `block` = a worker was occupied that long; `section` = wall time only,
         // awaits included. Same shape, different claim — see `SECTION_STATS`.
-        let mut sections = crate::observability::section_stats();
-        sections.sort_unstable_by_key(|s| s.0);
-        let block: Vec<Row> = sections
+        let block: Vec<Row> = crate::observability::section_stats()
             .into_iter()
+            .sorted_unstable_by_key(|section| section.0)
             .flat_map(|((component, name), count, total_us, max_us)| {
                 [("count", count), ("total_ms", total_us / 1000), ("max_ms", max_us / 1000), ("avg_us", total_us.checked_div(count).unwrap_or(0))]
                     .map(|(k, v)| (component, format!("{name}.{k}"), v.to_string()))

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -16,6 +16,7 @@ use foyer::{
     BlockEngineConfig, DeviceBuilder, FsDeviceBuilder, HybridCache, HybridCacheBuilder, HybridCachePolicy, HybridCacheProperties, Location, PsyncIoEngineConfig,
 };
 use futures::stream::BoxStream;
+use itertools::Itertools;
 use object_store::{
     Attributes, CopyOptions, GetOptions, GetRange, GetResult, GetResultPayload, ListResult, MultipartUpload, ObjectMeta, ObjectStore, ObjectStoreExt,
     PutMultipartOptions, PutOptions, PutPayload, PutResult, Result as ObjectStoreResult, path::Path,
@@ -319,21 +320,9 @@ pub struct FoyerRuntimeStats {
 
 impl CacheStats {
     fn log(&self) {
-        let hit_rate = if self.hits + self.misses > 0 { (self.hits as f64 / (self.hits + self.misses) as f64) * 100.0 } else { 0.0 };
-        info!(
-            "Foyer cache stats - Hit rate: {:.2}%, Hits: {}, Misses: {}, Range hits: {}, Range misses: {}, Bytes served: {}, Inner bytes read: {}, Range bytes read: {}, TTL expirations: {}, Inner gets: {}, Inner puts: {}",
-            hit_rate,
-            self.hits,
-            self.misses,
-            self.range_hits,
-            self.range_misses,
-            self.bytes_served,
-            self.inner_bytes_read,
-            self.range_bytes_read,
-            self.ttl_expirations,
-            self.inner_gets,
-            self.inner_puts
-        );
+        let lookups = self.hits + self.misses;
+        let hit_rate = if lookups > 0 { (self.hits as f64 / lookups as f64) * 100.0 } else { 0.0 };
+        info!(hit_rate, stats = ?self, "Foyer cache stats");
     }
 }
 
@@ -577,6 +566,10 @@ impl SharedFoyerCache {
         self.metadata_stats.read().await.log();
     }
 
+    /// How long Foyer's close may take before it is abandoned. Small on purpose:
+    /// see the note in `shutdown_by`.
+    const CLOSE_BUDGET: std::time::Duration = std::time::Duration::from_secs(5);
+
     /// Close the caches, bounded by `deadline`. Foyer's `close()` flushes
     /// in-memory entries to disk; on a large cache / slow disk this can run for
     /// minutes (prod 2026-07-13: 377MB → 8.5min), and because it blocks process
@@ -584,10 +577,6 @@ impl SharedFoyerCache {
     /// a redeploy. The disk cache is a rebuildable READ cache, so abandoning an
     /// in-progress flush loses only warmth, never durable data — prioritize
     /// releasing the WAL lock over cache completeness.
-    /// How long Foyer's close may take before it is abandoned. Small on purpose:
-    /// see the note in `shutdown_by`.
-    const CLOSE_BUDGET: std::time::Duration = std::time::Duration::from_secs(5);
-
     pub async fn shutdown_by(&self, deadline: tokio::time::Instant) -> anyhow::Result<()> {
         info!("Shutting down Foyer cache...");
         self.log_stats().await;
@@ -651,8 +640,7 @@ impl SharedFoyerCache {
 /// Strip the `scheme://` prefix and trailing slashes from a table URI, yielding
 /// the bare table path used to build `_delta_log` cache keys.
 fn table_path_from_uri(table_uri: &str) -> &str {
-    let table_path = table_uri.find("://").map(|idx| &table_uri[idx + 3..]).unwrap_or(table_uri);
-    table_path.trim_end_matches('/')
+    table_uri.split_once("://").map_or(table_uri, |(_, path)| path).trim_end_matches('/')
 }
 
 /// Cache key (and object path) of a table's mutable `_last_checkpoint` file.
@@ -795,11 +783,8 @@ pub fn date_partition_within(s: &str, cutoff: Option<chrono::NaiveDate>) -> bool
 /// Keeps cold-tier rewrites (recompress of week+-old partitions) out of the
 /// cache so recent data stays local and old data is served from S3.
 fn is_within_recent_window(location: &Path, recent_days: usize) -> bool {
-    if recent_days == 0 {
-        return true;
-    }
-    let cutoff = Utc::now().date_naive() - chrono::Duration::days(recent_days as i64);
-    date_partition_within(location.as_ref(), Some(cutoff))
+    let cutoff = (recent_days > 0).then(|| Utc::now().date_naive() - chrono::Duration::days(recent_days as i64));
+    date_partition_within(location.as_ref(), cutoff)
 }
 
 /// Insert into the main full-file cache, steering large entries to disk-only
@@ -819,6 +804,20 @@ fn insert_main(cache: &FoyerCache, key: String, value: CacheValue, l1_max_entry_
 /// a post-write GET just to learn the metadata.
 fn put_result_meta(location: Path, size: u64, result: &PutResult) -> ObjectMeta {
     ObjectMeta { location, last_modified: Utc::now(), size, e_tag: result.e_tag.clone(), version: result.version.clone() }
+}
+
+/// A cached byte range, stamped with the file's identity (etag/version/mtime)
+/// but the *range's* length as its size. Takes `Bytes` so admitting a range
+/// shares the fetched buffer instead of copying it.
+fn range_value(location: &Path, data: Bytes, file: &ObjectMeta) -> CacheValue {
+    let meta = ObjectMeta {
+        location: location.clone(),
+        last_modified: file.last_modified,
+        size: data.len() as u64,
+        e_tag: file.e_tag.clone(),
+        version: file.version.clone(),
+    };
+    CacheValue::new(data, meta)
 }
 
 /// Foyer-based hybrid cache implementation for object store
@@ -952,18 +951,12 @@ impl FoyerObjectStoreCache {
     pub async fn shutdown(&self) -> anyhow::Result<()> {
         info!("Shutting down foyer hybrid cache");
 
-        // Cancel all background refresh tasks
         let mut tasks = self.background_tasks.lock().await;
         debug!("Cancelling {} background refresh tasks", tasks.len());
         tasks.abort_all();
-        // Wait for all tasks to complete or be cancelled
         while tasks.join_next().await.is_some() {}
-
-        // Clear the refreshing set
         self.refreshing.clear();
-
-        // Note: We don't close the caches here because they're shared
-        // and owned by SharedFoyerCache
+        // The caches themselves are owned by SharedFoyerCache and closed there.
         Ok(())
     }
 
@@ -979,9 +972,7 @@ impl FoyerObjectStoreCache {
         *self.stats.write().await = CacheStats::default();
         *self.metadata_stats.write().await = CacheStats::default();
     }
-}
 
-impl FoyerObjectStoreCache {
     /// Read a payload body into bytes, propagating IO/stream errors.
     async fn read_payload(payload: GetResultPayload) -> ObjectStoreResult<Vec<u8>> {
         use futures::TryStreamExt;
@@ -1298,7 +1289,7 @@ impl FoyerObjectStoreCache {
                 );
 
                 bump(&self.metadata_stats, |s| s.inner_bytes_read += data.len() as u64).await;
-                self.admit_range(location, range_cache_key, &data, &file_meta);
+                self.admit_range(location, range_cache_key, data.clone(), &file_meta);
 
                 return Ok(data);
             }
@@ -1375,7 +1366,7 @@ impl FoyerObjectStoreCache {
         record_range_miss(&self.stats, result.len() as u64).await;
         bump(&self.stats, |s| s.inner_bytes_read += result.len() as u64).await;
         if let Some(meta) = range_meta.as_ref() {
-            self.admit_data_range(location, range_cache_key, &result, meta);
+            self.admit_data_range(location, range_cache_key, result.clone(), meta);
         }
         Ok(match response_slice {
             Some((start, end)) => result.slice(start..end),
@@ -1449,10 +1440,7 @@ impl FoyerObjectStoreCache {
         // known payload size; no post-write GET. insert_main_value applies the
         // recent-days window and large-entry disk steering.
         if payload_size > 0 {
-            let data = payload_for_cache.iter().fold(Vec::with_capacity(payload_size), |mut acc, chunk| {
-                acc.extend_from_slice(chunk);
-                acc
-            });
+            let data = payload_for_cache.as_ref().concat();
             let meta = put_result_meta(location.clone(), payload_size as u64, &result);
             self.insert_main_value(location, CacheValue::new(data, meta));
             debug!("Warmed cache from write payload: {} (size: {} bytes)", location, payload_size);
@@ -1522,33 +1510,18 @@ impl FoyerObjectStoreCache {
         !self.bypass_seen.insert(key.to_string())
     }
 
-    /// Cache a fetched byte range under `key`, stamped with the file's identity
-    /// (etag/version/mtime) but the *range's* length as its size.
-    fn admit_range(&self, location: &Path, key: String, data: &[u8], file: &ObjectMeta) {
-        let meta = ObjectMeta {
-            location: location.clone(),
-            last_modified: file.last_modified,
-            size: data.len() as u64,
-            e_tag: file.e_tag.clone(),
-            version: file.version.clone(),
-        };
-        self.admit(&self.metadata_cache, key, CacheValue::new(data.to_vec(), meta), 0);
+    /// Cache a fetched metadata byte range under `key`.
+    fn admit_range(&self, location: &Path, key: String, data: Bytes, file: &ObjectMeta) {
+        self.admit(&self.metadata_cache, key, range_value(location, data, file), 0);
     }
 
     /// Admit an exact parquet data range to the main cache. This is the
     /// fallback for files whose full-file post-commit warm has not landed.
-    fn admit_data_range(&self, location: &Path, key: String, data: &[u8], file: &ObjectMeta) {
+    fn admit_data_range(&self, location: &Path, key: String, data: Bytes, file: &ObjectMeta) {
         if !is_within_recent_window(location, self.config.cache_recent_days) {
             return;
         }
-        let meta = ObjectMeta {
-            location: location.clone(),
-            last_modified: file.last_modified,
-            size: data.len() as u64,
-            e_tag: file.e_tag.clone(),
-            version: file.version.clone(),
-        };
-        self.admit(&self.cache, key, CacheValue::new(data.to_vec(), meta), self.config.l1_max_entry_bytes);
+        self.admit(&self.cache, key, range_value(location, data, file), self.config.l1_max_entry_bytes);
     }
 
     /// Cache a path's `ObjectMeta` (body-less entry) so later reads skip the HEAD.
@@ -1797,7 +1770,7 @@ impl ObjectStore for FoyerObjectStoreCache {
             // reads use) and the immutable-meta cache, so the next footer read is
             // a pure cache hit.
             if is_parquet_file(location) {
-                self.admit_range(location, Self::make_range_cache_key(location, &abs_range), &bytes, &meta);
+                self.admit_range(location, Self::make_range_cache_key(location, &abs_range), bytes.clone(), &meta);
                 self.admit_meta(location, meta.clone());
             }
             return Ok(Self::make_get_result_at(bytes, meta, attributes, abs_range.start));
@@ -2077,48 +2050,53 @@ mod tests {
         Ok(())
     }
 
+    /// Writing through the cache warms it from the payload, so every later read
+    /// is a hit and the inner store is never touched — whatever the file count,
+    /// the file size, or how small the L1 budget is.
+    #[test_case::test_case("basic_ops", 10 * 1024 * 1024, &[9] ; "one small file")]
+    #[test_case::test_case("s3_bypass", 10 * 1024 * 1024, &[1024, 2048, 4096] ; "several files")]
+    #[test_case::test_case("disk", 1024, &[10 * 1024] ; "file larger than the memory budget")]
     #[tokio::test]
-    async fn test_basic_operations() -> anyhow::Result<()> {
-        let inner = Arc::new(InMemory::new());
-        let cache = FoyerObjectStoreCache::new(inner, FoyerCacheConfig::test_config("basic_ops")).await?;
+    async fn writes_warm_the_cache_so_reads_never_reach_the_inner_store(name: &str, memory_bytes: usize, sizes: &[usize]) -> anyhow::Result<()> {
+        let config = FoyerCacheConfig::test_config_with(name, |c| c.memory_size_bytes = memory_bytes);
+        let _dir = CacheDirGuard(config.cache_dir.clone());
+        let cache = FoyerObjectStoreCache::new(Arc::new(InMemory::new()), config).await?;
         cache.reset_stats().await;
 
-        let path = Path::from("test/file.parquet");
-        let data = Bytes::from("test data");
+        let files: Vec<(Path, Bytes)> =
+            sizes.iter().enumerate().map(|(i, &n)| (Path::from(format!("table/part-{i}.parquet")), Bytes::from(vec![b'a'; n]))).collect();
+        for (path, data) in &files {
+            cache.put(path, PutPayload::from(data.clone())).await?;
+        }
+        assert_eq!(cache.get_stats().await.main.inner_puts, files.len() as u64);
 
-        cache.put(&path, PutPayload::from(data.clone())).await?;
+        // Two read passes: both served from the write payload, so no re-fetch.
+        for _ in 0..2 {
+            for (path, data) in &files {
+                assert_eq!(&cache.get(path).await?.bytes().await?[..], &data[..]);
+            }
+        }
 
         let stats = cache.get_stats().await;
-        assert_eq!(stats.main.inner_puts, 1);
-        assert_eq!(stats.main.inner_gets, 0); // Cached directly from the write payload — no re-fetch
-
-        // First get - cache hit (since we cache on write)
-        assert_eq!(cache.get(&path).await?.bytes().await?, data);
-
-        let stats = cache.get_stats().await;
-        assert_eq!(stats.main.inner_gets, 0); // No fetch needed - cached from write payload
+        assert_eq!(stats.main.inner_gets, 0, "nothing is ever fetched back from the inner store");
         assert_eq!(stats.main.misses, 0);
-        assert_eq!(stats.main.hits, 1);
-
-        // Second get - cache hit
-        assert_eq!(cache.get(&path).await?.bytes().await?, data);
-
-        let stats = cache.get_stats().await;
-        assert_eq!(stats.main.inner_gets, 0); // Still no fetch - served from cache
-        assert_eq!(stats.main.hits, 2); // Two cache hits total
-        assert_eq!(stats.main.misses, 0);
-        assert_eq!(stats.main.bytes_served, (data.len() * 2) as u64);
+        assert_eq!(stats.main.hits, 2 * files.len() as u64);
+        assert_eq!(stats.main.bytes_served, 2 * sizes.iter().sum::<usize>() as u64);
         assert_eq!(cache.try_get_stats().main.bytes_served, stats.main.bytes_served);
 
+        cache.shutdown().await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn a_deleted_object_is_no_longer_served_from_cache() -> anyhow::Result<()> {
+        let cache = FoyerObjectStoreCache::new(Arc::new(InMemory::new()), FoyerCacheConfig::test_config("delete")).await?;
+        let path = Path::from("test/file.parquet");
+        cache.put(&path, PutPayload::from(Bytes::from_static(b"test data"))).await?;
         cache.delete(&path).await?;
+        tokio::time::sleep(Duration::from_millis(10)).await; // deletion is processed off the call
 
-        // Give cache time to process deletion
-        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
-
-        // After deletion, get should fail
-        let get_result = cache.get(&path).await;
-        assert!(get_result.is_err(), "Expected error after delete, got: {:?}", get_result);
-
+        assert!(cache.get(&path).await.is_err(), "a deleted object must not be served from cache");
         cache.shutdown().await?;
         Ok(())
     }
@@ -2128,7 +2106,7 @@ mod tests {
     #[tokio::test]
     async fn cache_hit_serves_the_requested_range() -> anyhow::Result<()> {
         let cache = SharedFoyerCache::new(FoyerCacheConfig::test_config("hit_range")).await?;
-        let store = FoyerObjectStoreCache::new_with_shared_cache(Arc::new(object_store::memory::InMemory::new()), &cache);
+        let store = FoyerObjectStoreCache::new_with_shared_cache(Arc::new(InMemory::new()), &cache);
         let path = Path::from("test/zc.parquet");
         let body: Vec<u8> = (0u8..=255).collect();
         let meta = ObjectMeta { location: path.clone(), last_modified: Utc::now(), size: body.len() as u64, e_tag: None, version: None };
@@ -2151,7 +2129,7 @@ mod tests {
     #[tokio::test]
     async fn held_slice_does_not_pin_the_cache_entry() -> anyhow::Result<()> {
         let cache = SharedFoyerCache::new(FoyerCacheConfig::test_config("no_pin")).await?;
-        let store = FoyerObjectStoreCache::new_with_shared_cache(Arc::new(object_store::memory::InMemory::new()), &cache);
+        let store = FoyerObjectStoreCache::new_with_shared_cache(Arc::new(InMemory::new()), &cache);
         let path = Path::from("test/pin.parquet");
         let body: Vec<u8> = (0u8..=255).collect();
         let meta = ObjectMeta { location: path.clone(), last_modified: Utc::now(), size: body.len() as u64, e_tag: None, version: None };
@@ -2204,54 +2182,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_cache_prevents_s3_access() -> anyhow::Result<()> {
-        let inner = Arc::new(InMemory::new());
-        let config = FoyerCacheConfig::test_config_with("s3_bypass", |c| {
-            c.memory_size_bytes = 10 * 1024 * 1024;
-            c.disk_size_bytes = 100 * 1024 * 1024;
-            c.ttl = Duration::from_secs(300);
-        });
-
-        let cache = FoyerObjectStoreCache::new(inner, config).await?;
-        cache.reset_stats().await;
-
-        let files =
-            vec![("table/part-001.parquet", vec![b'a'; 1024]), ("table/part-002.parquet", vec![b'b'; 2048]), ("table/part-003.parquet", vec![b'c'; 4096])];
-
-        // Write all files
-        for (path_str, data) in &files {
-            let path = Path::from(*path_str);
-            cache.put(&path, PutPayload::from(Bytes::from(data.clone()))).await?;
-        }
-
-        // First read - cache hit (since we cache on write)
-        for (path_str, data) in &files {
-            let path = Path::from(*path_str);
-            assert_eq!(cache.get(&path).await?.bytes().await?.len(), data.len());
-        }
-
-        let stats = cache.get_stats().await;
-        assert_eq!(stats.main.inner_gets, 0); // Cached from write payloads — no re-fetch
-        assert_eq!(stats.main.misses, 0);
-        assert_eq!(stats.main.hits, 3);
-
-        // Second read - cache hit
-        for (path_str, data) in &files {
-            let path = Path::from(*path_str);
-            assert_eq!(cache.get(&path).await?.bytes().await?.len(), data.len());
-        }
-
-        let stats = cache.get_stats().await;
-        assert_eq!(stats.main.inner_gets, 0); // No inner gets at all
-        assert_eq!(stats.main.hits, 6); // Total 6 hits (3 per read)
-
-        info!("Cache successfully prevented {} S3 accesses", stats.main.hits);
-
-        cache.shutdown().await?;
-        Ok(())
-    }
-
-    #[tokio::test]
     async fn test_ttl_expiration() -> anyhow::Result<()> {
         let config = FoyerCacheConfig::test_config_with("ttl", |c| {
             c.ttl = Duration::from_millis(100);
@@ -2263,53 +2193,18 @@ mod tests {
         let cache = FoyerObjectStoreCache::new(inner, config).await?;
 
         let path = Path::from("test/ttl_file.parquet");
-        let data = Bytes::from("test data");
+        cache.put(&path, PutPayload::from(Bytes::from_static(b"test data"))).await?;
+        let _ = cache.get(&path).await?;
+        cache.reset_stats().await; // normalize: only the post-expiry read is under test
 
-        cache.put(&path, PutPayload::from(data.clone())).await?;
+        tokio::time::sleep(Duration::from_millis(200)).await; // 2x the TTL
         let _ = cache.get(&path).await?;
 
-        tokio::time::sleep(Duration::from_millis(200)).await;
-
-        let _ = cache.get(&path).await?;
-
         let stats = cache.get_stats().await;
-        info!("TTL test - main cache hits: {}, misses: {}", stats.main.hits, stats.main.misses);
+        assert_eq!(stats.main.ttl_expirations, 1, "the stale entry must be counted as expired");
+        assert_eq!(stats.main.misses, 1, "an expired entry is re-fetched, not served");
+        assert_eq!(stats.main.hits, 0);
 
-        cache.shutdown().await?;
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_large_file_disk_cache() -> anyhow::Result<()> {
-        let inner = Arc::new(InMemory::new());
-        let config = FoyerCacheConfig::test_config_with("disk", |c| {
-            c.memory_size_bytes = 1024; // Very small memory
-        });
-
-        let cache = FoyerObjectStoreCache::new(inner, config).await?;
-        cache.reset_stats().await;
-
-        let large_data = Bytes::from(vec![b'x'; 10 * 1024]); // 10KB
-        let path = Path::from("test/large_file.parquet");
-
-        cache.put(&path, PutPayload::from(large_data.clone())).await?;
-
-        // First get - cache hit (since we cache on write)
-        assert_eq!(cache.get(&path).await?.bytes().await?.len(), large_data.len());
-
-        let stats = cache.get_stats().await;
-        assert_eq!(stats.main.inner_gets, 0); // Cached from write payload — no re-fetch
-        assert_eq!(stats.main.hits, 1);
-
-        // Second get - cache hit
-        assert_eq!(cache.get(&path).await?.bytes().await?.len(), large_data.len());
-
-        let stats = cache.get_stats().await;
-        assert_eq!(stats.main.inner_gets, 0); // Still no fetch - served from cache
-        assert_eq!(stats.main.hits, 2); // Two cache hits total
-
-        info!("Large file test - main cache hits: {}, misses: {}", stats.main.hits, stats.main.misses);
         cache.shutdown().await?;
         Ok(())
     }
@@ -2376,78 +2271,7 @@ mod tests {
         assert_eq!(stats.main.inner_gets, 1); // No additional inner get
         assert_eq!(stats.main.hits, 1); // Cache hit on full file
 
-        info!("Parquet metadata optimization test passed");
-        info!("Main cache - hits: {}, misses: {}", stats.main.hits, stats.main.misses);
-        info!("Metadata cache - hits: {}, misses: {}", stats.metadata.hits, stats.metadata.misses);
         cache.shutdown().await?;
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_metadata_cache_separation() -> anyhow::Result<()> {
-        // Use in-memory store for testing
-        let inner = Arc::new(InMemory::new());
-
-        // Configure cache with small limits to test separation
-        let config = FoyerCacheConfig::test_config_with("metadata_separation", |c| {
-            c.memory_size_bytes = 10 * 1024 * 1024; // 10MB
-            c.disk_size_bytes = 50 * 1024 * 1024; // 50MB
-            c.metadata_memory_size_bytes = 5 * 1024 * 1024; // 5MB
-            c.metadata_disk_size_bytes = 20 * 1024 * 1024; // 20MB
-            c.parquet_metadata_size_hint = 1024; // 1KB
-        });
-
-        let _dir = CacheDirGuard(config.cache_dir.clone());
-
-        let cache = FoyerObjectStoreCache::new(inner.clone(), config).await?;
-        cache.reset_stats().await;
-
-        // Create a parquet file
-        let path = Path::from("test.parquet");
-        let file_size = 1024 * 1024; // 1MB
-        let data = vec![b'a'; file_size];
-        inner.put(&path, PutPayload::from(Bytes::from(data))).await?;
-
-        // Test 1: Read metadata range (should use metadata cache)
-        let metadata_range = (file_size - 1024) as u64..file_size as u64;
-        let result = cache.get_range(&path, metadata_range.clone()).await?;
-        assert_eq!(result.len(), 1024, "Should get correct range size");
-
-        let stats = cache.get_stats().await;
-        info!(
-            "After first get_range - metadata.misses: {}, metadata.hits: {}, main.misses: {}, main.hits: {}",
-            stats.metadata.misses, stats.metadata.hits, stats.main.misses, stats.main.hits
-        );
-        assert_eq!(stats.metadata.misses, 1, "Should have 1 metadata cache miss");
-        assert_eq!(stats.metadata.hits, 0, "Should have 0 metadata cache hits");
-        assert_eq!(stats.main.hits, 0, "Should have 0 main cache hits");
-
-        // Test 2: Read same metadata range again (should hit metadata cache)
-        let _ = cache.get_range(&path, metadata_range.clone()).await?;
-
-        let stats = cache.get_stats().await;
-        assert_eq!(stats.metadata.hits, 1, "Should have 1 metadata cache hit");
-        assert_eq!(stats.metadata.misses, 1, "Should still have 1 metadata cache miss");
-
-        // Test 3: Read data range (should use main cache)
-        let data_range = 0..1024;
-        let _ = cache.get_range(&path, data_range).await?;
-
-        let stats = cache.get_stats().await;
-        assert_eq!(stats.main.misses, 1, "Should have 1 main cache miss");
-
-        // Test 4: Read full file (should use main cache)
-        let _ = cache.get(&path).await?;
-
-        let stats = cache.get_stats().await;
-        assert!(stats.main.hits > 0 || stats.main.misses > 0, "Main cache should be used for full file");
-
-        info!("Main cache stats: hits={}, misses={}", stats.main.hits, stats.main.misses);
-        info!("Metadata cache stats: hits={}, misses={}", stats.metadata.hits, stats.metadata.misses);
-
-        cache.shutdown().await?;
-
         Ok(())
     }
 
@@ -2478,10 +2302,6 @@ mod tests {
         assert_eq!(result.len(), 1024, "Should get correct range size");
 
         let stats = cache.get_stats().await;
-        info!(
-            "After first get_range - metadata.misses: {}, metadata.hits: {}, main.misses: {}, main.hits: {}",
-            stats.metadata.misses, stats.metadata.hits, stats.main.misses, stats.main.hits
-        );
         assert_eq!(stats.metadata.misses, 1, "Should have metadata cache miss");
         assert_eq!(stats.metadata.hits, 0, "Should have no metadata cache hits yet");
 
@@ -2500,21 +2320,12 @@ mod tests {
         // The range will be served from the main cache since put() caches the full file
         assert_eq!(stats.main.hits, 1, "Should hit main cache after put");
 
-        info!("Metadata cache invalidation test passed");
-        info!(
-            "Final stats - Main: hits={}, misses={}, Metadata: hits={}, misses={}",
-            stats.main.hits, stats.main.misses, stats.metadata.hits, stats.metadata.misses
-        );
-
         cache.shutdown().await?;
-
         Ok(())
     }
 
     #[tokio::test]
     async fn test_multipart_capture_warms_cache() -> anyhow::Result<()> {
-        use object_store::MultipartUpload;
-
         let inner = Arc::new(InMemory::new());
         // Tighten the inline cap to 1MB (below the 4MB block size) so we can
         // exercise both the captured and skipped paths.
@@ -2564,8 +2375,6 @@ mod tests {
     /// 256MB compaction output sat in heap per concurrent upload.
     #[tokio::test]
     async fn test_write_capture_cap_bounds_tee() -> anyhow::Result<()> {
-        use object_store::MultipartUpload;
-
         let inner = Arc::new(InMemory::new());
         // Block size stays 4MB; only the write-capture cap is tightened.
         let config = FoyerCacheConfig::test_config_with("wcap_cap", |c| {
@@ -2611,8 +2420,6 @@ mod tests {
     /// capture silently stops entirely.
     #[tokio::test]
     async fn test_write_capture_cap_is_clamped_to_budget() -> anyhow::Result<()> {
-        use object_store::MultipartUpload;
-
         let inner = Arc::new(InMemory::new());
         let config = FoyerCacheConfig::test_config_with("wcap_clamp", |c| {
             c.write_capture_max_bytes = 0; // bounded by the (4MB) block size
@@ -2638,8 +2445,6 @@ mod tests {
     /// exhausted, further uploads skip capture — but never block and never fail.
     #[tokio::test]
     async fn test_write_capture_budget_skips_without_failing_uploads() -> anyhow::Result<()> {
-        use object_store::MultipartUpload;
-
         let inner = Arc::new(InMemory::new());
         // Budget fits exactly one concurrent capture (1x the per-upload cap).
         let config = FoyerCacheConfig::test_config_with("wcap_budget", |c| {
@@ -2908,8 +2713,6 @@ mod tests {
     /// entry would either never be read back or never be evicted.
     #[tokio::test]
     async fn test_multipart_warm_read_and_evict_key_consistency() -> anyhow::Result<()> {
-        use object_store::MultipartUpload;
-
         let inner = Arc::new(InMemory::new());
         let shared = SharedFoyerCache::new(FoyerCacheConfig::test_config("mpu_key_consistency")).await?;
         let cache = FoyerObjectStoreCache::new_with_shared_cache(inner, &shared);
@@ -2951,8 +2754,8 @@ mod tests {
     #[display("CountingStore")]
     struct CountingStore {
         inner: Arc<InMemory>,
-        heads: Arc<std::sync::atomic::AtomicUsize>,
-        gets: Arc<std::sync::atomic::AtomicUsize>,
+        heads: Arc<AtomicUsize>,
+        gets: Arc<AtomicUsize>,
         delay: Duration,
     }
 
@@ -2967,7 +2770,6 @@ mod tests {
         }
 
         async fn get_opts(&self, location: &Path, options: GetOptions) -> ObjectStoreResult<GetResult> {
-            use std::sync::atomic::Ordering;
             if options.head {
                 self.heads.fetch_add(1, Ordering::Relaxed);
             } else {
@@ -3007,8 +2809,6 @@ mod tests {
 
     #[tokio::test]
     async fn concurrent_cold_gets_share_one_inner_fetch() -> anyhow::Result<()> {
-        use std::sync::atomic::{AtomicUsize, Ordering};
-
         let inner = Arc::new(InMemory::new());
         let path = Path::from(format!("table/date={}/part.parquet", Utc::now().date_naive()));
         inner.put(&path, PutPayload::from(Bytes::from(vec![b'x'; 1024]))).await?;
@@ -3035,8 +2835,6 @@ mod tests {
     /// zero S3 round-trips (no HEAD to classify, no GET).
     #[tokio::test]
     async fn test_warm_footer_eliminates_read_path_heads() -> anyhow::Result<()> {
-        use std::sync::atomic::{AtomicUsize, Ordering};
-
         let mem = Arc::new(InMemory::new());
         let file_size = 10 * 1024usize;
         let path = Path::from("table/date=2026-06-05/part-heads.parquet");
@@ -3139,7 +2937,6 @@ mod tests {
     /// GETs).
     #[tokio::test]
     async fn tiny_parquet_file_is_cached_whole_not_per_range() -> anyhow::Result<()> {
-        use std::sync::atomic::AtomicUsize;
         let mem = Arc::new(InMemory::new());
         let (heads, gets) = (Arc::new(AtomicUsize::new(0)), Arc::new(AtomicUsize::new(0)));
         let counting = Arc::new(CountingStore { inner: mem.clone(), heads: heads.clone(), gets: gets.clone(), delay: Duration::ZERO });
@@ -3230,7 +3027,6 @@ mod tests {
     // free to confirm: only the write-capture gap may cost a fetch.
     #[tokio::test]
     async fn warm_full_if_absent_fetches_only_the_uncaptured_files() -> anyhow::Result<()> {
-        use std::sync::atomic::AtomicUsize;
         let mem = Arc::new(InMemory::new());
         let (heads, gets) = (Arc::new(AtomicUsize::new(0)), Arc::new(AtomicUsize::new(0)));
         let counting = Arc::new(CountingStore { inner: mem.clone(), heads: heads.clone(), gets: gets.clone(), delay: Duration::ZERO });
@@ -3743,8 +3539,6 @@ pub trait CoverageLedger: Send + Sync {
     fn coverage(&self, cell: &CoverageCell) -> Vec<CoverageEntry>;
     /// Record a slice that is ALREADY COMMITTED. See the ordering note above.
     fn record(&self, cell: &CoverageCell, entry: CoverageEntry);
-    /// Drop a cell entirely — its partition aged out, or its coverage is being
-    /// rebuilt from scratch.
     /// Replace a cell's coverage wholesale with what a replay just proved.
     ///
     /// `record` alone is APPEND-ONLY, and coverage is not: a slice rebuilt under
@@ -3784,10 +3578,10 @@ pub trait CoverageLedger: Send + Sync {
 /// a range no single build ever produced.
 pub fn merge_coverage(mut entries: Vec<CoverageEntry>) -> Vec<CoverageEntry> {
     entries.sort_by(|a, b| (&a.generation, a.start_micros).cmp(&(&b.generation, b.start_micros)));
-    let mut merged: Vec<CoverageEntry> = Vec::with_capacity(entries.len());
-    for entry in entries {
-        match merged.last_mut() {
-            Some(last) if last.generation == entry.generation && entry.start_micros <= last.end_micros => {
+    entries
+        .into_iter()
+        .coalesce(|mut last, entry| {
+            if last.generation == entry.generation && entry.start_micros <= last.end_micros {
                 last.end_micros = last.end_micros.max(entry.end_micros);
                 // A merged range is only as trustworthy as its weakest part: one
                 // witness-less contributor makes the whole span unverifiable,
@@ -3803,11 +3597,12 @@ pub fn merge_coverage(mut entries: Vec<CoverageEntry>) -> Vec<CoverageEntry> {
                 last.files.extend(entry.files);
                 last.files.sort_unstable();
                 last.files.dedup();
+                Ok(last)
+            } else {
+                Err((last, entry))
             }
-            _ => merged.push(entry),
-        }
-    }
-    merged
+        })
+        .collect()
 }
 
 /// One `(cell -> entries)` row as it is persisted. Flat on purpose: a tuple key
@@ -3882,15 +3677,14 @@ impl JsonCoverageLedger {
     /// and two entries there. The covered SET is identical, which is the only
     /// thing routing asks.
     pub fn routing_view(&self, source: &str, table_name: &str) -> std::collections::HashMap<String, Vec<CoverageEntry>> {
-        let mut by_project: std::collections::HashMap<String, Vec<CoverageEntry>> = std::collections::HashMap::new();
-        for cell in self.cells.iter() {
-            let (cell_source, project_id, cell_table, _date) = cell.key();
-            if cell_source != source || cell_table != table_name {
-                continue;
-            }
-            by_project.entry(project_id.clone()).or_default().extend(cell.value().iter().cloned());
-        }
-        by_project.into_iter().map(|(project, entries)| (project, merge_coverage(entries))).collect()
+        self.cells
+            .iter()
+            .filter(|cell| cell.key().0 == source && cell.key().2 == table_name)
+            .map(|cell| (cell.key().1.clone(), cell.value().clone()))
+            .into_group_map()
+            .into_iter()
+            .map(|(project, entries)| (project, merge_coverage(entries.into_iter().flatten().collect())))
+            .collect()
     }
 
     /// Drop cells whose date is older than `keep_from` (a `YYYY-MM-DD` bound),
@@ -3919,10 +3713,11 @@ impl CoverageLedger for JsonCoverageLedger {
     }
 
     fn record(&self, cell: &CoverageCell, entry: CoverageEntry) {
-        self.cells.entry(cell.clone()).or_default().push(entry);
-        if let Some(mut entries) = self.cells.get_mut(cell) {
-            let merged = merge_coverage(std::mem::take(&mut *entries));
-            *entries = merged;
+        {
+            // Scoped so the map guard is released before `persist` iterates the map.
+            let mut entries = self.cells.entry(cell.clone()).or_default();
+            entries.push(entry);
+            *entries = merge_coverage(std::mem::take(&mut *entries));
         }
         self.persist();
     }

--- a/src/support.rs
+++ b/src/support.rs
@@ -5,6 +5,12 @@
 
 use std::sync::atomic::{AtomicI64, Ordering};
 
+/// Lock without letting a poisoned mutex propagate: the mutexes in this crate
+/// guard plain data, so a panicking holder leaves the data usable.
+pub(crate) fn lock<T>(mutex: &std::sync::Mutex<T>) -> std::sync::MutexGuard<'_, T> {
+    mutex.lock().unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
 /// An impossible epoch value marks wall-clock mode.
 const WALL_SENTINEL: i64 = i64::MIN;
 
@@ -16,8 +22,7 @@ fn frozen_micros() -> Option<i64> {
 
 pub fn init_from_env() {
     let Ok(s) = std::env::var("TIMEFUSION_FROZEN_TIME") else { return };
-    let t = chrono::DateTime::parse_from_rfc3339(&s).unwrap_or_else(|e| panic!("TIMEFUSION_FROZEN_TIME must be RFC3339 ({s:?}): {e}")).timestamp_micros();
-    set_micros(t);
+    set_micros(chrono::DateTime::parse_from_rfc3339(&s).unwrap_or_else(|e| panic!("TIMEFUSION_FROZEN_TIME must be RFC3339 ({s:?}): {e}")).timestamp_micros());
     tracing::warn!(frozen_at = %s, "TIMEFUSION_FROZEN_TIME set; clock is frozen (test mode)");
 }
 
@@ -187,6 +192,7 @@ pub mod test_helpers {
         datatypes::{DataType, Field, Schema},
         record_batch::RecordBatch,
     };
+    use itertools::Itertools;
     use serde_json::{Value, json};
 
     use crate::{config::AppConfig, schema::get_default_schema};
@@ -200,13 +206,12 @@ pub mod test_helpers {
     pub struct TestConfigBuilder {
         test_name: String,
         buffer_mode: BufferMode,
-        rollups: bool,
         deletion_vectors: bool,
     }
 
     impl TestConfigBuilder {
         pub fn new(test_name: &str) -> Self {
-            Self { test_name: test_name.to_string(), buffer_mode: BufferMode::Enabled, rollups: false, deletion_vectors: true }
+            Self { test_name: test_name.to_string(), buffer_mode: BufferMode::Enabled, deletion_vectors: true }
         }
 
         pub fn with_buffer_mode(mut self, mode: BufferMode) -> Self {
@@ -214,8 +219,9 @@ pub mod test_helpers {
             self
         }
 
-        pub fn with_rollups(mut self) -> Self {
-            self.rollups = true;
+        /// Rollups are unconditional now, so this gates nothing — it stays as a
+        /// declaration of intent at the call sites.
+        pub fn with_rollups(self) -> Self {
             self
         }
 
@@ -234,9 +240,6 @@ pub mod test_helpers {
             let mut cfg = minio_base_config(&id, &format!("/tmp/timefusion-{id}"));
             cfg.buffer.timefusion_flush_immediately = self.buffer_mode == BufferMode::FlushImmediately;
             cfg.maintenance.timefusion_use_deletion_vectors = self.deletion_vectors;
-            // Rollups are unconditional now, so `with_rollups()` no longer gates
-            // anything — it stays as a declaration of intent at the call sites.
-            let _ = self.rollups;
             Arc::new(cfg)
         }
     }
@@ -277,15 +280,15 @@ pub mod test_helpers {
     /// budget-blocked (no DV written, no rewrite) still counts both copies.
     pub async fn delta_physical_row_count(table_ref: &tokio::sync::RwLock<deltalake::DeltaTable>) -> anyhow::Result<i64> {
         let guard = table_ref.read().await;
-        let snapshot = guard.snapshot()?.snapshot().clone();
         // Per active file: numRecords minus its deletion-vector cardinality (the
         // masked rows), same accounting as the dedup verify path in maintain.rs.
-        let live = snapshot.log_data().iter().fold(0i64, |acc, f| {
-            let records = f.num_records().and_then(|n| i64::try_from(n).ok()).unwrap_or(0);
-            let masked = f.deletion_vector_descriptor().map_or(0, |dv| dv.cardinality);
-            acc + records - masked
-        });
-        Ok(live)
+        Ok(guard
+            .snapshot()?
+            .snapshot()
+            .log_data()
+            .iter()
+            .map(|f| f.num_records().and_then(|n| i64::try_from(n).ok()).unwrap_or(0) - f.deletion_vector_descriptor().map_or(0, |dv| dv.cardinality))
+            .sum())
     }
 
     /// Build a BufferedWriteLayer for tests/benches without repeating the registry boilerplate.
@@ -324,17 +327,22 @@ pub mod test_helpers {
                 .fields()
                 .iter()
                 .map(|f| {
-                    let data_type = match f.data_type() {
-                        DataType::Utf8View => DataType::Utf8,
-                        DataType::List(inner) if inner.data_type() == &DataType::Utf8View => DataType::List(Arc::new(Field::new("item", DataType::Utf8, true))),
-                        other => other.clone(),
-                    };
-                    Field::new(f.name(), data_type, f.is_nullable())
+                    Field::new(
+                        f.name(),
+                        match f.data_type() {
+                            DataType::Utf8View => DataType::Utf8,
+                            DataType::List(inner) if inner.data_type() == &DataType::Utf8View => {
+                                DataType::List(Arc::new(Field::new("item", DataType::Utf8, true)))
+                            }
+                            other => other.clone(),
+                        },
+                        f.is_nullable(),
+                    )
                 })
                 .collect::<Vec<_>>(),
         ));
 
-        let json_data = records.iter().map(ToString::to_string).collect::<Vec<_>>().join("\n");
+        let json_data = records.iter().join("\n");
 
         let batch = ReaderBuilder::new(json_read_schema)
             .with_batch_size(records.len().max(1))

--- a/src/tantivy/search.rs
+++ b/src/tantivy/search.rs
@@ -22,6 +22,7 @@ use std::{
 use anyhow::{Context, Result, anyhow};
 use dashmap::DashMap;
 use futures::{StreamExt, TryStreamExt};
+use itertools::Itertools;
 use lru::LruCache;
 use object_store::{ObjectStore, path::Path as ObjPath};
 use parking_lot::Mutex;
@@ -378,7 +379,7 @@ impl TantivySearchService {
             // path. `block_in_place` rather than `spawn_blocking` because the
             // body borrows `self`, `node` and the stats — moving the OTHER
             // tasks off this thread needs no ownership changes at all.
-            let out = crate::support::without_blocking_the_worker(|| {
+            crate::support::without_blocking_the_worker(|| {
                 let (index, reader) = self.open_cached(&dir).with_context(|| format!("open index {file_uuid}"))?;
                 SearchStats::timed(&self.stats.prepares, &self.stats.prepare_us, prepare_started);
                 let started = Instant::now();
@@ -406,8 +407,7 @@ impl TantivySearchService {
                 };
                 SearchStats::timed(&self.stats.searches, &self.stats.search_us, started);
                 Ok::<_, anyhow::Error>(out)
-            })?;
-            Ok::<_, anyhow::Error>(out)
+            })
         }))
         .buffer_unordered(self.config.search_concurrency());
 
@@ -1001,7 +1001,6 @@ fn analyzed_conjunction_query(index: &Index, field: Field, tokenizer: &str, quer
     // WHOLE literal: `default` splits it itself, and `raw` indexes the value as
     // one token, so pre-splitting it would under-match.
     let words: Vec<&str> = if tokenizer == NGRAM3_TOKENIZER { query.split_whitespace().collect() } else { vec![query] };
-    let mut seen: HashSet<String> = HashSet::new();
     let clauses: Vec<(Occur, Box<dyn Query>)> = words
         .iter()
         // Plan-time classification appends `*` for `LIKE 'foo%'`; on a 3-gram
@@ -1014,7 +1013,7 @@ fn analyzed_conjunction_query(index: &Index, field: Field, tokenizer: &str, quer
             analyzer.token_stream(word.trim_end_matches('*')).process(&mut |t| terms.push(t.text.clone()));
             terms
         })
-        .filter(|t| seen.insert(t.clone()))
+        .unique()
         .map(|t| (Occur::Must, Box::new(TermQuery::new(Term::from_field_text(field, &t), IndexRecordOption::Basic)) as Box<dyn Query>))
         .collect();
     if clauses.is_empty() {
@@ -1064,19 +1063,17 @@ pub fn query_with_searcher(searcher: &Searcher, query: &dyn Query, limit: Option
             // `None` = no fast columns for this segment, or this doc carries no
             // value for them (shouldn't happen for required fields) — either way
             // fall back to the doc store.
-            let fast = match cols {
-                Some((ts_col, id_col, ord_col)) => match (ts_col.first(addr.doc_id), id_col.term_ords(addr.doc_id).next()) {
-                    (Some(ts), Some(ord)) => {
-                        id_buf.clear();
-                        id_col.ord_to_str(ord, &mut id_buf).map_err(|e| anyhow!("fast _id read: {e}"))?.then(|| Hit {
-                            timestamp_micros: ts,
-                            id: id_buf.clone(),
-                            row_ordinal: ord_col.as_ref().and_then(|c| c.first(addr.doc_id)),
-                        })
-                    }
-                    _ => None,
-                },
-                None => None,
+            let fast = if let Some((ts_col, id_col, ord_col)) = cols
+                && let (Some(ts), Some(ord)) = (ts_col.first(addr.doc_id), id_col.term_ords(addr.doc_id).next())
+            {
+                id_buf.clear();
+                id_col.ord_to_str(ord, &mut id_buf).map_err(|e| anyhow!("fast _id read: {e}"))?.then(|| Hit {
+                    timestamp_micros: ts,
+                    id: id_buf.clone(),
+                    row_ordinal: ord_col.as_ref().and_then(|c| c.first(addr.doc_id)),
+                })
+            } else {
+                None
             };
             match fast {
                 Some(hit) => Ok(hit),
@@ -1228,24 +1225,6 @@ use crate::{
     write::TantivyIndexCallback,
 };
 
-/// Where the indexed batches came from — fixes both `_row_ordinal` validity
-/// and the merge cadence.
-#[derive(Debug, Clone, Copy)]
-enum IndexSource {
-    /// Flush path: batches are indexed BEFORE the Delta writer's sort, so doc
-    /// order ≠ parquet row order and ordinals must not drive row selection.
-    /// Merging is deferred to keep it off the ingest path.
-    Flush,
-}
-
-impl IndexSource {
-    fn ordinals_and_merge(self) -> (bool, MergeMode) {
-        match self {
-            Self::Flush => (false, MergeMode::Deferred),
-        }
-    }
-}
-
 /// Owns the object store + tantivy config and produces a callback.
 #[derive(Debug)]
 pub struct TantivyIndexService {
@@ -1318,7 +1297,7 @@ impl TantivyIndexService {
             let uuid = Uuid::new_v4().to_string();
             (format!("bucket-{uuid}"), super::blob_path(table_name, project_id, &uuid))
         });
-        self.build_pack_upload(table_name, project_id, &key, path, added_files, batches, IndexSource::Flush).await
+        self.build_pack_upload(table_name, project_id, &key, path, added_files, batches).await
     }
 
     /// Build & publish an index for a single already-committed parquet file,
@@ -1365,14 +1344,14 @@ impl TantivyIndexService {
     /// (index=None, error set) and returns the error. Shared by the flush
     /// callback (random bucket key + flat path) and `build_index_for_file`
     /// (parquet-rel key + partition-mirrored path).
-    // Still 8 with `&self` even after `(ordinals_valid, merge)` folded into
-    // `source`; the rest are independent identifiers, not a cohesive struct.
-    #[allow(clippy::too_many_arguments)]
     async fn build_pack_upload(
         &self, table_name: &str, project_id: &str, manifest_key: &str, blob_path: object_store::path::Path, covered_files: Vec<String>,
-        batches: Vec<arrow::record_batch::RecordBatch>, source: IndexSource,
+        batches: Vec<arrow::record_batch::RecordBatch>,
     ) -> Result<()> {
-        let (ordinals_valid, merge) = source.ordinals_and_merge();
+        // Flush path: batches are indexed BEFORE the Delta writer's sort, so doc
+        // order ≠ parquet row order and ordinals must not drive row selection;
+        // merging is deferred to keep it off the ingest path.
+        let (ordinals_valid, merge) = (false, MergeMode::Deferred);
         let svc_table = crate::schema::get_schema(table_name).with_context(|| format!("schema not found for {table_name}"))?;
         let level = self.config.compression_level();
         let pack_result = tokio::task::spawn_blocking(move || {
@@ -1529,9 +1508,8 @@ impl TantivyIndexService {
             if !removed_rel.iter().all(|u| covered.contains(u)) {
                 return (false, false);
             }
-            let removed_set = &removed_rel;
             let mut touched = false;
-            for e in m.entries.values_mut().filter(|e| usable(e) && e.covered_files.iter().any(|u| removed_set.contains(&rel_of(u)))) {
+            for e in m.entries.values_mut().filter(|e| usable(e) && e.covered_files.iter().any(|u| removed_rel.contains(&rel_of(u)))) {
                 let fresh: Vec<String> = added.iter().filter(|u| !e.covered_files.contains(u)).cloned().collect();
                 e.covered_files.extend(fresh);
                 e.ordinals_valid = false;

--- a/src/tantivy/udf.rs
+++ b/src/tantivy/udf.rs
@@ -47,6 +47,9 @@ pub fn classify_like_pattern(pat: &str, escape: Option<char>, allow_substring: b
     let leading_wildcard = it.next_if_eq(&'%').is_some();
     let mut out = String::new();
     let mut trailing_wildcard = false;
+    // Kept imperative: an invalid char must bail the WHOLE function (`return None`),
+    // while a trailing '%' must merely stop the loop (`break`, out still valid) —
+    // collecting via an iterator adapter conflates those two exits.
     while let Some(c) = it.next() {
         let lit = match c {
             c if c == esc => it.next()?, // trailing escape → bail
@@ -96,20 +99,22 @@ const REGEX_META: &str = ".^$*+?()[]{}|\\";
 /// and therefore bail: prefix/suffix routing over a 3-gram field needs its own
 /// correctness argument and is out of scope here.
 pub fn regex_literal_substring(pat: &str) -> Option<String> {
-    let mut out = String::new();
     let mut it = pat.chars();
-    while let Some(c) = it.next() {
-        let lit = match c {
-            // trailing backslash / non-meta escape (`\d`, `\y`, …) → not a literal
-            '\\' => it.next().filter(|n| REGEX_META.contains(*n))?,
-            c if REGEX_META.contains(c) => return None,
-            c => c,
-        };
-        if !is_tantivy_safe_term_char(lit) {
-            return None;
-        }
-        out.push(lit);
-    }
+    // `Option<char>` items collect into `Option<String>`, short-circuiting on the
+    // first non-literal exactly like the early `return None`s it replaces.
+    let out = std::iter::from_fn(move || {
+        let c = it.next()?;
+        Some(
+            match c {
+                // trailing backslash / non-meta escape (`\d`, `\y`, …) → not a literal
+                '\\' => it.next().filter(|n| REGEX_META.contains(*n)),
+                c if REGEX_META.contains(c) => None,
+                c => Some(c),
+            }
+            .filter(|c| is_tantivy_safe_term_char(*c)),
+        )
+    })
+    .collect::<Option<String>>()?;
     (!out.is_empty()).then_some(out)
 }
 
@@ -122,16 +127,14 @@ pub fn regex_literal_substring(pat: &str) -> Option<String> {
 /// original predicate still post-filters).
 pub fn classify_deferred(kind: &str, value: &str) -> Option<String> {
     use crate::tantivy::{NGRAM3_TOKENIZER, RAW_TOKENIZER};
-    if kind == "eq" {
-        return (!value.is_empty() && value.chars().all(is_eq_term_safe)).then(|| value.to_string());
-    }
-    let (form, tok) = kind.split_once(':')?;
-    match form {
-        "ilike" if tok == RAW_TOKENIZER => return None, // case-sensitive single token can't serve ILIKE
-        "like" | "ilike" => {}
+    let Some((form, tok)) = kind.split_once(':') else {
+        return (kind == "eq" && !value.is_empty() && value.chars().all(is_eq_term_safe)).then(|| value.to_string());
+    };
+    let allow_substring = match (form, tok) {
+        ("ilike", t) if t == RAW_TOKENIZER => return None, // case-sensitive single token can't serve ILIKE
+        ("like" | "ilike", t) => t == NGRAM3_TOKENIZER,
         _ => return None,
-    }
-    let allow_substring = tok == NGRAM3_TOKENIZER;
+    };
     let q = classify_like_pattern(value, None, allow_substring)?;
     (!allow_substring || q.chars().filter(|c| *c != '*').count() >= NGRAM_MIN_QUERY_LEN).then_some(q)
 }
@@ -172,27 +175,21 @@ impl ScalarUDFImpl for TextMatchUdf {
         let kind: Option<String> = arrs.get(2).filter(|a| !a.is_empty()).and_then(|a| string_extractor(a)(0));
         let out: BooleanArray = (0..n)
             .map(|i| {
-                Some(match (col_str(i), pat_str(i)) {
-                    (Some(haystack), Some(needle)) => match kind.as_deref() {
-                        Some(k) => deferred_row_matches(k, &needle, &haystack),
-                        // 2-arg: plan-time-classified tantivy syntax
-                        // (`'foo*'` prefix, `'foo'` substring on ngram3);
-                        // strip wildcards and require token containment.
-                        None => {
-                            let h_low = haystack.to_lowercase();
-                            needle
-                                .to_lowercase()
-                                .split_whitespace()
-                                .map(|tok| tok.trim_matches(|c: char| c == '*' || c == '?'))
-                                .all(|tok| !tok.is_empty() && h_low.contains(tok))
-                        }
-                    },
-                    _ => false,
-                })
+                Some(col_str(i).zip(pat_str(i)).is_some_and(|(haystack, needle)| {
+                    kind.as_deref().map_or_else(|| tantivy_tokens_contained(&needle, &haystack), |k| deferred_row_matches(k, &needle, &haystack))
+                }))
             })
             .collect();
         Ok(ColumnarValue::Array(Arc::new(out) as ArrayRef))
     }
+}
+
+/// Row eval of a 2-arg (plan-time-classified) text_match: the query is tantivy
+/// syntax (`'foo*'` prefix, `'foo'` substring on ngram3), so strip wildcards and
+/// require every token to be contained, case-insensitively.
+fn tantivy_tokens_contained(query: &str, haystack: &str) -> bool {
+    let h_low = haystack.to_lowercase();
+    query.to_lowercase().split_whitespace().map(|tok| tok.trim_matches(|c: char| c == '*' || c == '?')).all(|tok| !tok.is_empty() && h_low.contains(tok))
 }
 
 /// Row-level evaluation of a DEFERRED (3-arg) text_match: a SUPERSET of the
@@ -414,26 +411,29 @@ fn expr_node(e: &datafusion::logical_expr::Expr) -> NodeRes {
 mod tests {
     use super::*;
 
-    #[test]
-    fn deferred_like_row_eval_is_a_superset_of_sql_like() {
-        // `_` and embedded `%` — the shapes the old substring row-eval dropped.
-        assert!(like_match_ci("a_c", "abc"));
-        assert!(!like_match_ci("a_c", "abbc"));
-        assert!(like_match_ci("foo%bar", "fooXbar"));
-        assert!(like_match_ci("foo%bar", "foobar"));
-        assert!(!like_match_ci("foo%bar", "fooba"));
-        assert!(like_match_ci("%user_id%", "xuserXidz"));
-        assert!(like_match_ci("%foo%", "afoob"));
-        assert!(like_match_ci("foo", "FOO"), "case-insensitive superset of LIKE");
-        assert!(!like_match_ci("foo", "food"), "no wildcard = exact length");
-        assert!(like_match_ci("a\\_c", "a_c"), "escaped underscore is literal");
-        assert!(!like_match_ci("a\\_c", "abc"));
-        assert!(like_match_ci("%", ""));
-        assert!(!like_match_ci("_", ""));
+    // `_` and embedded `%` — the shapes the old substring row-eval dropped.
+    #[test_case::test_case("a_c", "abc" => true)]
+    #[test_case::test_case("a_c", "abbc" => false)]
+    #[test_case::test_case("foo%bar", "fooXbar" => true)]
+    #[test_case::test_case("foo%bar", "foobar" => true)]
+    #[test_case::test_case("foo%bar", "fooba" => false)]
+    #[test_case::test_case("%user_id%", "xuserXidz" => true)]
+    #[test_case::test_case("%foo%", "afoob" => true)]
+    #[test_case::test_case("foo", "FOO" => true ; "case-insensitive superset of LIKE")]
+    #[test_case::test_case("foo", "food" => false ; "no wildcard = exact length")]
+    #[test_case::test_case("a\\_c", "a_c" => true ; "escaped underscore is literal")]
+    #[test_case::test_case("a\\_c", "abc" => false ; "escaped underscore does not match any char")]
+    #[test_case::test_case("%", "" => true)]
+    #[test_case::test_case("_", "" => false)]
+    fn like_ci_is_a_superset_of_sql_like(pattern: &str, text: &str) -> bool {
+        like_match_ci(pattern, text)
+    }
 
-        assert!(deferred_row_matches("eq", "abc", "xxabcyy"), "eq → containment superset");
-        assert!(deferred_row_matches("like:tf_ngram3", "%a_b%", "zzaXbzz"));
-        assert!(!deferred_row_matches("like:tf_ngram3", "%a_b%", "zzabzz"));
+    #[test_case::test_case("eq", "abc", "xxabcyy" => true ; "eq → containment superset")]
+    #[test_case::test_case("like:tf_ngram3", "%a_b%", "zzaXbzz" => true)]
+    #[test_case::test_case("like:tf_ngram3", "%a_b%", "zzabzz" => false)]
+    fn deferred_row_eval_reproduces_the_original_predicate(kind: &str, value: &str, haystack: &str) -> bool {
+        deferred_row_matches(kind, value, haystack)
     }
 
     #[test]


### PR DESCRIPTION
Final `rs-distill` groups — `server/`, `tantivy/`, `config.rs`, `storage.rs`,
`schema.rs`, `observability.rs`, `dml.rs`, `main.rs`, `support.rs` — plus
follow-up consolidation across the groups already merged in #233.

**20 files, 1029 insertions / 1497 deletions — a net 468 lines removed.**

Mostly code that did not need to exist, rather than pipeline rewrites:

- `strum::IntoStaticStr` / `EnumCount` on `Operation`, replacing hand-written
  variant-to-string and variant-count code
- dead code deleted: `fair_ready_tasks`, `ReadyGroups`, `Operation::priority`
  (its ordering tests retargeted at `scheduling_class`)
- one poison-tolerant lock helper instead of the same recover-or-panic repeated
- `Deref` derived on `Watched`; `DerivedBudget::log` as an inherent method
- Add stats parsed once instead of once per field

## Two deliberate non-changes

- **`partition_file_fp` keeps its exact hash form** (`to_vec` → `sort` → hash)
  while gaining a slice parameter. That fingerprint is persisted in
  certification records, so a tidier rewrite would silently invalidate every
  stored fingerprint in production.
- **`src/tantivy/mod.rs` is not distilled.** The sweep ran against a pre-#230
  tree, so its version of this file reverted `element_fields` on
  `IndexBuildStats` and the newer `m.insert` manifest API. Master's version is
  kept intact; distilling it should be redone against current master.

## Verification

Full five-check gate green on this exact tree after rebasing onto `e44e08cd`:
fmt, clippy, test (1506 passed, 17 skipped), pg-smoke, e2e (63 passed).
Attestations published for each, so CI's gate can reuse them.