### PR TITLE
Add the production hash histogram probe and its benchmark review

### DIFF
--- a/bench/hash_histogram_production.py
+++ b/bench/hash_histogram_production.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Compare ordinary and native hash histograms on the saved production workload.
+
+Usage: python3 bench/hash_histogram_production.py <image-tag-or-digest-reference> <output.json>
+Requires psycopg, SSH access to the production host, and the sibling monoscope
+.env TIMEFUSION_PG_URL. Credentials are neither logged nor saved. This script
+runs read-only queries sequentially with a three-second statement timeout.
+Global counter deltas are supporting evidence, not per-query attribution.
+This is a smoke check, not the full release latency or workload acceptance.
+Exit 0 requires all pairs to complete and agree, all native queries to finish
+within three seconds, and the expected image to remain on running tasks.
+"""
+import datetime
+import json
+from pathlib import Path
+import subprocess
+import sys
+import time
+import uuid
+
+import psycopg
+
+ROOT = Path(__file__).resolve().parents[1]
+
+def image():
+    return subprocess.check_output([
+        'ssh', '-o', 'BatchMode=yes', '-o', 'ConnectTimeout=10',
+        'ubuntu@captain.s.past3.tech',
+        'docker service inspect srv-captain--timefusion --format "{{.Spec.TaskTemplate.ContainerSpec.Image}}"',
+    ], text=True).strip()
+
+def running_tasks():
+    raw = subprocess.check_output([
+        'ssh', '-o', 'BatchMode=yes', '-o', 'ConnectTimeout=10',
+        'ubuntu@captain.s.past3.tech',
+        'docker service ps srv-captain--timefusion --filter desired-state=running --no-trunc --format "{{json .}}"',
+    ], text=True)
+    return [json.loads(line) for line in raw.splitlines() if line.strip()]
+
+def matches_image(actual, expected):
+    return actual == expected if '@sha256:' in expected else actual.split('@')[0].rsplit(':', 1)[-1] == expected
+
+def ready(tasks, expected):
+    return bool(tasks) and all(
+        matches_image(task['Image'], expected)
+        and task['CurrentState'].startswith('Running ')
+        for task in tasks
+    )
+
+def main():
+    expected, destination = sys.argv[1:]
+    report = {'at': datetime.datetime.now(datetime.timezone.utc).isoformat(),
+              'image_before': image(), 'tasks_before': running_tasks(), 'queries': [], 'completed_pairs': 0, 'mismatch': False}
+    if not matches_image(report['image_before'], expected) or not ready(report['tasks_before'], expected):
+        raise SystemExit('Expected image is not deployed; no queries run.')
+    url = next(line.split('=', 1)[1].strip().strip('\"\'')
+               for line in (ROOT.parent / 'monoscope/.env').read_text().splitlines()
+               if line.startswith('TIMEFUSION_PG_URL='))
+    windows = [
+        ('narrow', '2026-09-02 08:04:30+00', '2026-09-02 08:04:31+00'),
+        ('positive_day', '2026-09-02 00:00:00+00', '2026-09-03 00:00:00+00'),
+        ('slow_day', '2026-09-06 00:00:00+00', '2026-09-07 00:00:00+00'),
+        ('week', '2026-09-02 00:00:00+00', '2026-09-09 00:00:00+00'),
+    ]
+    tags = [('saved', 'err:e03848c6'), ('absent', 'probe:' + uuid.uuid4().hex)]
+    try:
+        with psycopg.connect(url, connect_timeout=5, autocommit=True) as connection:
+            connection.execute("SET statement_timeout='3s'")
+            def stats():
+                return connection.execute("SELECT component,key,value FROM timefusion_stats WHERE key LIKE '%histogram%'").fetchall()
+            report['stats_before'] = stats()
+            for repeat in range(2):
+                for label, start, end in windows:
+                    for kind, tag in tags:
+                        pair = {}
+                        arms = ['count(timestamp)', 'count(*)']
+                        if repeat % 2:
+                            arms.reverse()
+                        for aggregate in arms:
+                            sql = (f"SELECT time_bucket('1 hour',timestamp), {aggregate} FROM otel_logs_and_spans "
+                                   "WHERE project_id='00000000-0000-0000-0000-000000000000' "
+                                   f"AND timestamp >= TIMESTAMPTZ '{start}' AND timestamp < TIMESTAMPTZ '{end}' "
+                                   f"AND hashes @> ARRAY['{tag}'] GROUP BY 1 ORDER BY 1")
+                            sample = {'repeat': repeat, 'window': label, 'tag_kind': kind, 'aggregate': aggregate, 'sql': sql}
+                            sample['stats_before'] = stats()
+                            began = time.monotonic()
+                            try:
+                                sample['rows'] = connection.execute(sql).fetchall()
+                                pair[aggregate] = sample['rows']
+                            except psycopg.Error as error:
+                                sample['error'] = {'type': type(error).__name__, 'sqlstate': error.sqlstate}
+                            sample['elapsed_ms'] = round((time.monotonic() - began) * 1000, 2)
+                            sample['stats_after'] = stats()
+                            report['queries'].append(sample)
+                            print(repeat, label, kind, aggregate, sample['elapsed_ms'], sample.get('error', sample.get('rows')), flush=True)
+                        if len(pair) == 2:
+                            report['completed_pairs'] += 1
+                            if pair['count(*)'] != pair['count(timestamp)']:
+                                report['mismatch'] = True
+                        if kind == 'absent' and any(pair.values()):
+                            report['mismatch'] = True
+                        if report['mismatch']:
+                            break
+                    if report['mismatch']:
+                        break
+                if report['mismatch']:
+                    break
+            report['stats_after'] = stats()
+    except psycopg.Error as error:
+        report['probe_error'] = {'type': type(error).__name__, 'sqlstate': error.sqlstate}
+    report['image_after'] = image()
+    report['tasks_after'] = running_tasks()
+    report['same_image'] = report['image_before'] == report['image_after'] and ready(report['tasks_after'], expected)
+    report['probe_passed'] = (
+        report['same_image'] and not report['mismatch'] and 'probe_error' not in report
+        and report['completed_pairs'] == 16
+        and all('error' not in sample and sample['elapsed_ms'] <= 3000
+                for sample in report['queries'] if sample['aggregate'] == 'count(*)')
+    )
+    Path(destination).write_text(json.dumps(report, indent=2, default=str) + '\n')
+    print(destination, 'probe_passed=', report['probe_passed'], 'completed_pairs=', report['completed_pairs'])
+    return 0 if report['probe_passed'] else 1
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/docs/plans/2026-09-09-hash-sql-benchmark-review.md
+++ b/docs/plans/2026-09-09-hash-sql-benchmark-review.md
@@ -1,0 +1,114 @@
+# Hash SQL benchmark review
+
+The harness uses the merged dd5647f implementation with real Delta files,
+local MinIO, physical Tantivy sidecars, and the ordinary SQL planner.
+It checks each hourly bucket against an independent arithmetic oracle.
+Repeated array terms count once; overlapping tag predicates form a union.
+An unindexed newer version removes the old matching row from the result.
+The harness requires the expected histogram and uniqueness counters.
+A timeout, wrong bucket, or wrong route fails the run.
+
+First rs-distill pass: reuse the existing database, MinIO configuration,
+record conversion, physical index builder, and SQL session helpers.
+Predicate, coverage, and route are enums. Query setup and expected results
+remain separate from measured execution. The nested oracle loops remain
+because explicit row-by-row counting is easy to compare with generated data.
+Benchmark JSON output is the artifact, not application logging.
+
+First rs-evasion pass: no hit cap, fake visibility mask, forced route,
+ignored error, unsafe code, or assertion suppression is introduced.
+The partial-coverage case performs a real newer-version insert. Its index
+is deliberately absent to measure the fallback, not to manufacture a pass.
+Review found that workers should stop before temporary storage is dropped.
+The harness now awaits Database::shutdown and propagates its failure.
+Shutdown occurs after measured queries and before publishing the result.
+
+Second scoped review: warm uniqueness proofs are an explicit setup condition,
+not evidence of cold-reader performance. The ordinary route uses
+count(timestamp), which is equivalent on this non-null fixture, and the
+native route uses count(*). Arm order reverses each repetition. Timing
+includes SQL planning and collection, but excludes network wire overhead.
+No remaining scoped finding. Optimized execution, cold-reader measurements,
+and concurrent-ingestion measurements are still pending.
+
+The production probe lives in bench/hash_histogram_production.py. It checks
+running task images before and after sequential queries. All sixteen pairs
+must complete and agree, and every native query must finish within three
+seconds, before its acceptance result can pass. Global counter deltas do
+not establish per-query attribution. Python compilation passed. An actual
+SSH check with an intentionally wrong image exited 1 before reading the DSN
+or running SQL and created no result artifact. Production execution awaits
+the deployment; no performance improvement is claimed from this check.
+
+Cold-reader extension: reuse the real restart fixture's configuration clone
+and separate data/index directory. Every cold arm gets a new Database and
+TantivySearchService. It must recover existing proofs from storage and pass
+the same exact bucket and route assertions. ReaderState labels each sample.
+The shared constructor keeps writer/reader wiring identical in both modes.
+Each case has four warm repetitions and one cold sample, for 240 queries.
+A single cold sample is not a latency distribution. MinIO and OS page caches
+remain warm; this measures fresh application caches, not cold storage media.
+Database construction is outside the timer; SQL planning and collection
+remain inside. Each cold database shuts down before its directory is dropped.
+
+Follow-up rs-distill review consolidated database/index construction instead
+of duplicating the setup. Follow-up rs-evasion review checked that the
+set-once search service is attached to a newly constructed database, not a
+clone of the warm database that would silently keep its old reader. No cache
+reset API or production configuration knob was added. Execution is pending
+the current optimized build; source review alone does not establish results.
+
+Release-scope review: rename the production script result to probe_passed.
+Two repetitions over this saved error and an absent hash cannot establish
+the plan's proposed p95 < 1 second and p99 < 2 seconds release targets.
+The three-second bound is only an initial smoke gate. Full validation also
+requires common endpoints, log patterns, overlapping hashes, 3/7/30-day
+windows, non-hourly buckets, recent data, chart API timing, concurrent
+ingestion, and maintenance progress. No smoke result can close that scope.
+
+Optimized execution completed successfully on 300,000 events (10,000/day).
+All 240 bucket and route assertions passed, including cold persisted proofs
+and unindexed replacements. Setup took 21.762 seconds; proof warmup took
+3.628 seconds. Compressed raw results and a summary with source/benchmark
+hashes are saved under evidence/2026-09-08-hashes/local-histogram-sql-optimized-300k*.
+
+At 30 days, complete warm native medians were 5.78–18.72 ms; ordinary
+medians were 41.63–46.26 ms. Complete cold native samples were 217.88–244.47 ms
+versus ordinary 100.24–138.81 ms. Partial warm native medians were
+302.82–428.96 ms versus ordinary 57.20–69.78 ms. Partial cold native samples
+were 524.05–584.75 ms versus ordinary 122.33–157.02 ms. These are local
+fixture results, not production latency forecasts or p95/p99 estimates.
+
+The partial-coverage and cold-reader costs are material gaps, even though
+this small workload finishes below one second. The unchanged optimized
+binary is now running 100,000 rows/day (three million total), session 25216,
+with /tmp/timefusion-hash-sql-optimized-100000.json and .log outputs.
+Use that scale result and production observations before choosing a fix.
+Do not present complete warm performance as evidence that the recent or
+partially covered production tail is fast.
+
+The three-million-event baseline passed all 240 cases. Complete warm 30-day
+medians were 8.47–142.81 ms, versus ordinary 122.97–156.40 ms. Partial warm
+medians were 730.08–980.74 ms, versus ordinary 152.90–175.20 ms. Partial cold
+samples were 1,416.89–1,801.51 ms, versus ordinary 271.10–295.33 ms.
+Raw and summarized scale evidence is saved as local-histogram-sql-optimized-3m*.
+
+A diagnostic build now retains symbols and adds existing SearchStats phase
+counters to each measurement. It passed all 240 cases too. Complete cold
+30-day queries recorded 30 blob fetches: fetch-plus-unpack accounted for
+644–752 ms, with reader opens about 21–22 ms, within 709–840 ms total.
+Warm partial cases recorded zero fetches and opens but still took about
+736–1,012 ms. Fetch counters include unpacking, not just network time.
+This separates a cold-cache cost from the remaining visibility/read work.
+
+The diagnostic binary is hash_histogram_sql-b0f1217e96d29072, built with
+`cargo rustc --release --bench hash_histogram_sql --locked -- -C strip=none`.
+Its symbol table is present; the original 92a1b55615e170c8 binary is stripped.
+The first sample attempt found the completed process and took no profile.
+A repeat now triggers sample automatically at the first partial-coverage
+fallback warning. Treat that repeat as profiled diagnostic data, not an
+unprofiled latency baseline.
+
+Review: Measurement and IndexIo keep metrics in named typed fields and reuse
+the existing counters. Cold measurements retain their own search service.
+No application behavior, runtime setting, or route assertion changed.


### PR DESCRIPTION
Tooling and documentation only; no crate source changes.

- `bench/hash_histogram_production.py` is the read-only acceptance probe used for the #244 release smoke. It was written during the investigation but never committed, so the only copy lived in a dirty worktree.
- `docs/plans/2026-09-09-hash-sql-benchmark-review.md` is the rs-distill / rs-evasion review record for the SQL benchmark.

Both paths are in deploy.yml's `paths-ignore`, so merging does not restart production. Credentials are read at runtime and never saved; measurement artifacts are deliberately left out.