### PR TITLE
Cross-compile production images in local signoff and share deployment checks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,9 @@ concurrency:
   group: deploy-master
   cancel-in-progress: false
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-24.04
@@ -62,7 +65,17 @@ jobs:
           # This workflow only runs on master push, so :latest == latest master.
           echo "IMAGE_LATEST=${REPO}:latest" >> $GITHUB_ENV
 
+      - name: Find locally signed-off image
+        id: candidate
+        run: |
+          if image="$(python3 scripts/production-image.py resolve)"; then
+            echo "image=$image" >> "$GITHUB_OUTPUT"
+          else
+            echo "No matching published candidate; building the production image here"
+          fi
+
       - name: Build and Push Docker Image
+        if: steps.candidate.outputs.image == ''
         uses: docker/build-push-action@v5
         with:
           context: .
@@ -74,37 +87,21 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      # Pull the published image and verify the binary actually starts.
-      # We previously shipped images that exited at the dynamic linker
-      # (GLIBC mismatch from a builder/runtime base skew) because nothing
-      # between "image pushed" and "CapRover deploys it" had ever executed
-      # the binary. With TIMEFUSION_ALLOW_INSECURE_AUTH the process can
-      # boot without secrets, reach the PGWire listen call, then we kill
-      # it. SIGTERM via `timeout` exits 124; anything else means the
-      # binary crashed and we must NOT deploy it.
-      - name: Smoke test pushed image
+      - name: Promote locally built image
+        if: steps.candidate.outputs.image != ''
+        env:
+          CANDIDATE_IMAGE: ${{ steps.candidate.outputs.image }}
         run: |
-          docker pull "$IMAGE_URL"
-          set +e
-          docker run -d \
-            -e TIMEFUSION_ALLOW_INSECURE_AUTH=true \
-            -e AWS_S3_BUCKET=smoke -e AWS_REGION=us-east-1 \
-            -e AWS_ACCESS_KEY_ID=smoke -e AWS_SECRET_ACCESS_KEY=smoke \
-            -e RUST_LOG=info \
-            --name tf-smoke "$IMAGE_URL"
-          trap 'docker rm -f tf-smoke >/dev/null 2>&1 || true' EXIT
-          # Give it 12s to reach the PGWire listen log; then kill.
-          for i in $(seq 1 12); do
-            if docker logs tf-smoke 2>&1 | grep -Eq \
-              "(Listening on|Bound PGWire listener on) 0.0.0.0:5432"; then
-              echo "smoke: PGWire listening, image OK"
-              exit 0
-            fi
-            sleep 1
-          done
-          echo "smoke: binary never reached PGWire listen — last logs:"
-          docker logs tf-smoke 2>&1 | tail -40
-          exit 1
+          docker buildx imagetools create --tag "$IMAGE_URL" --tag "$IMAGE_LATEST" "$CANDIDATE_IMAGE"
+
+      # Pin the digest before smoke and deployment. Moving a tag afterward must
+      # never make CapRover deploy bytes different from the tested image.
+      - name: Smoke test production image
+        run: |
+          image="$(python3 scripts/production-image.py digest "$IMAGE_URL")"
+          docker pull "$image"
+          python3 scripts/production-image.py smoke "$image"
+          echo "IMAGE_URL=$image" >> "$GITHUB_ENV"
 
       # Install the same CLI used by caprover/deploy-from-github@v1.1.2 before
       # starting the handoff clock. Pin it: the upstream action installs an
@@ -113,278 +110,10 @@ jobs:
       - name: Install CapRover deploy client
         run: npm install --global caprover@2.3.1
 
-      # First pay the large backlog flush while reads+writes remain online.
-      # New binaries then HANDOFF-fence writes and drain only arrivals from that
-      # online flush; SIGTERM becomes local snapshot-only. Old binaries use the
-      # successful FLUSH as the compatibility path for the first rollout.
-      - name: Prepare production handoff
-        id: handoff
-        env:
-          PGURL: ${{ secrets.TIMEFUSION_PG_URL }}
-        run: |
-          set -euo pipefail
-          : "${PGURL:?TIMEFUSION_PG_URL GitHub Actions secret is required}"
-          # Best-effort pre-deploy flush. The unflushed tail is WAL-durable and the
-          # replacement replays it, so this must NOT fail the deploy when prod is
-          # unreachable — most often it's mid-boot from the *previous* deploy
-          # (psql: "the database system is starting up"). Failing here deadlocked
-          # every deploy after a slow boot (2026-07-20). Retry briefly, then proceed.
-          # timeout: a hung psql (e.g. protocol negotiation with newer psql,
-          # which needs max_protocol_version=3.0 against TF, or a wedged FLUSH)
-          # otherwise pins attempt 1 forever and the retry loop never runs
-          # (2026-07-30: flush step sat 25+ min on a single psql call).
-          # PGMAXPROTOCOLVERSION: env form (not URI param) — older libpq ignores
-          # unknown env vars but rejects unknown URI params.
-          export PGMAXPROTOCOLVERSION=3.0
-          flush_ok=false
-          for attempt in $(seq 1 3); do
-            if timeout 300 psql "$PGURL" -v ON_ERROR_STOP=1 -c 'FLUSH' 2>&1; then
-              echo "online flush ok (attempt $attempt)"
-              flush_ok=true
-              break
-            fi
-            echo "flush attempt $attempt failed or timed out; retrying in 15s"
-            sleep 15
-          done
-          if timeout 300 psql "$PGURL" -v ON_ERROR_STOP=1 -c 'HANDOFF' 2>&1; then
-            echo "write-fenced tail drain ready; production remains read-available"
-            echo "drained=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          if $flush_ok; then
-            echo "HANDOFF unsupported by outgoing binary; using successful FLUSH compatibility path"
-            echo "drained=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          echo "drained=false" >> "$GITHUB_OUTPUT"
-          echo "::warning::neither pre-deploy FLUSH nor HANDOFF succeeded; proceeding (tail is WAL-durable, replay will recover it)"
-
-      - name: Record production boot
-        id: production_before
-        env:
-          PGURL: ${{ secrets.TIMEFUSION_PG_URL }}
-        run: |
-          set -euo pipefail
-          : "${PGURL:?TIMEFUSION_PG_URL GitHub Actions secret is required}"
-          boot_micros="$(psql "$PGURL" -v ON_ERROR_STOP=1 -Atqc "SELECT value FROM timefusion_stats WHERE component = 'buffered_layer' AND key = 'boot_micros'" || true)"
-          last_old_response_epoch_ms="$(date +%s%3N)"
-          echo "boot_micros=${boot_micros}" >> "$GITHUB_OUTPUT"
-          echo "last_old_response_epoch_ms=${last_old_response_epoch_ms}" >> "$GITHUB_OUTPUT"
-          # Record total rollout wall time separately from the concurrent SQL
-          # probe's actual client-visible unready interval.
-          echo "handoff_started_epoch_ms=$(date +%s%3N)" >> "$GITHUB_OUTPUT"
-
-      - id: deploy
-        name: Deploy Image to CapRover
+      - name: Deploy and verify production
         env:
           CAPROVER_SERVER: ${{ secrets.CAPTAINROVER_SERVER }}
           CAPROVER_APP: ${{ secrets.CAPTAINROVER_APP_NAME }}
           CAPROVER_TOKEN: ${{ secrets.CAPTAINROVER_APP_TOKEN }}
           PGURL: ${{ secrets.TIMEFUSION_PG_URL }}
