### PR TITLE
Backfill the newest data first, excluding today

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1024,8 +1024,23 @@ pub struct TantivyConfig {
     /// cannot fix that ordering; only a reservation can.
     ///
     /// Carved OUT of the cap, never added to it, so pass cost is unchanged.
-    /// 0 restores pure newest-first.
-    #[serde_inline_default(33)]
+    ///
+    /// DEFAULT 0 since 2026-09-09: the premise above no longer holds. That
+    /// measurement predates `skip_today`, which now drops today's partition
+    /// from the queue BEFORE this split runs, so the 624 hot files that once
+    /// buried the cap are never in it. Recent data is what every dashboard
+    /// queries and what maintenance should reach first, so the pass is pure
+    /// newest-first over everything except today.
+    ///
+    /// Measured cost of the old default, prod 2026-09-09: with a third of each
+    /// pass spent on mid-August, the unified project's Sep 1-7 gained ZERO
+    /// physical hash coverage across two 76- and 82-minute windows, while
+    /// fleet throughput rose 1.6x from a concurrency and budget raise. The
+    /// dashboard band is reached by ordering, not by throughput.
+    ///
+    /// Raise it again if the oldest files are observed frozen while newer ones
+    /// converge — that is the starvation this exists to prevent.
+    #[serde_inline_default(0)]
     pub timefusion_tantivy_backfill_tail_share_pct: u8,
     /// Skip TODAY's date partition in the backfill queue.
     ///
@@ -3128,6 +3143,18 @@ mod tests {
         // orders of magnitude throttled the cheap tables to protect the
         // expensive one. See the field's own comment.
         assert_eq!(cfg.timefusion_tantivy_backfill_max_files_per_pass, 320);
+
+        // The backfill order policy, as a pair: recent data first, today
+        // excluded. Neither half is safe alone. Pure newest-first WITHOUT
+        // `skip_today` is the 2026-08-22 starvation the reservation was added
+        // to fix, because today's churn refills faster than a pass drains it;
+        // a reservation WITH `skip_today` spends a third of every pass on the
+        // oldest files while the dashboard window it is meant to serve gains
+        // nothing (prod 2026-09-09: Sep 1-7 gained zero coverage over two
+        // consecutive hours). Changing either default alone reintroduces one
+        // of those two failures.
+        assert_eq!(cfg.timefusion_tantivy_backfill_tail_share_pct, 0);
+        assert!(cfg.timefusion_tantivy_backfill_skip_today);
 
         let derived = TantivyConfig::default();
         assert!(!derived.seed_cache_on_publish(), "derived Default really does diverge — that is why this test exists");


### PR DESCRIPTION
One-line default change plus its guard. `timefusion_tantivy_backfill_tail_share_pct` now defaults to **0** instead of 33.

## Why the old default no longer holds

The oldest-first reservation was sized on a 2026-08-22 measurement taken **before `skip_today` existed**, when today's churning partition could bury the file cap on its own (624 uncovered files against a 150-file cap) and no pass could reach yesterday. `skip_today` now defaults to true and drops today from the queue *before* this split runs, so that condition cannot arise. What the reservation does today is spend a third of every pass on the oldest files while the recent window every dashboard queries gains nothing.

## Measured

Production 2026-09-09: the unified project's Sep 1–7 gained **zero** physical hash coverage across two consecutive windows of 76 and 82 minutes, while fleet throughput rose 1.6x from a concurrency and byte-budget raise (48–52 builds/hour against 33; 3,653 MB planned per pass against 1,977). Ordering, not throughput, is what reaches the dashboard band.

## Scope and reversibility

The knob and `fair_tantivy_backfill_work_split` are unchanged, so raising the share restores the reservation if the oldest files are ever seen frozen while newer ones converge. The existing test that proves pure newest-first starves the tail still passes — it tests the function, not the default.

## Verification

- Red/green: reverting the default to 33 fails `tantivy_defaults_are_the_deserialized_ones_not_the_derived_ones` (`left: 33, right: 0`); restored, it passes.
- `cargo lint` clean, `cargo fmt --check` clean.
- Full suite: 1508 passed, 17 skipped.

The defaults test asserts both halves of the policy together, since either alone reintroduces one of the two measured failures.