### PR TITLE
Measure the partial-coverage route penalty and reject a route gate

### DIFF
--- a/docs/plans/2026-09-08-indexed-hash-histogram-plan.md
+++ b/docs/plans/2026-09-08-indexed-hash-histogram-plan.md
@@ -1845,3 +1845,58 @@ degrades to lost work and orphan blobs rather than wrong query results,
 because missing coverage falls back to scanning, but it would erase the very
 progress the drain intends to make. Both a conditional manifest write and a
 new subcommand would be required first.
+
+### Partial coverage is a pessimization, measured in production — 2026-09-09 18:35 UTC
+
+Correction first. An earlier note here said the native histogram route "has
+not executed once in production" because histogram_snapshots stayed 0. That
+reading was wrong. record_histogram_snapshot fires at the END of a partition,
+so a query cancelled at the statement timeout records its Parquet prepares
+and never reaches the snapshot counter. Prepares moving while snapshots stay
+0 means the route ran and did not finish, not that the route was skipped.
+
+Varying only the aggregate names the code path, and it produces a clear
+result. On the same one-hour window, same predicate, arms alternated across
+three repetitions with a twelve-second timeout:
+
+Sep 8, which has partial coverage of 21 of 73 live files, answered
+count(timestamp) in 899, 1,071 and 1,278 ms, and count(*) in 3,824, 5,114
+and 3,646 ms. The native route is 3.4 to 4.8 times SLOWER, in every
+alternation, and it exceeds the three-second dashboard bound while the
+ordinary scan stays under 1.3 seconds.
+
+Sep 2, which has no coverage at all, answered 539, 422 and 328 ms ordinary
+against 524, 523 and 298 ms native. Indistinguishable.
+
+So the penalty belongs to PARTIAL partition coverage specifically, not to
+missing coverage. This reproduces the local 3M benchmark, where partial warm
+native medians were 730-981 ms against ordinary 153-175 ms while complete
+warm native was 8-147 ms against ordinary 123-156 ms. Production shows a
+wider gap than the fixture did.
+
+The consequence matters more than the measurement. Every date passes through
+partial coverage on its way to complete coverage, so backfill drags each date
+through a regime where the chart query it is meant to accelerate is several
+times slower than it was before. Raising the backfill knobs at 18:00 UTC
+doubles the rate at which dates enter that regime. Sep 8 is in it now.
+
+A route gate conditional on complete partition coverage was considered and
+REJECTED. It would not help the queries this work exists to fix. Sep 6 and
+the Sep 2 to Sep 9 week exceed the three-second bound on count(timestamp)
+and count(*) alike, and Sep 6 has no coverage at all, so has_index is false
+and both aggregates already take the ordinary route. Its timeout is bytes,
+not routing. The penalty measured here applies only to a day that is midway
+through being indexed, and only at sub-day windows.
+
+That state is transient and self-healing. Sealed dates are indexed once and
+stay indexed, because compaction rewrites recent partitions rather than old
+ones, so each date leaves the degraded regime when its backfill completes and
+does not re-enter it. The correct response is to finish indexing those dates,
+which is the existing plan, not to add routing code that optimizes a few
+hours of transit on a path where a wrong-cost defect passes correctness
+tests unnoticed. No route behavior was changed by this reading.
+
+Worth watching rather than fixing: recent partitions ARE re-partialized by
+compaction, as Sep 9 going from 33 covered to 1 shows. If a recent date is
+observed sitting in the degraded regime persistently rather than passing
+through it, this decision should be revisited with that evidence.

--- a/docs/plans/evidence/2026-09-08-hashes/production-f007af8f-partial-coverage-route.json
+++ b/docs/plans/evidence/2026-09-08-hashes/production-f007af8f-partial-coverage-route.json
@@ -1,0 +1,18 @@
+{
+  "at": "2026-09-09T18:35:00+00:00",
+  "image": "ghcr.io/monoscope-tech/timefusion@sha256:f007af8f064b3a87c2a4828cc0889de119b2153cd09b1dd8b8894a8cce369556",
+  "method": "Same one-hour window, same predicate, arms alternated each repetition, 12s statement timeout, production pgwire.",
+  "query": "SELECT time_bucket('1 hour',timestamp), <aggregate> FROM otel_logs_and_spans WHERE project_id='00000000-0000-0000-0000-000000000000' AND timestamp >= <start> AND timestamp < <start>+1h AND hashes @> ARRAY['err:e03848c6'] GROUP BY 1 ORDER BY 1",
+  "cases": [
+    {"date": "2026-09-08", "coverage": "partial: 21 of 73 live files carry physical hash candidates",
+     "ordinary_count_timestamp_ms": [898.519, 1071.464, 1277.969],
+     "native_count_star_ms": [3823.566, 5114.337, 3646.176],
+     "ratio_native_over_ordinary": "3.4x to 4.8x slower"},
+    {"date": "2026-09-02", "coverage": "none: 0 of 21 live files",
+     "ordinary_count_timestamp_ms": [538.808, 422.147, 328.008],
+     "native_count_star_ms": [524.128, 523.443, 298.170],
+     "ratio_native_over_ordinary": "indistinguishable"}
+  ],
+  "limitations": "Six samples per date on a live box under concurrent maintenance; medians not distributions. One project and one tag. Does not measure a fully covered production date, because none exists yet.",
+  "reading": "The penalty is specific to PARTIAL partition coverage, not to absent coverage. It reproduces the local 3M benchmark, where partial native was 730-981 ms against ordinary 153-175 ms while complete native was 8-147 ms against ordinary 123-156 ms."
+}


### PR DESCRIPTION
Documentation and evidence only; no source change, no route behaviour changed.

- Varying only the aggregate isolates the code path. On a partially covered date (Sep 8, 21 of 73 files) the native route is 3.4–4.8x slower than the ordinary scan across three alternating repetitions; on an uncovered date (Sep 2) the two are indistinguishable. The penalty belongs to *partial* coverage, not missing coverage.
- Corrects an earlier claim that the native route "has not executed once in production". `record_histogram_snapshot` fires at the end of a partition, so a query cancelled at the statement timeout records its Parquet prepares and never reaches the snapshot counter.
- Records that a coverage-conditional route gate was **considered and rejected**: it would not help the shapes that matter, since Sep 6 and the Sep 2–9 week exceed three seconds on both aggregates and Sep 6 already takes the ordinary route. The degraded state is transient for sealed dates and resolves when their backfill completes.

Also notes what would justify revisiting: a recent date sitting persistently in the degraded regime rather than passing through it.