-          PREVIOUS_BOOT_MICROS: ${{ steps.production_before.outputs.boot_micros }}
-          LAST_OLD_RESPONSE_EPOCH_MS: ${{ steps.production_before.outputs.last_old_response_epoch_ms }}
-        run: |
-          set -euo pipefail
-          : "${CAPROVER_SERVER:?CAPTAINROVER_SERVER is required}"
-          : "${CAPROVER_APP:?CAPTAINROVER_APP_NAME is required}"
-          : "${CAPROVER_TOKEN:?CAPTAINROVER_APP_TOKEN is required}"
-          : "${PGURL:?TIMEFUSION_PG_URL is required}"
-          export PGMAXPROTOCOLVERSION=3.0
-
-          # Measure client-visible unavailability concurrently with the opaque
-          # CapRover rollout. Total deploy wall time includes image pull while
-          # the old task is healthy; it is not database downtime. Persist the
-          # longest continuous SELECT failure interval for the verification
-          # step instead.
-          probe_dir="$(mktemp -d)"
-          probe_stop="$probe_dir/stop"
-          probe_result="$probe_dir/max_unready_ms"
-          handoff_result="$probe_dir/query_handoff_ms"
-          (
-            unready_started_ms=0
-            max_unready_ms=0
-            # The preceding step already proved this exact old boot answered a
-            # query. Seed from that timestamp so a very short handoff remains
-            # measurable even when the first concurrent sample hits 57P03.
-            last_old_response_ms="$LAST_OLD_RESPONSE_EPOCH_MS"
-            query_handoff_ms=0
-            while [ ! -e "$probe_stop" ]; do
-              attempt_started_ms="$(date +%s%3N)"
-              responding_boot="$(timeout 1 psql "$PGURL" -v ON_ERROR_STOP=1 -Atqc "SELECT value FROM timefusion_stats WHERE component = 'buffered_layer' AND key = 'boot_micros'" 2>/dev/null || true)"
-              if [ -n "$responding_boot" ]; then
-                if (( unready_started_ms > 0 )); then
-                  interval_ms=$(( $(date +%s%3N) - unready_started_ms ))
-                  (( interval_ms > max_unready_ms )) && max_unready_ms=$interval_ms
-                  unready_started_ms=0
-                fi
-                if [ "$responding_boot" = "$PREVIOUS_BOOT_MICROS" ]; then
-                  last_old_response_ms="$(date +%s%3N)"
-                elif (( query_handoff_ms == 0 )); then
-                  query_handoff_ms=$(( $(date +%s%3N) - last_old_response_ms ))
-                fi
-              elif (( unready_started_ms == 0 )); then
-                unready_started_ms="$attempt_started_ms"
-              fi
-              sleep 0.1
-            done
-            if (( unready_started_ms > 0 )); then
-              interval_ms=$(( $(date +%s%3N) - unready_started_ms ))
-              (( interval_ms > max_unready_ms )) && max_unready_ms=$interval_ms
-            fi
-            echo "$max_unready_ms" > "$probe_result"
-            echo "$query_handoff_ms" > "$handoff_result"
-          ) &
-          probe_pid=$!
-          stop_probe() {
-            touch "$probe_stop"
-            wait "$probe_pid"
-          }
-          trap stop_probe EXIT
-
-          # The image is already built, pushed, pulled by the smoke test, and
-          # the outgoing process is HANDOFF-drained when supported. Submit the
-          # Swarm update immediately so the leased fence cannot expire. The
-          # first compatibility rollout may use FLUSH; its shutdown path still
-          # fences and drains any tail with the full correctness budget.
-          caprover deploy \
-            --caproverUrl "$CAPROVER_SERVER" \
-            --appToken "$CAPROVER_TOKEN" \
-            --appName "$CAPROVER_APP" \
-            -i "$IMAGE_URL" >caprover-deploy.log 2>&1 &
-          deploy_pid=$!
-
-          deploy_status=0
-          wait "$deploy_pid" || deploy_status=$?
-
-          # CapRover can return after it has submitted the Swarm update but
-          # before the replacement owns PGWire. Keep the concurrent probe alive
-          # until a query proves that a DIFFERENT boot completed recovery;
-          # otherwise stopping it here reports a false 0ms outage.
-          replacement_deadline=$((SECONDS + 720))
-          while (( deploy_status == 0 && SECONDS < replacement_deadline )); do
-            boot_micros="$(timeout 3 psql "$PGURL" -v ON_ERROR_STOP=1 -Atqc "SELECT value FROM timefusion_stats WHERE component = 'buffered_layer' AND key = 'boot_micros'" 2>/dev/null || true)"
-            recovery_complete="$(timeout 3 psql "$PGURL" -v ON_ERROR_STOP=1 -Atqc "SELECT value FROM timefusion_stats WHERE component = 'wal' AND key = 'recovery_complete'" 2>/dev/null || true)"
-            if [ -n "$boot_micros" ] && [ "$boot_micros" != "$PREVIOUS_BOOT_MICROS" ] && [ "$recovery_complete" = true ]; then
-              break
-            fi
-            sleep 0.5
-          done
-          stop_probe
-          trap - EXIT
-          observed_unready_ms="$(cat "$probe_result")"
-          query_handoff_ms="$(cat "$handoff_result")"
-          echo "observed_unready_ms=$observed_unready_ms" >> "$GITHUB_OUTPUT"
-          echo "query_handoff_ms=$query_handoff_ms" >> "$GITHUB_OUTPUT"
-          cat caprover-deploy.log
-          (( deploy_status == 0 )) || exit "$deploy_status"
-
-      - name: Verify production recovery
-        env:
-          PGURL: ${{ secrets.TIMEFUSION_PG_URL }}
-          PREVIOUS_BOOT_MICROS: ${{ steps.production_before.outputs.boot_micros }}
-          HANDOFF_STARTED_EPOCH_MS: ${{ steps.production_before.outputs.handoff_started_epoch_ms }}
-          OBSERVED_UNREADY_MS: ${{ steps.deploy.outputs.observed_unready_ms }}
-          QUERY_HANDOFF_MS: ${{ steps.deploy.outputs.query_handoff_ms }}
-          # A planned deploy is pre-flushed. Exact local cursor/tail equality
-          # now skips both Delta reconciliation and replay, so minutes-class
-          # recovery is a regression, not an expected operating mode.
-          MAX_WAL_RECOVERY_MS: '5000'
-          # Whether the OUTGOING process reported a drained WAL before the
-          # rollout. Only then is a ~0ms recovery a promise rather than a hope.
-          PREFLUSHED_HANDOFF: ${{ steps.handoff.outputs.drained }}
-          MAX_READY_WAIT_SECS: '10'
-          RECOVERY_WAIT_SECS: '720'
-        run: |
-          set -euo pipefail
-          : "${PGURL:?TIMEFUSION_PG_URL GitHub Actions secret is required}"
-          export PGMAXPROTOCOLVERSION=3.0
-          boot_micros=""
-          recovery_complete=""
-          recovery_ms=""
-          deadline=$((SECONDS + RECOVERY_WAIT_SECS))
-          while (( SECONDS < deadline )); do
-            if ! timeout 5 psql "$PGURL" -v ON_ERROR_STOP=1 -Atqc 'SELECT 1' >/dev/null 2>&1; then
-              sleep 2
-              continue
-            fi
-            boot_micros="$(timeout 5 psql "$PGURL" -v ON_ERROR_STOP=1 -Atqc "SELECT value FROM timefusion_stats WHERE component = 'buffered_layer' AND key = 'boot_micros'" || true)"
-            recovery_complete="$(timeout 5 psql "$PGURL" -v ON_ERROR_STOP=1 -Atqc "SELECT value FROM timefusion_stats WHERE component = 'wal' AND key = 'recovery_complete'" || true)"
-            recovery_ms="$(timeout 5 psql "$PGURL" -v ON_ERROR_STOP=1 -Atqc "SELECT value FROM timefusion_stats WHERE component = 'wal' AND key = 'recovery_duration_ms'" || true)"
-            if [ -n "$boot_micros" ] && [ "$boot_micros" != "$PREVIOUS_BOOT_MICROS" ] && [ "$recovery_complete" = true ] && [[ "$recovery_ms" =~ ^[0-9]+$ ]]; then
-              ready_elapsed_ms=$(( $(date +%s%3N) - HANDOFF_STARTED_EPOCH_MS ))
-              ready_wait=$(( (ready_elapsed_ms + 999) / 1000 ))
-              echo "rollout measurement: total ${ready_elapsed_ms}ms; last-old-query to first-new-query ${QUERY_HANDOFF_MS}ms; longest client-visible unready interval ${OBSERVED_UNREADY_MS}ms; WAL recovery ${recovery_ms}ms"
-              [[ "$QUERY_HANDOFF_MS" =~ ^[1-9][0-9]*$ ]] || { echo "::error::rollout probe did not observe the old-to-new query handoff: '$QUERY_HANDOFF_MS'"; exit 1; }
-              [[ "$OBSERVED_UNREADY_MS" =~ ^[0-9]+$ ]] || { echo "::error::rollout readiness probe did not produce a valid downtime measurement: '$OBSERVED_UNREADY_MS'"; exit 1; }
-              (( OBSERVED_UNREADY_MS <= MAX_READY_WAIT_SECS * 1000 )) || { echo "::error::replacement returned 57P03/not-ready continuously for ${OBSERVED_UNREADY_MS}ms (budget $((MAX_READY_WAIT_SECS * 1000))ms)"; exit 1; }
-              # A PLANNED deploy drains the WAL first, so recovery is 0ms and this
-              # budget is the assertion that the drain actually happened. It is NOT
-              # a bound on crash recovery: after an OOM or SIGKILL the replacement
-              # legitimately replays a real backlog (64,427ms on 2026-08-14), and
-              # failing the deploy for that told us nothing we could act on while
-              # marking every post-incident rollout red — which is how a genuine
-              # deploy failure would have been missed.
-              #
-              # So: fail only when a DRAINED handoff was expected and did not
-              # happen, and otherwise surface the replay as a warning with the
-              # number attached.
-              if (( recovery_ms > MAX_WAL_RECOVERY_MS )); then
-                if [ "$PREFLUSHED_HANDOFF" = "true" ]; then
-                  echo "::error::WAL recovery took ${recovery_ms}ms (budget ${MAX_WAL_RECOVERY_MS}ms) after a DRAINED handoff — the drain did not take"
-                  exit 1
-                fi
-                echo "::warning::WAL recovery took ${recovery_ms}ms — the predecessor did not exit cleanly, so this rollout replayed a real backlog"
-              fi
-              echo "rollout completed within recovery and availability budgets"
-              exit 0
-            fi
-            sleep 2
-          done
-          echo "::error::replacement did not finish WAL recovery within ${RECOVERY_WAIT_SECS}s (boot=${boot_micros:-missing}, complete=${recovery_complete:-missing}, duration=${recovery_ms:-missing})"
-          exit 1
-
-      # A process can open PGWire and complete WAL recovery before deferred
-      # startup/background work begins competing for the runtime. The
-      # 2026-08-15 incident passed the point-in-time recovery check, then
-      # stopped serving queries seconds later. Require sustained availability
-      # before a deployment can be called successful.
-      - name: Soak production readiness
-        env:
-          PGURL: ${{ secrets.TIMEFUSION_PG_URL }}
-          SOAK_SECS: '120'
-          PROBE_INTERVAL_SECS: '2'
-          MAX_CONSECUTIVE_FAILURES: '2'
-        run: |
-          set -euo pipefail
-          : "${PGURL:?TIMEFUSION_PG_URL GitHub Actions secret is required}"
-          export PGMAXPROTOCOLVERSION=3.0
-
-          deadline=$((SECONDS + SOAK_SECS))
-          probes=0
-          failures=0
-          consecutive_failures=0
-          max_consecutive_failures=0
-          while (( SECONDS < deadline )); do
-            probes=$((probes + 1))
-            if timeout 3 psql "$PGURL" -v ON_ERROR_STOP=1 -Atqc \
-              "SELECT CASE WHEN EXISTS (SELECT 1 FROM timefusion_stats WHERE component = 'wal' AND key = 'recovery_complete' AND value = 'true') THEN 1 ELSE 0 END" \
-              | grep -qx 1; then
-              consecutive_failures=0
-            else
-              failures=$((failures + 1))
-              consecutive_failures=$((consecutive_failures + 1))
-              if (( consecutive_failures > max_consecutive_failures )); then
-                max_consecutive_failures=$consecutive_failures
-              fi
-              if (( consecutive_failures > MAX_CONSECUTIVE_FAILURES )); then
-                echo "::error::production failed ${consecutive_failures} consecutive readiness probes during the post-deploy soak"
-                exit 1
-              fi
-            fi
-            sleep "$PROBE_INTERVAL_SECS"
-          done
-
-          echo "post-deploy soak passed: ${probes} probes, ${failures} transient failures, max ${max_consecutive_failures} consecutive"
-
-      - name: Show Deployment Output
-        run: 'echo "CapRover deployment and recovery verification completed"'
+        run: python3 scripts/deploy/run.py ci

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,36 @@
 ##############################
 #         Chef base          #
 ##############################
