### PR TITLE
Record verified local image and production deployment workflow

### DIFF
--- a/docs/local-ci.md
+++ b/docs/local-ci.md
@@ -193,11 +193,14 @@ for the final smoke test. ARM64 Docker hosts automatically use a native QEMU
 emulator with an x86-64 guest address offset. The unchanged production image
 must stay running and pass its PGWire protocol probe. The first cross-build
 took about 40 minutes; warm rebuild speed is not yet measured.
-The publication and deployment path remains under validation. After the checked change is merged,
+Local cross-compilation, image publication, CI reuse, and production rollout
+have passed verification. After the checked change is merged,
 `make deploy` runs the shared handoff, rollout, recovery, and readiness soak
 from a clean checkout of the current master commit. It requires PGURL,
 CAPROVER_SERVER, CAPROVER_APP, and CAPROVER_TOKEN in the environment.
-Local rollout has not yet been exercised with production credentials.
+A verified local rollout measured 2,423 ms of continuous unavailability,
+zero WAL recovery time, and 55 passing readiness probes. A repeated invocation
+recognized the same image and boot, passed its soak, and did not restart it.
 
 Local and GitHub rollouts share a Git lease. A completed digest and live
 boot receipt avoids a duplicate restart. Failure after handoff begins

--- a/docs/plans/2026-09-09-local-production-image.md
+++ b/docs/plans/2026-09-09-local-production-image.md
@@ -111,3 +111,28 @@ updated local signoff passed; matching Rust checks and the tested production
 image were reused. A separate recovery soak and a new local rollout will
 verify the live state and correction. Do not reinterpret the failed observer
 as a passing rollout.
+
+## Verified local rollout
+
+The failed observer run received a separate recovery soak: 56 probes, zero
+failures. A live query confirmed boot 1788961446354900, completed WAL recovery,
+and zero recovery duration. The expected digest was running. Only then was
+lease 309522a14d1c5d1b931b4ae211c704439206f50b explicitly released with an
+owner-checked push. No successful receipt was created for the failed rollout.
+
+PR 242 merged as 8524b316. Its redundant CI rollout 34359412366 was cancelled
+before deployment work. The corrected `make deploy` exited 0: 2,525 ms between
+old/new query replies, 2,423 ms longest unready interval, zero WAL recovery,
+and a 55-probe readiness soak with no failures. The running task is
+wnq9wino83lpcb11ig1gx3qa0 at digest 5f00b4db. A successful receipt was published.
+
+The saved hash smoke ran against that exact digest and reproduced the known
+performance gap: 8/16 complete pairs, no mismatches, stable image, and day/week
+statement timeouts. Local release success does not close the hash latency goal.
+
+A second `make deploy` exited 0 without HANDOFF or rollout. It invoked only
+record-boot and soak, recognized the same digest and live boot, and passed
+55 more readiness probes with zero failures. This verifies duplicate invocation
+reuse. Documentation-only signoff (`CHECKS=fmt`) passed; the complete gate found
+all five matching Rust check records, helper tests passed, and the tested image
+was reused. No required check remains for GitHub.


### PR DESCRIPTION
Record the verified local cross-build, CI image reuse, production rollout, and repeat invocation that avoids a restart. Preserve the failed observer measurement and explicit recovery record. The hash day/week latency gap remains open.

Validation: `CARGO_TARGET_DIR=/tmp/timefusion-isolated-target make ci-signoff CHECKS=fmt` passed. The gate found all five matching Rust check records; helper tests passed and the tested image was reused. No required check remains for GitHub. This change only updates documentation.
