### PR TITLE
Start Tantivy backfill automatically

### DIFF
--- a/docs/plans/2026-09-09-automatic-hash-backfill-review.md
+++ b/docs/plans/2026-09-09-automatic-hash-backfill-review.md
@@ -1,0 +1,82 @@
+# Automatic startup hash backfill
+
+Production dd5647f deployed successfully through run 34343939580. Its saved
+SQL smoke probe completed eight of sixteen comparison pairs with no mismatch;
+the day/week cases timed out. Histogram completion counters remained zero.
+That result does not establish fast native execution.
+
+The new task logged active Tantivy indexing and a coverage census of 2,281
+uncovered files (218 today, 1,339 in the last week, 724 older). It did not log
+a startup backfill. Inspection found a remaining boolean opt-in:
+timefusion_tantivy_backfill defaults to false, and the production service has
+no corresponding environment entry. Scheduled reconciliation still runs.
+The startup gate conflicts with the user's instruction to avoid unnecessary
+knobs and let indexing run automatically.
+
+The regression uses deserialized production Tantivy defaults, real MinIO,
+a committed historical Parquet file, and a fresh empty index manifest.
+It requires startup to publish physical element coverage and then requires
+an actual SQL hash histogram to return one event through the native route.
+The two identical array elements must count once.
+
+The red run failed in 10.340 seconds with: default startup must publish a
+physical hash index without an opt-in. The run exited 100; no passing
+attestation was published. Log: /tmp/timefusion-startup-backfill-red.log.
+
+Implementation removes the boolean field and its conditional return.
+An attached indexer now always starts the existing bounded backfill pass.
+A shared per-table semaphore prevents startup and scheduled passes from
+building the same table concurrently. Other tables keep their independent
+budgets and can still progress. Skipped duplicate passes emit a named event.
+File-count, byte, age-selection, and build-concurrency bounds are retained.
+
+First rs-distill pass: reuse the existing backfill path and Semaphore;
+there is no new scheduler, index format, configuration option, or copy of
+the indexing implementation. The admission map has one entry per table.
+
+First rs-evasion pass: the semaphore is an internal resource guard, not an
+opt-out. Its OwnedSemaphorePermit spans the pass; the DashMap entry guard is
+dropped before I/O. Errors and cancellation release admission automatically.
+Skipping duplicate work does not claim coverage; the next census still
+checks manifests. The failed real regression remains enabled.
+
+Second scoped review: startup and cron share the same Database admission
+map through Arc clones. The check sits inside backfill_table_indexes so
+both callers are covered. Existing manifest publication and index-reader
+seeding remain unchanged. No warnings, tests, or type contracts are weakened.
+Green regression, full local signoff, and production verification remain
+pending. This change alone does not prove all historical coverage or the
+release latency targets have been met.
+
+The regression now passes in 0.663 seconds, nextest run
+d60c3e3b-20c5-4a9f-a880-c42ded26e2bf. The default-startup index is physical,
+contains the required element field, and answers the exact SQL count.
+Full local signoff remains required before push. The known production
+smoke failure and broader performance gaps remain open.
+
+Local signoff follow-up: formatting, Clippy, the 1,508-test suite, ten
+doctests, and PostgreSQL smoke have passed and published matching attestations.
+The suite reported one flaky test: shutdown_writes_clean_snapshot_under_deadline
+failed on its first attempt because the cursor snapshot was absent, then
+passed on the configured retry. A separate nextest run with --stress-count 10
+and --retries 0 passed all ten iterations in 8.883 seconds. The first failure
+is retained as evidence; this does not establish that the timing issue is fixed.
+The shutdown code is unchanged by this patch. Its one-second test grace gives
+the snapshot at most 200 ms after the deliberately hung flush; runtime and
+filesystem scheduling can exhaust that budget. Production shutdown uses the
+configured grace and falls back to durable WAL replay when no snapshot exists.
+No deadline, assertion, retry policy, or source contract was weakened.
+
+Commands used the isolated /tmp/timefusion-isolated-target cache:
+- make ci-signoff (full check still running through end-to-end tests).
+- cargo nextest run --locked -E 'test(shutdown_writes_clean_snapshot_under_deadline)' --stress-count 10 --retries 0.
+
+The current production chart handler still exceeds a 12-second client
+deadline on the saved issue day/week windows. Automatic startup backfill
+is a required coverage fix, not proof that those latency gaps are resolved.
+
+Final local signoff completed with exit 0. All five checks have matching
+published attestations; no checks remain for GitHub. End-to-end nextest run
+830909b0-4b71-4ce0-a3c1-7574152c14cc passed all 63 tests in 255.558 seconds
+(four slow, no retry). Full log: /tmp/timefusion-automatic-backfill-signoff.log.
+The main-suite flaky result above remains part of the signoff record.

