### PR TITLE
Wait for the rollout observer to see the replacement

### DIFF
--- a/docs/plans/2026-09-09-local-production-image.md
+++ b/docs/plans/2026-09-09-local-production-image.md
@@ -95,3 +95,19 @@ both helper suites. Image smoke passed and published digest
 `sha256:5f00b4db1acefb426fc8522b540fa4b75a8961805b3fee91087e98915d4d1c2d`.
 No required check remains for GitHub. The next rollout will exercise the local
 command directly; production hash latency acceptance remains open.
+
+## Local observer race
+
+The local command on 95bdacb1 successfully flushed, drained HANDOFF, and
+submitted digest 5f00b4db. The replacement ran, but verification failed because
+the concurrent probe reported no first-new-boot observation. The foreground
+readiness query completed first and stopped the slower observer. Recorded
+unready time was 2,208 ms and WAL recovery was zero. The lease was retained;
+no successful deployment receipt was published for this failed verification.
+
+The rollout now waits for the background probe to observe the new boot before
+stopping it. Readiness and recovery budgets are unchanged. Bash syntax and
+updated local signoff passed; matching Rust checks and the tested production
+image were reused. A separate recovery soak and a new local rollout will
+verify the live state and correction. Do not reinterpret the failed observer
+as a passing rollout.

--- a/scripts/deploy/rollout.sh
+++ b/scripts/deploy/rollout.sh
@@ -15,6 +15,7 @@ probe_dir="$(mktemp -d)"
 probe_stop="$probe_dir/stop"
 probe_result="$probe_dir/max_unready_ms"
 handoff_result="$probe_dir/query_handoff_ms"
+handoff_observed="$probe_dir/handoff-observed"
 (
   unready_started_ms=0
   max_unready_ms=0
@@ -36,6 +37,7 @@ handoff_result="$probe_dir/query_handoff_ms"
         last_old_response_ms="$(date +%s%3N)"
       elif (( query_handoff_ms == 0 )); then
         query_handoff_ms=$(( $(date +%s%3N) - last_old_response_ms ))
+        touch "$handoff_observed"
       fi
     elif (( unready_started_ms == 0 )); then
       unready_started_ms="$attempt_started_ms"
@@ -79,7 +81,9 @@ replacement_deadline=$((SECONDS + 720))
 while (( deploy_status == 0 && SECONDS < replacement_deadline )); do
   boot_micros="$(timeout 3 psql "$PGURL" -v ON_ERROR_STOP=1 -Atqc "SELECT value FROM timefusion_stats WHERE component = 'buffered_layer' AND key = 'boot_micros'" 2>/dev/null || true)"
   recovery_complete="$(timeout 3 psql "$PGURL" -v ON_ERROR_STOP=1 -Atqc "SELECT value FROM timefusion_stats WHERE component = 'wal' AND key = 'recovery_complete'" 2>/dev/null || true)"
-  if [ -n "$boot_micros" ] && [ "$boot_micros" != "$PREVIOUS_BOOT_MICROS" ] && [ "$recovery_complete" = true ]; then
+  # The foreground readiness query can win the race against the background
+  # probe. Do not stop that probe before it observes the replacement itself.
+  if [ -n "$boot_micros" ] && [ "$boot_micros" != "$PREVIOUS_BOOT_MICROS" ] && [ "$recovery_complete" = true ] && [ -e "$handoff_observed" ]; then
     break
   fi
   sleep 0.5


### PR DESCRIPTION
The local rollout exposed a race: its foreground readiness query saw the replacement before the concurrent observer did, then stopped the observer. Verification correctly rejected the resulting zero handoff measurement even though the new image was running.

Wait for the observer's own new-boot observation before stopping it. The 10-second unready limit and WAL recovery budget remain unchanged.

Validation: the production local rollout reproduced the failure (2,208 ms measured unready, zero WAL recovery, missing handoff observation), and retained its lease. Bash syntax, diff checks, and `CARGO_TARGET_DIR=/tmp/timefusion-isolated-target make ci-signoff` passed. All five matching Rust checks and the previously tested image were reused; both helper test suites ran and passed. No required checks remain for GitHub. A separate recovery soak and local rollout will verify the fix in production.
