### PR TITLE
Normalize production image digests across manifest promotion

### DIFF
--- a/docs/plans/2026-09-09-local-production-image.md
+++ b/docs/plans/2026-09-09-local-production-image.md
@@ -72,3 +72,26 @@ A Delta/manifest audit found only 14 physical hash candidates among 1,406 live
 project files for Sep 2–8. Sep 6 had none. Complete warm benchmark queries are
 fast, but partial coverage and cold index loading remain expensive. Continue
 coverage and visibility optimization after the local release path is usable.
+
+## First production deployment and digest correction
+
+PR 240 merged as 750742d6. GitHub run 34358189411 found the local candidate,
+skipped compilation, passed native smoke, deployed, and passed its readiness
+soak: 46 probes with zero transient failures. The workflow completed successfully.
+
+During concurrent local preflight, inspection found that promotion wrapped the
+single image in a manifest index. Its outer digest differed from the candidate
+although the amd64 image manifest was identical. The local lease waiter was
+stopped before it acquired ownership or changed production. Comparing the two
+registry references reproduced a failing assertion before the fix.
+
+Digest resolution now selects exactly one Linux amd64 manifest. It rejects
+missing or ambiguous platform matches. Existing receipts are normalized too,
+so the first index-based receipt remains usable. The real registry comparison
+now passes; a regression test covers index wrappers and ambiguous platforms.
+
+Updated local signoff passed, reusing all five matching Rust results and running
+both helper suites. Image smoke passed and published digest
+`sha256:5f00b4db1acefb426fc8522b540fa4b75a8961805b3fee91087e98915d4d1c2d`.
+No required check remains for GitHub. The next rollout will exercise the local
+command directly; production hash latency acceptance remains open.

--- a/scripts/deploy/run.py
+++ b/scripts/deploy/run.py
@@ -49,7 +49,7 @@ def main():
         execute('python3', 'scripts/production-image.py', 'smoke', image)
         execute('docker', 'build', '-f', 'ci/deploy.Dockerfile', '-t', CLIENT, 'ci')
     else:
-        image = os.environ['IMAGE_URL']
+        image = output('python3', 'scripts/production-image.py', 'digest', os.environ['IMAGE_URL'])
     if not re.fullmatch(r'ghcr\.io/monoscope-tech/timefusion@sha256:[0-9a-f]{64}', image):
         parser.error('Deployment requires an immutable production image digest')
     values = {name: os.environ[name] for name in CREDENTIALS}
@@ -97,7 +97,8 @@ def main():
 
         previous = stage('record-boot')
         receipt = lease.record(RECEIPT_REF)
-        if receipt and receipt.get('image') == image and previous.get('boot_micros') and receipt.get('boot_micros') == previous['boot_micros']:
+        receipt_image = output('python3', 'scripts/production-image.py', 'digest', receipt['image']) if receipt else None
+        if receipt_image == image and previous.get('boot_micros') and receipt.get('boot_micros') == previous['boot_micros']:
             stage('soak')
             print('The tested image is already deployed on this boot; readiness soak passed.')
             return

--- a/scripts/production-image.py
+++ b/scripts/production-image.py
@@ -41,10 +41,23 @@ def digest(image):
     if not image.startswith((REGISTRY + ':', REGISTRY + '@')):
         raise ValueError('Only production-registry images can be resolved')
     manifest = json.loads(output('docker', 'buildx', 'imagetools', 'inspect', image, '--format', '{{json .Manifest}}'))
+    return REGISTRY + '@' + runtime_digest(manifest)
+
+
+def runtime_digest(manifest):
+    # Promotion may wrap an unchanged image in an index. Deployment receipts
+    # identify the actual Linux amd64 manifest, not that incidental wrapper.
+    if 'manifests' in manifest:
+        candidates = [entry for entry in manifest['manifests']
+                      if entry.get('platform', {}).get('os') == 'linux'
+                      and entry['platform'].get('architecture') == 'amd64']
+        if len(candidates) != 1:
+            raise RuntimeError('Production index must identify exactly one Linux amd64 image')
+        manifest = candidates[0]
     value = manifest['digest']
     if not re.fullmatch(r'sha256:[0-9a-f]{64}', value):
         raise RuntimeError('Registry returned an invalid image digest')
-    return REGISTRY + '@' + value
+    return value
 
 
 def smoke(image, recipe=ROOT / 'ci/smoke.Dockerfile'):

--- a/scripts/test-production-image.py
+++ b/scripts/test-production-image.py
@@ -9,6 +9,18 @@ import unittest
 
 
 class ImageSnapshotTest(unittest.TestCase):
+    def test_promoted_index_identifies_runtime_image(self):
+        spec = importlib.util.spec_from_file_location('production_image', Path(__file__).with_name('production-image.py'))
+        image = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(image)
+        runtime = {'digest': 'sha256:' + 'a' * 64, 'platform': {'os': 'linux', 'architecture': 'amd64'}}
+        attestation = {'digest': 'sha256:' + 'b' * 64, 'platform': {'os': 'unknown', 'architecture': 'unknown'}}
+        index = {'digest': 'sha256:' + 'c' * 64, 'manifests': [attestation, runtime]}
+        self.assertEqual(image.runtime_digest(index), image.runtime_digest(runtime))
+        for entries in ([], [attestation], [runtime, runtime]):
+            with self.subTest(entries=entries), self.assertRaises(RuntimeError):
+                image.runtime_digest(dict(index, manifests=entries))
+
     def test_build_inputs_and_frozen_context(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)


### PR DESCRIPTION
Image promotion wraps the locally built image in a manifest index. Comparing its outer digest with the original amd64 manifest could trigger a second rollout for identical runtime bytes. Resolve exactly one Linux amd64 manifest for both deployment and stored receipts; reject missing or ambiguous platform matches.

Validation: a real comparison of the published candidate and promoted `750742d` failed before the fix and passed afterward. Added wrapper/platform regression coverage. `CARGO_TARGET_DIR=/tmp/timefusion-isolated-target make ci-signoff` passed: all five unchanged Rust checks reused matching passing records, helper tests ran, and the image smoke passed. No required checks remain for GitHub. Published tested digest: `sha256:5f00b4db1acefb426fc8522b540fa4b75a8961805b3fee91087e98915d4d1c2d`.

The first reuse deployment (34358189411) completed successfully with compilation skipped and 46/46 readiness probes passing. The concurrent local waiter was stopped before any production mutation. The next rollout will exercise the local deployment path.