--- a/src/config.rs
+++ b/src/config.rs
@@ -884,12 +884,6 @@ pub struct TantivyConfig {
     /// bloom/stats-only equality pruning.
     #[serde_inline_default(true)]
     pub timefusion_tantivy_route_equality: bool,
-    /// Startup backfill: build partition-mirrored indexes for live parquet
-    /// files no manifest entry covers (pre-tantivy history, failed builds,
-    /// files landed while the feature was off). Oldest-first, bounded
-    /// concurrency. Off by default — reads every uncovered file back from S3.
-    #[serde(default)]
-    pub timefusion_tantivy_backfill: bool,
     /// Concurrent index builds during backfill/reconcile/post-optimize
     /// reindex. 2 is safe alongside prod query load; the off-box repair CLI
     /// raises it (each 1 GB parquet takes ~2-3 min to index).

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -3005,6 +3005,8 @@ pub struct Database {
     /// At most one query-triggered proof build, including time waiting for the
     /// shared count-builder budget. Admission never queues query requests.
     histogram_proof_build: Arc<histogram::HistogramProofBuilds>,
+    /// Startup and scheduled backfill share one pass per indexed table.
+    tantivy_backfill_slots: Arc<dashmap::DashMap<String, Arc<tokio::sync::Semaphore>>>,
     /// Last snapshot-persist time per table URL; throttles `persist_snapshot`.
     /// The on-disk snapshot is only a boot-recovery seed, so staleness just
     /// means boot replays a few more sub-second commits.
@@ -3740,6 +3742,7 @@ impl Database {
             histogram_dml: Arc::new(dashmap::DashMap::new()),
             histogram_delta: Arc::new(histogram::HistogramDeltaCache::default()),
             histogram_proof_build: Arc::new(histogram::HistogramProofBuilds::default()),
+            tantivy_backfill_slots: Default::default(),
             snapshot_persist_gate: Arc::new(dashmap::DashMap::new()),
             buffered_layer: Arc::new(std::sync::OnceLock::new()),
             bypass_buffer: false,
@@ -3841,16 +3844,13 @@ impl Database {
         self.bloom_prune.get().filter(|_| self.config.maintenance.timefusion_file_bloom_pruning)
     }
 
-    /// Startup backfill (gated on `timefusion_tantivy_backfill`): build
+    /// Automatically backfill existing files when an indexer is attached: build
     /// partition-mirrored indexes for live parquet files that no successful
     /// manifest entry covers, newest partition first. Every covered file
     /// widens the windows where the coverage gate lets the prefilter engage
     /// (pre-tantivy history, failed builds, pre-reindex compactions).
     pub fn spawn_tantivy_backfill(&self) {
         let Some(svc) = self.tantivy_indexer().cloned() else { return };
-        if !self.config.tantivy.timefusion_tantivy_backfill {
-            return;
-        }
         let db = self.clone();
         tokio::spawn(async move {
             for table_name in svc.config.indexed_tables() {
@@ -4196,6 +4196,11 @@ impl Database {
 
     async fn backfill_table_indexes(&self, svc: &Arc<crate::tantivy::search::TantivyIndexService>, table_name: &str) -> anyhow::Result<usize> {
         use crate::tantivy::search::parquet_rel_of_uri;
+        let slot = self.tantivy_backfill_slots.entry(table_name.to_owned()).or_insert_with(|| Arc::new(tokio::sync::Semaphore::new(1))).clone();
+        let Ok(_pass) = slot.try_acquire_owned() else {
+            info!(table_name, event = "tantivy_backfill_already_active");
+            return Ok(0);
+        };
         // Unified table ("default") holds every default-routed project's
         // files; custom project tables are resolved separately.
         let mut roots: Vec<String> = vec!["default".into()];

--- a/tests/suite/tantivy_e2e_test.rs
+++ b/tests/suite/tantivy_e2e_test.rs
@@ -878,3 +878,48 @@ async fn uncovered_live_file_uses_hybrid_prefilter_without_dropping_rows() -> Re
     assert_eq!(r_on, vec!["c1".to_string(), "c2".to_string()], "both matching rows survive the coverage gate");
     Ok(())
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn startup_backfills_existing_hashes_without_an_opt_in() -> Result<()> {
+    use timefusion::support::test_helpers::{json_to_batch_for, minio_test_config};
+
+    let dir = tempfile::tempdir()?;
+    let project = unique_project();
+    let mut config = (*minio_test_config(&project, dir.path().to_str().unwrap())).clone();
+    config.tantivy = serde_json::from_str("{}")?;
+    let config = Arc::new(config);
+    let db = Database::with_config(config.clone()).await?;
+    let uri = format!("s3://timefusion-tests/{}/tantivy", config.core.timefusion_table_prefix);
+    let store = db.create_object_store(&uri, &config.aws.build_storage_options(None)).await?;
+    let indexer = Arc::new(TantivyIndexService::new(store.clone(), Arc::new(config.tantivy.clone())));
+    let search = Arc::new(TantivySearchService::new(store.clone(), dir.path().join("indexes"), Arc::new(config.tantivy.clone())));
+    indexer.with_reader(&search);
+    let db = Arc::new(db.with_tantivy_indexer(indexer).with_tantivy_search(search.clone()));
+    let table = "mor_versioned";
+    let timestamp = chrono::Utc::now() - chrono::Duration::days(2);
+    let row = json!({"project_id": project, "id": "existing", "timestamp": timestamp.timestamp_micros(), "date": timestamp.date_naive().to_string(), "hashes": ["needle", "needle"]});
+    db.insert_records_batch(&project, table, vec![json_to_batch_for(table, vec![row])?], true, None).await?;
+    assert!(timefusion::tantivy::load_manifest(store.as_ref(), table, &project).await?.entries.is_empty());
+    db.spawn_tantivy_backfill();
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
+    loop {
+        let manifest = timefusion::tantivy::load_manifest(store.as_ref(), table, &project).await?;
+        if manifest.entries.values().any(|entry| entry.covers_current_elements(timefusion::schema::get_schema(table).unwrap())) {
+            break;
+        }
+        anyhow::ensure!(tokio::time::Instant::now() < deadline, "default startup must publish a physical hash index without an opt-in");
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+    let mut ctx = db.clone().create_session_context();
+    db.setup_session_context(&mut ctx)?;
+    let sql = format!(
+        "SELECT time_bucket('1 hour', timestamp), count(*) FROM {table} WHERE project_id='{project}' AND timestamp >= TIMESTAMP '{}' AND timestamp < TIMESTAMP '{}' AND hashes @> ARRAY['needle'] GROUP BY 1",
+        timestamp.format("%Y-%m-%d %H:%M:%S%.6f"),
+        (timestamp + chrono::Duration::microseconds(1)).format("%Y-%m-%d %H:%M:%S%.6f")
+    );
+    let result = ctx.sql(&sql).await?.collect().await?;
+    assert_eq!(result.iter().flat_map(|batch| batch.column(1).as_primitive::<arrow::datatypes::Int64Type>().values()).sum::<i64>(), 1);
+    assert_eq!(search.stats.histogram_snapshots.load(std::sync::atomic::Ordering::Relaxed), 1, "backfilled hashes must reach native SQL counting");
+    db.shutdown().await?;
+    Ok(())
+}


### PR DESCRIPTION
Production starts with Tantivy enabled but skips historical backfill unless a separate boolean opt-in is set. Remove that opt-in so an attached indexer always starts the existing bounded pass. Startup and scheduled backfill share per-table admission to avoid overlapping passes. The real MinIO regression verifies that production defaults build physical hash coverage and count duplicate array elements once through native SQL.

Two rs-distill and rs-evasion review passes are recorded in docs/plans/2026-09-09-automatic-hash-backfill-review.md. Existing byte, file-count, and concurrency bounds remain in effect.

Local validation uses CARGO_TARGET_DIR=/tmp/timefusion-isolated-target:

- make ci-signoff: exit 0. Formatting, Clippy, 1,508 tests, ten doctests, PostgreSQL smoke, and all 63 end-to-end tests passed. All five attestations published; no checks remain for GitHub. End-to-end tests took 255.558 seconds with four slow tests and no retries.
- The new regression failed before the fix, then passed in 0.663 seconds.
- The main suite passed 1,508 tests in 121.706 seconds with one shutdown-snapshot test passing on retry. Ten follow-up runs of that test with --stress-count 10 --retries 0 all passed; the original timing failure is retained in the review record.

Production day/week SQL and chart latency remains unresolved. This patch enables automatic startup progress; deployment and production coverage checks must establish its behavior.