-FROM rust:1.91-slim-bookworm AS chef
+FROM --platform=$BUILDPLATFORM rust:1.91-slim-bookworm AS chef
+ARG TARGETARCH
 WORKDIR /app
 # make is required by tikv-jemalloc-sys (jemalloc compiles from C source under --features
 # profiling); the slim image ships cc but not make. libunwind-dev backs the
 # heap profiler's unwinder (see JEMALLOC_SYS_PROF_BACKTRACE below).
-RUN apt-get update && \
-    apt-get install -y pkg-config libssl-dev make libunwind-dev && \
+# Compile on the builder CPU. Only the output and runtime use TARGETARCH.
+# Debian supplies matching target headers/libraries and the cross C linker.
+RUN case "$TARGETARCH" in \
+      amd64) rust_target=x86_64-unknown-linux-gnu; gnu_target=x86_64-linux-gnu ;; \
+      arm64) rust_target=aarch64-unknown-linux-gnu; gnu_target=aarch64-linux-gnu ;; \
+      *) echo "unsupported production architecture: $TARGETARCH" >&2; exit 1 ;; \
+    esac && \
+    compiler_packages="gcc g++" && \
+    if [ "$(dpkg --print-architecture)" != "$TARGETARCH" ]; then \
+      package_target=$(printf %s "$gnu_target" | tr _ -); \
+      compiler_packages="gcc-$package_target g++-$package_target"; \
+    fi && \
+    dpkg --add-architecture "$TARGETARCH" && apt-get update && \
+    apt-get install -y pkg-config make $compiler_packages \
+      "libssl-dev:$TARGETARCH" "libunwind-dev:$TARGETARCH" && \
+    rustup target add "$rust_target" && \
+    printf '%s\n' "$rust_target" > /rust-target && \
+    printf '%s\n' "$gnu_target" > /gnu-target && \
+    printf '[target.%s]\nlinker = "%s-gcc"\n' "$rust_target" "$gnu_target" > /usr/local/cargo/config.toml && \
     rm -rf /var/lib/apt/lists/*
+# cc-rs and pkg-config must resolve target C libraries, including the profilers.
+ENV PKG_CONFIG_ALLOW_CROSS=1
+RUN printf '#!/bin/sh\nset -eu\ngnu_target=$(cat /gnu-target)\nexport TARGET_CC="$gnu_target-gcc" TARGET_CXX="$gnu_target-g++" TARGET_AR="$gnu_target-ar"\nexport PKG_CONFIG_LIBDIR="/usr/lib/$gnu_target/pkgconfig:/usr/share/pkgconfig"\nexec cargo "$@" --target "$(cat /rust-target)"\n' > /usr/local/bin/target-cargo && \
+    chmod +x /usr/local/bin/target-cargo
 RUN cargo install cargo-chef --version 0.1.77 --locked
 
 ##############################
@@ -45,6 +67,7 @@ RUN cargo chef prepare --recipe-path recipe.json
 #         Builder            #
 ##############################
 FROM chef AS builder
+ARG CARGO_BUILD_JOBS
 # Cook compiles only dependencies. Docker layer-caches this step; cache-to:
 # type=gha,mode=max in deploy.yml persists the layer across CI runs. Layer
 # invalidates only when recipe.json changes (i.e. the dep graph changes),
@@ -89,21 +112,23 @@ ENV RUSTFLAGS="-C force-frame-pointers=yes -C target-cpu=${TARGET_CPU}"
 # `--enable-prof-libunwind`. Fallback needing no libs: `gcc` (uses the frame
 # pointers above). Verify with scripts/verify-jemalloc-prof.sh.
 ENV JEMALLOC_SYS_PROF_BACKTRACE=libunwind
-RUN cargo chef cook --release --locked --features profiling --recipe-path recipe.json
+RUN target-cargo chef cook --release --locked --features profiling --recipe-path recipe.json
 
 # Now compile the real binary. Deps are already built, so this only rebuilds
 # the crate itself when src/ changes.
 COPY Cargo.toml Cargo.lock ./
 COPY src/ src/
 COPY schemas/ schemas/
-RUN cargo build --release --locked --features profiling
+RUN target-cargo build --release --locked --features profiling && \
+    mkdir -p /output && cp "target/$(cat /rust-target)/release/timefusion" /output/timefusion
 
 # App state dirs (distroless runtime has no shell to mkdir at runtime).
 RUN mkdir -p /queue_db /data
 # jemalloc's profiler links libunwind dynamically; distroless ships neither it
 # nor its liblzma dep, so stage both (cp -a keeps the soname symlinks) for the
 # runtime stage. Arch-agnostic glob: /usr/lib/{x86_64,aarch64}-linux-gnu.
-RUN mkdir -p /profdeps && cp -a /usr/lib/*/libunwind.so.8* /usr/lib/*/liblzma.so.5* /profdeps/
+RUN mkdir -p /profdeps && \
+    cp -a /usr/lib/$(cat /gnu-target)/libunwind.so.8* /usr/lib/$(cat /gnu-target)/liblzma.so.5* /profdeps/
 
 ##############################
 #         Runtime            #
@@ -115,7 +140,7 @@ RUN mkdir -p /profdeps && cp -a /usr/lib/*/libunwind.so.8* /usr/lib/*/liblzma.so
 FROM gcr.io/distroless/cc-debian12:nonroot
 WORKDIR /app
 
-COPY --from=builder --chown=nonroot:nonroot /app/target/release/timefusion /usr/local/bin/timefusion
+COPY --from=builder --chown=nonroot:nonroot /output/timefusion /usr/local/bin/timefusion
 COPY --from=builder --chown=nonroot:nonroot /queue_db /app/queue_db
 COPY --from=builder --chown=nonroot:nonroot /data     /app/data
 COPY --from=builder /profdeps/ /usr/local/lib/

--- a/Makefile
+++ b/Makefile
@@ -189,6 +189,9 @@ ci-signoff:
 	./scripts/ci/ci.sh local $(CHECKS) || result=$$?; \
 	./scripts/ci/ci.sh gate || exit $$?; \
 	exit $$result
+	PYTHONDONTWRITEBYTECODE=1 python3 scripts/test-production-image.py
+	PYTHONDONTWRITEBYTECODE=1 python3 scripts/deploy/test_lease.py
+	python3 scripts/production-image.py signoff
 
 # What CI would run right now, without running any of it.
 ci-status:
@@ -199,3 +202,7 @@ ci-down:
 
 ci-selftest:
 	./scripts/ci/ci.sh selftest
+
+.PHONY: deploy
+deploy:
+	python3 scripts/deploy/run.py local

--- a/ci/deploy.Dockerfile
+++ b/ci/deploy.Dockerfile
@@ -1,0 +1,3 @@
+FROM node:22-bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends bash postgresql-client ca-certificates && \
+    rm -rf /var/lib/apt/lists/* && npm install --global caprover@2.3.1

--- a/ci/smoke.Dockerfile
+++ b/ci/smoke.Dockerfile
@@ -1,0 +1,4 @@
+# Native static emulator for testing the production amd64 image on ARM64.
+FROM debian:trixie-slim
+RUN apt-get update && apt-get install -y --no-install-recommends qemu-user && \
+    rm -rf /var/lib/apt/lists/*

--- a/docs/local-ci.md
+++ b/docs/local-ci.md
@@ -4,7 +4,7 @@ Run checks locally before pushing. Use `make ci-signoff` to run the CI checks an
 The final status output shows which checks still need a remote run.
 
 GitHub runs checks without matching attestations on standard GitHub-hosted runners.
-All workflows use GitHub runners, including releases and image builds.
+Remote workflows use GitHub runners. Production builds and deployment can also run locally.
 
 A signoff records passing checks for specific file contents. It does not bypass failed checks or approve different contents.
 Repository push access identifies who can publish these records. A Git `Signed-off-by` trailer does not replace CI results.
@@ -12,7 +12,7 @@ Repository push access identifies who can publish these records. A Git `Signed-o
 ## The short version
 
 ```bash
-make ci-signoff     # local checks, published results, then remaining remote checks
+make ci-signoff     # checks, passing records, and a tested production image
 make ci                      # everything CI runs
 make ci CHECKS="fmt clippy"  # just these
 make ci-status               # what CI would run right now, without running it
@@ -172,3 +172,35 @@ silently narrows what a check depends on, which is how an untested change ships.
 Narrow a check's `inputs` only where it is provably sound: a too-wide set costs a
 rerun, a too-narrow one ships an untested change. `fmt` is the one clear case —
 rustfmt reads `.rs` files and `rustfmt.toml`, not `Cargo.lock` and not `proto/`.
+
+## Production images
+
+`make ci-signoff` runs local checks, cross-compiles the production Linux
+amd64 image, checks that it reaches PGWire, and publishes a candidate to GHCR.
+Docker must have registry push access. This command does not update `latest`
+or restart production. The build uses an archived source snapshot, so edits
+during compilation cannot change the published candidate.
+
+The candidate tag contains a fingerprint of the Dockerfile, Rust manifests,
+source, schemas, vendor code, image helper, and smoke recipe. On master, deployment first
+looks for this candidate. If found, it skips compilation and promotes the
+image. Otherwise it builds in GitHub as before. Both paths resolve a digest
+and smoke-test it before the existing handoff and readiness checks.
+
+The compiler runs on the builder CPU. On an ARM64 laptop it produces Linux
+x86-64 code with target C libraries; amd64 container execution is required
+for the final smoke test. ARM64 Docker hosts automatically use a native QEMU
+emulator with an x86-64 guest address offset. The unchanged production image
+must stay running and pass its PGWire protocol probe. The first cross-build
+took about 40 minutes; warm rebuild speed is not yet measured.
+The publication and deployment path remains under validation. After the checked change is merged,
+`make deploy` runs the shared handoff, rollout, recovery, and readiness soak
+from a clean checkout of the current master commit. It requires PGURL,
+CAPROVER_SERVER, CAPROVER_APP, and CAPROVER_TOKEN in the environment.
+Local rollout has not yet been exercised with production credentials.
+
+Local and GitHub rollouts share a Git lease. A completed digest and live
+boot receipt avoids a duplicate restart. Failure after handoff begins
+retains the lease because the remote state may be unresolved. Inspect the
+rollout and release only the recorded owner after recovery. Diagnostics stay
+under .ci/deploy with private directory permissions.

--- a/docs/plans/2026-09-09-local-production-image.md
+++ b/docs/plans/2026-09-09-local-production-image.md
@@ -1,0 +1,74 @@
+# Local production image and deployment
+
+The ARM64 laptop cross-compiles the Linux amd64 production image. The compiler
+and dependency tools run natively. Runtime libraries match the target, including
+libunwind and liblzma. Profiling, frame pointers, and x86-64-v3 remain enabled.
+
+`make ci-signoff` runs the local checks and helper tests. When all required
+checks have matching passing records, it builds, smoke-tests, and publishes a
+candidate image. Limited signoff leaves image publication pending when required
+checks remain. No failed image smoke produces a published candidate.
+
+The helper archives a captured Git tree using a separate index. Build inputs
+and the smoke recipe determine the candidate fingerprint. User staging is
+preserved, and later edits cannot alter the archived build. Master deployment
+resolves that candidate to an immutable digest and skips compilation when it
+exists. The native CI build remains the fallback.
+
+`make deploy` requires a clean checkout of current master, matching checks,
+a published image, and PGURL/CAPROVER_SERVER/CAPROVER_APP/CAPROVER_TOKEN.
+It runs the same handoff, rollout, recovery verification, and readiness soak
+as CI. The five shell stages were extracted from the existing workflow without
+changing their thresholds. A shared Git lease serializes local and CI rollouts.
+A digest plus live boot receipt avoids a duplicate restart. Failure from the first
+handoff mutation retains the lease until the remote rollout is investigated.
+Private diagnostics remain under `.ci/deploy/rollout-*`.
+
+## Validation
+
+- ARM64 Rust and C toolchain probes produced runnable x86-64 executables.
+- Full cross-build exited 0. Image `timefusion-production-cross:local` has ID
+  `sha256:4cdb3458c830f0b65acf55e9e4582926f527c5b404985c9a617eb43afd63c7ae`.
+  The first uncached build took about 40 minutes. Warm speed is unmeasured.
+- Default local amd64 execution exited 139 for both this image and the known-good
+  production image a31c7b5. Explicit QEMU also failed with its default layout.
+- QEMU 10.0.11 with `-B 0x800000000000 -cpu max` started both unchanged images.
+  Both passed their actual PGWire healthcheck. A syscall trace of the failing
+  layout showed high guest mappings before SIGSEGV. This diagnoses the local
+  harness; it does not establish the exact allocator fault instruction.
+- The helper now selects QEMU automatically on ARM64 Docker hosts, waits through
+  the 12-second startup window, requires the real PGWire listener, and executes
+  the image's protocol healthcheck. Native amd64 runs the same checks directly.
+- Real temporary-Git tests cover fingerprint invalidation, frozen source,
+  preservation of staging, lease exclusion, receipt updates, interrupted rollout
+  retention, and verified release. No production lease has been created yet.
+- Actionlint 1.7.7 passed with shellcheck disabled. Ruby YAML parsing and Bash
+  syntax checks passed. The native deployment client image built successfully.
+
+Full updated `CARGO_TARGET_DIR=/tmp/timefusion-isolated-target make ci-signoff`
+passed (session 1851). All five unchanged Rust checks reused matching passing
+records; both helper tests ran and passed. The frozen image build reused its
+cached layers, passed the updated smoke, and published the production digest:
+
+`sha256:61104180933df79eb6f2c1ad2dcd15eedf71bb8769183578bc874f58439e2836`
+
+No required check remains for GitHub. CI candidate reuse and local production
+rollout remain to be exercised after merge. The existing enabled Timefusion
+app deployment token was located on the authorized CapRover host. Only its
+presence was reported. The local client is CapRover 2.3.1 and PostgreSQL 15.19.
+
+Two review passes checked artifact attribution and deployment interruption.
+The fixes preserve frozen smoke inputs, reject unexpected entrypoints, retain
+the lease from HANDOFF onward, and prevent Python imports from dirtying the
+checkout. The current diff has no Rust implementation changes.
+
+## Hash-query goal remains open
+
+Production a31c7b5 deployed successfully in run 34351293065. Startup backfill
+selected 34 otel files within 1,910 MiB and logged a completed indexing unit.
+The post-deployment SQL smoke still failed: only 8 of 16 result pairs completed.
+Sep 6 day and Sep 2–9 week queries exceeded the 3-second probe limit.
+A Delta/manifest audit found only 14 physical hash candidates among 1,406 live
+project files for Sep 2–8. Sep 6 had none. Complete warm benchmark queries are
+fast, but partial coverage and cold index loading remain expensive. Continue
+coverage and visibility optimization after the local release path is usable.

--- a/scripts/deploy/lease.py
+++ b/scripts/deploy/lease.py
@@ -1,0 +1,86 @@
+"""A shared Git lease for local and GitHub production rollouts."""
+import contextlib
+from dataclasses import dataclass
+import json
+import os
+import subprocess
+import time
+import uuid
+
+LEASE_REF = 'refs/timefusion-deploy/lease'
+RECEIPT_REF = 'refs/timefusion-deploy/completed'
+
+
+@dataclass
+class RolloutGuard:
+    owner: str
+    unresolved: bool = False
+
+    def submitted(self):
+        self.unresolved = True
+
+    def verified(self):
+        self.unresolved = False
+
+
+class DeploymentLease:
+    def __init__(self, root):
+        self.root = root
+
+    def git(self, *args, **kwargs):
+        return subprocess.run(['git', *args], cwd=self.root, text=True, check=True,
+                              stdout=subprocess.PIPE, stderr=subprocess.PIPE, **kwargs).stdout.strip()
+
+    def remote(self, ref):
+        value = self.git('ls-remote', 'origin', ref)
+        return value.split()[0] if value else None
+
+    def record(self, ref):
+        commit = self.remote(ref)
+        if commit is None:
+            return None
+        self.git('fetch', '--no-write-fetch-head', '--no-tags', 'origin', ref)
+        return json.loads(self.git('show', commit + ':record.json'))
+
+    def commit(self, record, parent=None):
+        blob = self.git('hash-object', '-w', '--stdin', input=json.dumps(record))
+        tree = self.git('mktree', input='100644 blob ' + blob + '\trecord.json\n')
+        parents = ['-p', parent] if parent else []
+        return self.git('-c', 'user.name=Timefusion deployment', '-c', 'user.email=deploy@timefusion.invalid',
+                        'commit-tree', tree, *parents, '-m', 'Production rollout record')
+
+    @contextlib.contextmanager
+    def hold(self, image, wait_seconds=2700):
+        owner = self.commit({'image': image, 'nonce': uuid.uuid4().hex,
+                             'run_id': os.environ.get('GITHUB_RUN_ID'), 'pid': os.getpid(), 'started': time.time()})
+        deadline = time.monotonic() + wait_seconds
+        last_notice = 0
+        while True:
+            try:
+                # Parentless commits cannot fast-forward an existing owner's ref.
+                self.git('push', 'origin', owner + ':' + LEASE_REF)
+                break
+            except subprocess.CalledProcessError:
+                occupied = self.remote(LEASE_REF)
+                if occupied is None or time.monotonic() >= deadline:
+                    raise
+                if time.monotonic() - last_notice >= 30:
+                    print('Production lease ' + occupied[:12] + ' is occupied; waiting.', flush=True)
+                    last_notice = time.monotonic()
+                time.sleep(5)
+        guard = RolloutGuard(owner)
+        try:
+            yield guard
+        finally:
+            if guard.unresolved:
+                print('Rollout state is unresolved; retaining production lease ' + owner + ' for recovery.', flush=True)
+            else:
+                # Never delete a lease whose owner has changed.
+                self.git('push', '--force-with-lease=' + LEASE_REF + ':' + owner, 'origin', ':' + LEASE_REF)
+
+    def complete(self, image, boot_micros):
+        previous = self.remote(RECEIPT_REF)
+        if previous:
+            self.git('fetch', '--no-write-fetch-head', '--no-tags', 'origin', RECEIPT_REF)
+        commit = self.commit({'image': image, 'boot_micros': boot_micros, 'completed': time.time()}, parent=previous)
+        self.git('push', 'origin', commit + ':' + RECEIPT_REF)

--- a/scripts/deploy/prepare.sh
+++ b/scripts/deploy/prepare.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+: "${PGURL:?TIMEFUSION_PG_URL GitHub Actions secret is required}"
+# Best-effort pre-deploy flush. The unflushed tail is WAL-durable and the
+# replacement replays it, so this must NOT fail the deploy when prod is
+# unreachable — most often it's mid-boot from the *previous* deploy
+# (psql: "the database system is starting up"). Failing here deadlocked
+# every deploy after a slow boot (2026-07-20). Retry briefly, then proceed.
+# timeout: a hung psql (e.g. protocol negotiation with newer psql,
+# which needs max_protocol_version=3.0 against TF, or a wedged FLUSH)
+# otherwise pins attempt 1 forever and the retry loop never runs
+# (2026-07-30: flush step sat 25+ min on a single psql call).
+# PGMAXPROTOCOLVERSION: env form (not URI param) — older libpq ignores
+# unknown env vars but rejects unknown URI params.
+export PGMAXPROTOCOLVERSION=3.0
+flush_ok=false
+for attempt in $(seq 1 3); do
+  if timeout 300 psql "$PGURL" -v ON_ERROR_STOP=1 -c 'FLUSH' 2>&1; then
+    echo "online flush ok (attempt $attempt)"
+    flush_ok=true
+    break
+  fi
+  echo "flush attempt $attempt failed or timed out; retrying in 15s"
+  sleep 15
+done
+if timeout 300 psql "$PGURL" -v ON_ERROR_STOP=1 -c 'HANDOFF' 2>&1; then
+  echo "write-fenced tail drain ready; production remains read-available"
+  echo "drained=true" >> "$GITHUB_OUTPUT"
+  exit 0
+fi
+if $flush_ok; then
+  echo "HANDOFF unsupported by outgoing binary; using successful FLUSH compatibility path"
+  echo "drained=true" >> "$GITHUB_OUTPUT"
+  exit 0
+fi
+echo "drained=false" >> "$GITHUB_OUTPUT"
+echo "::warning::neither pre-deploy FLUSH nor HANDOFF succeeded; proceeding (tail is WAL-durable, replay will recover it)"

--- a/scripts/deploy/record-boot.sh
+++ b/scripts/deploy/record-boot.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+: "${PGURL:?TIMEFUSION_PG_URL GitHub Actions secret is required}"
+boot_micros="$(psql "$PGURL" -v ON_ERROR_STOP=1 -Atqc "SELECT value FROM timefusion_stats WHERE component = 'buffered_layer' AND key = 'boot_micros'" || true)"
+last_old_response_epoch_ms="$(date +%s%3N)"
+echo "boot_micros=${boot_micros}" >> "$GITHUB_OUTPUT"
+echo "last_old_response_epoch_ms=${last_old_response_epoch_ms}" >> "$GITHUB_OUTPUT"
+# Record total rollout wall time separately from the concurrent SQL
+# probe's actual client-visible unready interval.
+echo "handoff_started_epoch_ms=$(date +%s%3N)" >> "$GITHUB_OUTPUT"

--- a/scripts/deploy/rollout.sh
+++ b/scripts/deploy/rollout.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+: "${CAPROVER_SERVER:?CAPTAINROVER_SERVER is required}"
+: "${CAPROVER_APP:?CAPTAINROVER_APP_NAME is required}"
+: "${CAPROVER_TOKEN:?CAPTAINROVER_APP_TOKEN is required}"
+: "${PGURL:?TIMEFUSION_PG_URL is required}"
+export PGMAXPROTOCOLVERSION=3.0
+
+# Measure client-visible unavailability concurrently with the opaque
+# CapRover rollout. Total deploy wall time includes image pull while
+# the old task is healthy; it is not database downtime. Persist the
+# longest continuous SELECT failure interval for the verification
+# step instead.
+probe_dir="$(mktemp -d)"
+probe_stop="$probe_dir/stop"
+probe_result="$probe_dir/max_unready_ms"
+handoff_result="$probe_dir/query_handoff_ms"
+(
+  unready_started_ms=0
+  max_unready_ms=0
+  # The preceding step already proved this exact old boot answered a
+  # query. Seed from that timestamp so a very short handoff remains
+  # measurable even when the first concurrent sample hits 57P03.
+  last_old_response_ms="$LAST_OLD_RESPONSE_EPOCH_MS"
+  query_handoff_ms=0
+  while [ ! -e "$probe_stop" ]; do
+    attempt_started_ms="$(date +%s%3N)"
+    responding_boot="$(timeout 1 psql "$PGURL" -v ON_ERROR_STOP=1 -Atqc "SELECT value FROM timefusion_stats WHERE component = 'buffered_layer' AND key = 'boot_micros'" 2>/dev/null || true)"
+    if [ -n "$responding_boot" ]; then
+      if (( unready_started_ms > 0 )); then
+        interval_ms=$(( $(date +%s%3N) - unready_started_ms ))
+        (( interval_ms > max_unready_ms )) && max_unready_ms=$interval_ms
+        unready_started_ms=0
+      fi
+      if [ "$responding_boot" = "$PREVIOUS_BOOT_MICROS" ]; then
+        last_old_response_ms="$(date +%s%3N)"
+      elif (( query_handoff_ms == 0 )); then
+        query_handoff_ms=$(( $(date +%s%3N) - last_old_response_ms ))
+      fi
+    elif (( unready_started_ms == 0 )); then
+      unready_started_ms="$attempt_started_ms"
+    fi
+    sleep 0.1
+  done
+  if (( unready_started_ms > 0 )); then
+    interval_ms=$(( $(date +%s%3N) - unready_started_ms ))
+    (( interval_ms > max_unready_ms )) && max_unready_ms=$interval_ms
+  fi
+  echo "$max_unready_ms" > "$probe_result"
+  echo "$query_handoff_ms" > "$handoff_result"
+) &
+probe_pid=$!
+stop_probe() {
+  touch "$probe_stop"
+  wait "$probe_pid"
+}
+trap stop_probe EXIT
+
+# The image is already built, pushed, pulled by the smoke test, and
+# the outgoing process is HANDOFF-drained when supported. Submit the
+# Swarm update immediately so the leased fence cannot expire. The
+# first compatibility rollout may use FLUSH; its shutdown path still
+# fences and drains any tail with the full correctness budget.
+caprover deploy \
+  --caproverUrl "$CAPROVER_SERVER" \
+  --appToken "$CAPROVER_TOKEN" \
+  --appName "$CAPROVER_APP" \
+  -i "$IMAGE_URL" >caprover-deploy.log 2>&1 &
+deploy_pid=$!
+
+deploy_status=0
+wait "$deploy_pid" || deploy_status=$?
+
+# CapRover can return after it has submitted the Swarm update but
+# before the replacement owns PGWire. Keep the concurrent probe alive
+# until a query proves that a DIFFERENT boot completed recovery;
+# otherwise stopping it here reports a false 0ms outage.
+replacement_deadline=$((SECONDS + 720))
+while (( deploy_status == 0 && SECONDS < replacement_deadline )); do
+  boot_micros="$(timeout 3 psql "$PGURL" -v ON_ERROR_STOP=1 -Atqc "SELECT value FROM timefusion_stats WHERE component = 'buffered_layer' AND key = 'boot_micros'" 2>/dev/null || true)"
+  recovery_complete="$(timeout 3 psql "$PGURL" -v ON_ERROR_STOP=1 -Atqc "SELECT value FROM timefusion_stats WHERE component = 'wal' AND key = 'recovery_complete'" 2>/dev/null || true)"
+  if [ -n "$boot_micros" ] && [ "$boot_micros" != "$PREVIOUS_BOOT_MICROS" ] && [ "$recovery_complete" = true ]; then
+    break
+  fi
+  sleep 0.5
+done
+stop_probe
+trap - EXIT
+observed_unready_ms="$(cat "$probe_result")"
+query_handoff_ms="$(cat "$handoff_result")"
+echo "observed_unready_ms=$observed_unready_ms" >> "$GITHUB_OUTPUT"
+echo "query_handoff_ms=$query_handoff_ms" >> "$GITHUB_OUTPUT"
+cat caprover-deploy.log
+(( deploy_status == 0 )) || exit "$deploy_status"

--- a/scripts/deploy/run.py
+++ b/scripts/deploy/run.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Run the same production handoff and verification locally or in GitHub."""
+import argparse
+import os
+from pathlib import Path
+import re
+import signal
+import subprocess
+import sys
+import tempfile
+import tarfile
+
+# Importing the helper must not dirty the checkout before the clean-tree check.
+sys.dont_write_bytecode = True
+from lease import DeploymentLease, RECEIPT_REF
+
+ROOT = Path(__file__).resolve().parents[2]
+CLIENT = 'timefusion-deploy-client:local'
+CREDENTIALS = ('PGURL', 'CAPROVER_SERVER', 'CAPROVER_APP', 'CAPROVER_TOKEN')
+LIMITS = {'MAX_WAL_RECOVERY_MS': '5000', 'MAX_READY_WAIT_SECS': '10', 'RECOVERY_WAIT_SECS': '720',
+          'SOAK_SECS': '120', 'PROBE_INTERVAL_SECS': '2', 'MAX_CONSECUTIVE_FAILURES': '2'}
+
+
+def execute(*args, **kwargs):
+    return subprocess.run(args, cwd=ROOT, check=True, **kwargs)
+
+
+def output(*args):
+    return execute(*args, stdout=subprocess.PIPE, text=True).stdout.strip()
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('mode', choices=('local', 'ci'))
+    args = parser.parse_args()
+    missing = [name for name in CREDENTIALS if not os.environ.get(name)]
+    if missing:
+        parser.error('Deployment credentials are required: ' + ', '.join(missing))
+    local = args.mode == 'local'
+    if local:
+        if output('git', 'status', '--porcelain'):
+            parser.error('Deploy from a clean checkout of the merged master commit')
+        expected = set(output('bash', 'scripts/ci/ci.sh', 'checks').splitlines())
+        passed = {line.split()[1] for line in output('bash', 'scripts/ci/ci.sh', 'gate').splitlines() if line.startswith('skip ')}
+        if passed != expected:
+            parser.error('Matching local checks are required; run make ci-signoff')
+        image = output('python3', 'scripts/production-image.py', 'resolve')
+        execute('docker', 'pull', image)
+        execute('python3', 'scripts/production-image.py', 'smoke', image)
+        execute('docker', 'build', '-f', 'ci/deploy.Dockerfile', '-t', CLIENT, 'ci')
+    else:
+        image = os.environ['IMAGE_URL']
+    if not re.fullmatch(r'ghcr\.io/monoscope-tech/timefusion@sha256:[0-9a-f]{64}', image):
+        parser.error('Deployment requires an immutable production image digest')
+    values = {name: os.environ[name] for name in CREDENTIALS}
+    values.update(LIMITS, IMAGE_URL=image)
+    lease = DeploymentLease(ROOT)
+    # A signal releases admission only before handoff or after verification.
+    # An unresolved remote rollout retains its owner record for recovery.
+    def interrupted(signum, frame):
+        raise SystemExit(128 + signum)
+    signal.signal(signal.SIGTERM, interrupted)
+    state_root = ROOT / '.ci/deploy'
+    state_root.mkdir(parents=True, exist_ok=True)
+    directory = tempfile.mkdtemp(prefix='rollout-', dir=state_root)
+    print('Deployment diagnostics: ' + directory, flush=True)
+    with lease.hold(image) as guard:
+        current = lease.git('rev-parse', 'HEAD')
+        master = lease.remote('refs/heads/master')
+        if current != master:
+            if local:
+                parser.error('The checkout must be the current merged master commit')
+            print('A newer master commit superseded this rollout; production is unchanged.')
+            return
+        archive = Path(directory) / 'scripts.tar'
+        execute('git', 'archive', '--format=tar', '-o', str(archive), current, 'scripts/deploy')
+        with tarfile.open(archive) as source:
+            source.extractall(directory, filter='data')
+        archive.unlink()
+        stage_root = Path(directory) / 'scripts/deploy'
+
+        def stage(name):
+            result = Path(directory) / ('outputs-' + name)
+            result.write_text('')
+            stage_values = dict(values, GITHUB_OUTPUT='/state/' + result.name if local else str(result))
+            env = dict(os.environ, **stage_values)
+            if local:
+                args = ['docker', 'run', '--rm', '-v', str(stage_root) + ':/deploy:ro',
+                        '-v', directory + ':/state', '-w', '/state']
+                for key in stage_values:
+                    args.extend(('-e', key))
+                args.extend((CLIENT, 'bash', '/deploy/' + name + '.sh'))
+            else:
+                args = ['bash', str(stage_root / (name + '.sh'))]
+            subprocess.run(args, cwd=directory, env=env, check=True)
+            return dict(line.split('=', 1) for line in result.read_text().splitlines() if '=' in line)
+
+        previous = stage('record-boot')
+        receipt = lease.record(RECEIPT_REF)
+        if receipt and receipt.get('image') == image and previous.get('boot_micros') and receipt.get('boot_micros') == previous['boot_micros']:
+            stage('soak')
+            print('The tested image is already deployed on this boot; readiness soak passed.')
+            return
+        # HANDOFF itself can fence writes. Retain ownership from the first
+        # production mutation, including interruption before CapRover submission.
+        guard.submitted()
+        handoff = stage('prepare')
+        previous = stage('record-boot')
+        values.update(PREVIOUS_BOOT_MICROS=previous['boot_micros'],
+                      LAST_OLD_RESPONSE_EPOCH_MS=previous['last_old_response_epoch_ms'],
+                      HANDOFF_STARTED_EPOCH_MS=previous['handoff_started_epoch_ms'],
+                      PREFLUSHED_HANDOFF=handoff['drained'])
+        rollout = stage('rollout')
+        values.update(OBSERVED_UNREADY_MS=rollout['observed_unready_ms'], QUERY_HANDOFF_MS=rollout['query_handoff_ms'])
+        stage('verify-recovery')
+        stage('soak')
+        boot = stage('record-boot')['boot_micros']
+        if not re.fullmatch(r'[0-9]+', boot):
+            raise RuntimeError('Cannot record deployment success without a valid live boot identifier')
+        lease.complete(image, boot)
+        guard.verified()
+        print('Production deployment and recovery verification completed.')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/deploy/soak.sh
+++ b/scripts/deploy/soak.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+: "${PGURL:?TIMEFUSION_PG_URL GitHub Actions secret is required}"
+export PGMAXPROTOCOLVERSION=3.0
+
+deadline=$((SECONDS + SOAK_SECS))
+probes=0
+failures=0
+consecutive_failures=0
+max_consecutive_failures=0
+while (( SECONDS < deadline )); do
+  probes=$((probes + 1))
+  if timeout 3 psql "$PGURL" -v ON_ERROR_STOP=1 -Atqc \
+    "SELECT CASE WHEN EXISTS (SELECT 1 FROM timefusion_stats WHERE component = 'wal' AND key = 'recovery_complete' AND value = 'true') THEN 1 ELSE 0 END" \
+    | grep -qx 1; then
+    consecutive_failures=0
+  else
+    failures=$((failures + 1))
+    consecutive_failures=$((consecutive_failures + 1))
+    if (( consecutive_failures > max_consecutive_failures )); then
+      max_consecutive_failures=$consecutive_failures
+    fi
+    if (( consecutive_failures > MAX_CONSECUTIVE_FAILURES )); then
+      echo "::error::production failed ${consecutive_failures} consecutive readiness probes during the post-deploy soak"
+      exit 1
+    fi
+  fi
+  sleep "$PROBE_INTERVAL_SECS"
+done
+
+echo "post-deploy soak passed: ${probes} probes, ${failures} transient failures, max ${max_consecutive_failures} consecutive"

--- a/scripts/deploy/test_lease.py
+++ b/scripts/deploy/test_lease.py
@@ -1,0 +1,47 @@
+import pathlib
+import subprocess
+import tempfile
+import unittest
+from lease import DeploymentLease, LEASE_REF, RECEIPT_REF
+
+
+class LeaseTest(unittest.TestCase):
+    def test_exclusion_release_and_receipt(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = pathlib.Path(directory)
+            remote, first, second = (root / name for name in ('remote', 'first', 'second'))
+            def git(*args):
+                subprocess.run(['git', *map(str, args)], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            git('init', '--bare', remote)
+            for checkout in (first, second):
+                git('clone', remote, checkout)
+            a, b = DeploymentLease(first), DeploymentLease(second)
+            with a.hold('image-a'):
+                with self.assertRaises(subprocess.CalledProcessError):
+                    with b.hold('image-b', wait_seconds=0):
+                        self.fail('Concurrent owner acquired an occupied lease')
+                a.complete('image-a', '123')
+                self.assertEqual(b.record(RECEIPT_REF)['boot_micros'], '123')
+            self.assertIsNone(a.remote(LEASE_REF))
+            with self.assertRaisesRegex(RuntimeError, 'failed rollout'):
+                with b.hold('image-b'):
+                    raise RuntimeError('failed rollout')
+            self.assertIsNone(b.remote(LEASE_REF))
+            with b.hold('image-b'):
+                b.complete('image-b', '456')
+            self.assertEqual(a.record(RECEIPT_REF)['image'], 'image-b')
+            with self.assertRaisesRegex(RuntimeError, 'unknown remote state'):
+                with a.hold('image-c') as guard:
+                    guard.submitted()
+                    raise RuntimeError('unknown remote state')
+            self.assertEqual(a.remote(LEASE_REF), guard.owner)
+            # Explicit recovery releases only the owner verified by this test.
+            a.git('push', '--force-with-lease=' + LEASE_REF + ':' + guard.owner, 'origin', ':' + LEASE_REF)
+            with a.hold('image-d') as guard:
+                guard.submitted()
+                guard.verified()
+            self.assertIsNone(a.remote(LEASE_REF))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/deploy/verify-recovery.sh
+++ b/scripts/deploy/verify-recovery.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+: "${PGURL:?TIMEFUSION_PG_URL GitHub Actions secret is required}"
+export PGMAXPROTOCOLVERSION=3.0
+boot_micros=""
+recovery_complete=""
+recovery_ms=""
+deadline=$((SECONDS + RECOVERY_WAIT_SECS))
+while (( SECONDS < deadline )); do
+  if ! timeout 5 psql "$PGURL" -v ON_ERROR_STOP=1 -Atqc 'SELECT 1' >/dev/null 2>&1; then
+    sleep 2
+    continue
+  fi
+  boot_micros="$(timeout 5 psql "$PGURL" -v ON_ERROR_STOP=1 -Atqc "SELECT value FROM timefusion_stats WHERE component = 'buffered_layer' AND key = 'boot_micros'" || true)"
+  recovery_complete="$(timeout 5 psql "$PGURL" -v ON_ERROR_STOP=1 -Atqc "SELECT value FROM timefusion_stats WHERE component = 'wal' AND key = 'recovery_complete'" || true)"
+  recovery_ms="$(timeout 5 psql "$PGURL" -v ON_ERROR_STOP=1 -Atqc "SELECT value FROM timefusion_stats WHERE component = 'wal' AND key = 'recovery_duration_ms'" || true)"
+  if [ -n "$boot_micros" ] && [ "$boot_micros" != "$PREVIOUS_BOOT_MICROS" ] && [ "$recovery_complete" = true ] && [[ "$recovery_ms" =~ ^[0-9]+$ ]]; then
+    ready_elapsed_ms=$(( $(date +%s%3N) - HANDOFF_STARTED_EPOCH_MS ))
+    ready_wait=$(( (ready_elapsed_ms + 999) / 1000 ))
+    echo "rollout measurement: total ${ready_elapsed_ms}ms; last-old-query to first-new-query ${QUERY_HANDOFF_MS}ms; longest client-visible unready interval ${OBSERVED_UNREADY_MS}ms; WAL recovery ${recovery_ms}ms"
+    [[ "$QUERY_HANDOFF_MS" =~ ^[1-9][0-9]*$ ]] || { echo "::error::rollout probe did not observe the old-to-new query handoff: '$QUERY_HANDOFF_MS'"; exit 1; }
+    [[ "$OBSERVED_UNREADY_MS" =~ ^[0-9]+$ ]] || { echo "::error::rollout readiness probe did not produce a valid downtime measurement: '$OBSERVED_UNREADY_MS'"; exit 1; }
+    (( OBSERVED_UNREADY_MS <= MAX_READY_WAIT_SECS * 1000 )) || { echo "::error::replacement returned 57P03/not-ready continuously for ${OBSERVED_UNREADY_MS}ms (budget $((MAX_READY_WAIT_SECS * 1000))ms)"; exit 1; }
+    # A PLANNED deploy drains the WAL first, so recovery is 0ms and this
+    # budget is the assertion that the drain actually happened. It is NOT
+    # a bound on crash recovery: after an OOM or SIGKILL the replacement
+    # legitimately replays a real backlog (64,427ms on 2026-08-14), and
+    # failing the deploy for that told us nothing we could act on while
+    # marking every post-incident rollout red — which is how a genuine
+    # deploy failure would have been missed.
+    #
+    # So: fail only when a DRAINED handoff was expected and did not
+    # happen, and otherwise surface the replay as a warning with the
+    # number attached.
+    if (( recovery_ms > MAX_WAL_RECOVERY_MS )); then
+      if [ "$PREFLUSHED_HANDOFF" = "true" ]; then
+        echo "::error::WAL recovery took ${recovery_ms}ms (budget ${MAX_WAL_RECOVERY_MS}ms) after a DRAINED handoff — the drain did not take"
+        exit 1
+      fi
+      echo "::warning::WAL recovery took ${recovery_ms}ms — the predecessor did not exit cleanly, so this rollout replayed a real backlog"
+    fi
+    echo "rollout completed within recovery and availability budgets"
+    exit 0
+  fi
+  sleep 2
+done
+echo "::error::replacement did not finish WAL recovery within ${RECOVERY_WAIT_SECS}s (boot=${boot_micros:-missing}, complete=${recovery_complete:-missing}, duration=${recovery_ms:-missing})"
+exit 1

--- a/scripts/production-image.py
+++ b/scripts/production-image.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Build, smoke-test, and publish immutable production image candidates."""
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import tarfile
+import tempfile
+import time
+import uuid
+
+ROOT = Path(__file__).resolve().parents[1]
+REGISTRY = 'ghcr.io/monoscope-tech/timefusion'
+INPUTS = ('Dockerfile', '.dockerignore', 'Cargo.toml', 'Cargo.lock', 'src', 'schemas', 'vendor', 'scripts/production-image.py', 'ci/smoke.Dockerfile')
+
+
+def run(*args, **kwargs):
+    return subprocess.run(args, cwd=ROOT, check=True, **kwargs)
+
+
+def output(*args, **kwargs):
+    return run(*args, stdout=subprocess.PIPE, text=True, **kwargs).stdout.strip()
+
+
+def snapshot():
+    # A separate index preserves the user's staging area. Archive this exact tree,
+    # so edits during a long build cannot silently change the published candidate.
+    with tempfile.TemporaryDirectory(prefix='tf-image-index-') as directory:
+        env = dict(os.environ, GIT_INDEX_FILE=str(Path(directory) / 'index'))
+        run('git', 'read-tree', 'HEAD', env=env)
+        run('git', 'add', '-A', '--', *INPUTS, env=env)
+        tree = output('git', 'write-tree', env=env)
+    entries = run('git', 'ls-tree', '-rz', tree, '--', *INPUTS, stdout=subprocess.PIPE).stdout
+    return tree, hashlib.sha256(b'timefusion-linux-amd64-image-v1\0' + entries).hexdigest()
+
+
+def digest(image):
+    if not image.startswith((REGISTRY + ':', REGISTRY + '@')):
+        raise ValueError('Only production-registry images can be resolved')
+    manifest = json.loads(output('docker', 'buildx', 'imagetools', 'inspect', image, '--format', '{{json .Manifest}}'))
+    value = manifest['digest']
+    if not re.fullmatch(r'sha256:[0-9a-f]{64}', value):
+        raise RuntimeError('Registry returned an invalid image digest')
+    return REGISTRY + '@' + value
+
+
+def smoke(image, recipe=ROOT / 'ci/smoke.Dockerfile'):
+    config = json.loads(output('docker', 'image', 'inspect', image, '--format', '{{json .Config}}'))
+    if config['Entrypoint'] != ['/usr/local/bin/timefusion'] or config.get('Cmd'):
+        raise RuntimeError('Smoke harness must be updated for the changed production entrypoint')
+    name = 'tf-image-smoke-' + uuid.uuid4().hex
+    state = ROOT / '.ci'
+    state.mkdir(exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix='image-smoke-', dir=state) as directory:
+        command = ['/usr/local/bin/timefusion']
+        options = []
+        if output('docker', 'info', '--format', '{{.Architecture}}') in ('arm64', 'aarch64'):
+            emulator = 'timefusion-smoke-emulator:local'
+            run('docker', 'build', '-f', str(recipe), '-t', emulator, str(recipe.parent))
+            try:
+                run('docker', 'create', '--name', name + '-emulator', emulator)
+                run('docker', 'cp', name + '-emulator:/usr/bin/qemu-x86_64', directory + '/qemu')
+            finally:
+                subprocess.run(['docker', 'rm', '-f', name + '-emulator'], check=False)
+            options = ['-v', directory + '/qemu:/qemu:ro', '--entrypoint', '/qemu']
+            # Keep guest mappings in the canonical x86-64 address range. The
+            # default ARM64 placement crashes the unchanged production allocator.
+            command = ['/qemu', '-B', '0x800000000000', '-cpu', 'max', *command]
+        try:
+            run('docker', 'run', '--platform', 'linux/amd64', '-d', '--name', name,
+                '--no-healthcheck', '--ulimit', 'core=0', *options,
+                '-e', 'TIMEFUSION_ALLOW_INSECURE_AUTH=true', '-e', 'AWS_S3_BUCKET=smoke',
+                '-e', 'AWS_REGION=us-east-1', '-e', 'AWS_ACCESS_KEY_ID=smoke',
+                '-e', 'AWS_SECRET_ACCESS_KEY=smoke', '-e', 'RUST_LOG=info',
+                image, *command[1:])
+            deadline = time.monotonic() + 12
+            while True:
+                status = json.loads(output('docker', 'inspect', '--format', '{{json .State}}', name))
+                if not status['Running']:
+                    raise RuntimeError('Production image exited: ' + json.dumps(status))
+                if time.monotonic() >= deadline:
+                    break
+                time.sleep(1)
+            logs = subprocess.run(['docker', 'logs', name], capture_output=True, text=True, check=True)
+            if not re.search(r'Listening on 0\.0\.0\.0:5432', logs.stdout + logs.stderr):
+                raise RuntimeError('Production image did not reach PGWire within 12 seconds')
+            # Run the image's real protocol probe explicitly on both platforms.
+            # Docker's normal probe would bypass the emulator on ARM64.
+            run('docker', 'exec', name, *command, 'healthcheck', timeout=5)
+            if output('docker', 'inspect', '--format', '{{.State.Running}}', name) != 'true':
+                raise RuntimeError('Production image exited during its health probe')
+            print('smoke: production image stayed running and passed PGWire probe', flush=True)
+        except Exception:
+            subprocess.run(['docker', 'logs', '--tail', '40', name], check=False)
+            raise
+        finally:
+            subprocess.run(['docker', 'rm', '-f', name], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+
+def signed_off():
+    expected = set(output('bash', 'scripts/ci/ci.sh', 'checks').splitlines())
+    gate = output('bash', 'scripts/ci/ci.sh', 'gate')
+    passed = {line.split()[1] for line in gate.splitlines() if line.startswith('skip ')}
+    return passed == expected
+
+
+def publish():
+    tree, fingerprint = snapshot()
+    if not signed_off() or snapshot()[1] != fingerprint:
+        raise RuntimeError('Matching local signoff is required; run make ci-signoff with stable inputs')
+    image = REGISTRY + ':input-' + fingerprint
+    try:
+        existing = digest(image)
+    except subprocess.CalledProcessError:
+        existing = None
+    if existing:
+        print('Reusing previously published image: ' + existing)
+        return
+    with tempfile.TemporaryDirectory(prefix='tf-image-context-') as directory:
+        archive = Path(directory) / 'context.tar'
+        run('git', 'archive', '--format=tar', '-o', str(archive), tree, '--', *INPUTS)
+        with tarfile.open(archive) as source:
+            source.extractall(directory, filter='data')
+        archive.unlink()
+        run('docker', 'buildx', 'build', '--load', '--platform', 'linux/amd64',
+            '--build-arg', 'CARGO_BUILD_JOBS=2', '--label', 'io.timefusion.source-fingerprint=' + fingerprint,
+            '-t', image, directory)
+        smoke(image, Path(directory) / 'ci/smoke.Dockerfile')
+    run('docker', 'push', image)
+    pushed = json.loads(output('docker', 'image', 'inspect', image, '--format', '{{json .RepoDigests}}'))
+    print(next(value for value in pushed if value.startswith(REGISTRY + '@')))
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('command', choices=('fingerprint', 'resolve', 'publish', 'signoff', 'smoke', 'digest'))
+    parser.add_argument('image', nargs='?')
+    args = parser.parse_args()
+    if args.command == 'fingerprint':
+        print(snapshot()[1])
+    elif args.command == 'resolve':
+        print(digest(REGISTRY + ':input-' + snapshot()[1]))
+    elif args.command == 'publish':
+        publish()
+    elif args.command == 'signoff':
+        if signed_off():
+            publish()
+        else:
+            print('Image publication pending: required checks still need to pass.')
+    elif args.image is None:
+        parser.error('This command requires an image')
+    elif args.command == 'smoke':
+        smoke(args.image)
+    else:
+        print(digest(args.image))
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/test-production-image.py
+++ b/scripts/test-production-image.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Exercise image attribution against a real temporary Git repository."""
+import importlib.util
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+
+class ImageSnapshotTest(unittest.TestCase):
+    def test_build_inputs_and_frozen_context(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            script = root / 'scripts/production-image.py'
+            script.parent.mkdir()
+            shutil.copyfile(Path(__file__).with_name('production-image.py'), script)
+            spec = importlib.util.spec_from_file_location('production_image', script)
+            image = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(image)
+            for name in image.INPUTS:
+                path = root / name
+                if name in ('src', 'schemas', 'vendor'):
+                    path.mkdir()
+                    (path / 'input').write_text('initial')
+                elif not path.exists():
+                    path.parent.mkdir(parents=True, exist_ok=True)
+                    path.write_text('initial')
+            def git(*args):
+                return subprocess.check_output(['git', *args], cwd=root, stderr=subprocess.DEVNULL)
+            git('init')
+            git('add', '.')
+            git('-c', 'user.name=Test', '-c', 'user.email=test@example.invalid', 'commit', '-m', 'fixture')
+            tree, original = image.snapshot()
+            (root / 'notes.md').write_text('Documentation does not change the image')
+            self.assertEqual(image.snapshot()[1], original)
+            for name in ('Dockerfile', 'Cargo.lock', 'src/input', 'schemas/input', 'vendor/input', 'ci/smoke.Dockerfile'):
+                path = root / name
+                before = path.read_bytes()
+                path.write_bytes(before + b' changed')
+                with self.subTest(path=name):
+                    self.assertNotEqual(image.snapshot()[1], original)
+                path.write_bytes(before)
+            (root / 'src/input').write_text('staged')
+            git('add', 'src/input')
+            staged = git('diff', '--cached', '--binary')
+            (root / 'src/input').write_text('working')
+            frozen, _ = image.snapshot()
+            self.assertEqual(git('diff', '--cached', '--binary'), staged)
+            (root / 'src/input').write_text('later edit')
+            self.assertEqual(git('show', frozen + ':src/input'), b'working')
+            self.assertEqual(git('show', tree + ':src/input'), b'initial')
+            archive = root / 'snapshot.tar'
+            image.run('git', 'archive', '--format=tar', '-o', str(archive), frozen, '--', *image.INPUTS)
+            self.assertGreater(archive.stat().st_size, 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Production builds currently repeat in GitHub after local checks pass. `make ci-signoff` now cross-compiles Linux amd64 on the ARM64 laptop, runs the unchanged image through a real PGWire smoke test, and publishes a source-fingerprinted candidate. Master deployment reuses its immutable digest and skips compilation.

`make deploy` runs the same handoff, rollout, recovery checks, and readiness soak as GitHub. Both paths share a Git lease and a completed digest/boot receipt, preventing concurrent rollouts and duplicate restarts. Interruptions from HANDOFF onward retain ownership for recovery. Existing rollout thresholds stay unchanged.

Validation:

- `CARGO_TARGET_DIR=/tmp/timefusion-isolated-target make ci-signoff` passed. All five unchanged Rust checks reused matching passing records; no required check remains for GitHub.
- Real temporary-Git image and lease tests passed. Actionlint 1.7.7 passed with shellcheck disabled; Python, Bash, YAML, and diff checks passed.
- Full ARM64 → Linux amd64 production build succeeded. Default local emulation crashed both the new and known-good images. Automatic QEMU with a canonical guest address offset fixed the local harness; both unchanged images passed their PGWire probes.
- Published tested digest: `sha256:61104180933df79eb6f2c1ad2dcd15eedf71bb8769183578bc874f58439e2836`. Initial cold build took about 40 minutes; the identical-source signoff build reused all compilation layers. Changed-source warm build speed is unmeasured.
- The local client image built with CapRover 2.3.1 and PostgreSQL 15.19. CI image reuse and the shared production rollout will be verified after merge. No runtime image or lease has yet been changed by this branch.

The hash performance goal remains open: automatic backfill is deployed, but sparse historical coverage and partial/cold query latency still need optimization.
