### PR TITLE
Record the three-hour coverage rate and correct the ordering diagnosis

### DIFF
--- a/docs/plans/2026-09-08-indexed-hash-histogram-plan.md
+++ b/docs/plans/2026-09-08-indexed-hash-histogram-plan.md
@@ -1927,3 +1927,37 @@ So the full-index rebuild work on 548920d1, which projects only indexed
 columns and prepares variants once per batch, converts directly into coverage
 rate rather than merely creating idle headroom. Its end-to-end speedup is
 still unmeasured, and that measurement is what should decide whether it ships.
+
+### Three and a half hours on the raised knobs — 2026-09-09 22:12 UTC
+
+The knob raise is working at fleet level and is not reaching the dashboard
+band. Between 18:45 and 22:12 the manifest gained 98 hash entries fleet-wide,
+while the unified project's Sep 8 went from 24 to 29 covered files and Sep 1
+through Sep 7 stayed at exactly zero for the third consecutive reading.
+Sep 9 fell from 15 to 2 as compaction rewrote today's partition.
+
+Five files in three and a half hours is 1.4 per hour. Sep 8 alone has 44
+files left, about 31 hours at that rate, and Sep 1 to Sep 7 holds 166 more,
+which is roughly five days. Cumulative builds were 107 in the 4.2 hours since
+the restart, about 25 per hour, below the 48 to 52 per hour measured in the
+first pass, so the early rate did not hold.
+
+The reserved oldest-first share is not the whole cause, and the earlier
+entries here should be read with that correction.
+fair_tantivy_backfill_work round-robins projects EQUALLY, so the unified
+project receives about one twelfth of every pass regardless of holding the
+overwhelming majority of the queried data and of the uncovered backlog.
+Removing the 33% reservation raises its share from two thirds of one twelfth
+to one twelfth, roughly three times on the band, which puts Sep 8 near eleven
+hours and the week near two days. That is a real improvement and it is not
+the order-of-magnitude the band needs.
+
+Weighting each project's share by its uncovered backlog, rather than giving
+every project an equal slice, is the remaining ordering lever. It is not
+implemented and is deliberately held back so that the newest-first default
+can be measured on its own.
+
+One clear positive: the cache release stopped being dormant. histogram_
+snapshots reached 13 and histogram_delta_cache_hits reached 3, both from 0
+at the 17:45 probe, so the native route now completes in production and the
+released cache is being consulted.

--- a/docs/plans/evidence/2026-09-08-hashes/production-20260909-2212-physical-hash-coverage.json
+++ b/docs/plans/evidence/2026-09-08-hashes/production-20260909-2212-physical-hash-coverage.json
@@ -1,0 +1,186 @@
+{
+  "at": "2026-09-09T22:12:33.973076+00:00",
+  "project": "00000000-0000-0000-0000-000000000000",
+  "delta_version": 558234,
+  "live_project_files": 344,
+  "manifest_entries": 11651,
+  "manifest_hash_entries": 428,
+  "by_date": {
+    "2026-08-06": {
+      "live_files": 1,
+      "physical_hash_candidates": 1,
+      "missing_compressed_bytes": 0
+    },
+    "2026-08-07": {
+      "live_files": 1,
+      "physical_hash_candidates": 1,
+      "missing_compressed_bytes": 0
+    },
+    "2026-08-08": {
+      "live_files": 1,
+      "physical_hash_candidates": 1,
+      "missing_compressed_bytes": 0
+    },
+    "2026-08-09": {
+      "live_files": 1,
+      "physical_hash_candidates": 1,
+      "missing_compressed_bytes": 0
+    },
+    "2026-08-10": {
+      "live_files": 1,
+      "physical_hash_candidates": 1,
+      "missing_compressed_bytes": 0
+    },
+    "2026-08-11": {
+      "live_files": 1,
+      "physical_hash_candidates": 1,
+      "missing_compressed_bytes": 0
+    },
+    "2026-08-12": {
+      "live_files": 1,
+      "physical_hash_candidates": 1,
+      "missing_compressed_bytes": 0
+    },
+    "2026-08-13": {
+      "live_files": 2,
+      "physical_hash_candidates": 2,
+      "missing_compressed_bytes": 0
+    },
+    "2026-08-14": {
+      "live_files": 1,
+      "physical_hash_candidates": 1,
+      "missing_compressed_bytes": 0
+    },
+    "2026-08-15": {
+      "live_files": 1,
+      "physical_hash_candidates": 1,
+      "missing_compressed_bytes": 0
+    },
+    "2026-08-16": {
+      "live_files": 1,
+      "physical_hash_candidates": 1,
+      "missing_compressed_bytes": 0
+    },
+    "2026-08-17": {
+      "live_files": 1,
+      "physical_hash_candidates": 1,
+      "missing_compressed_bytes": 0
+    },
+    "2026-08-18": {
+      "live_files": 2,
+      "physical_hash_candidates": 1,
+      "missing_compressed_bytes": 71996755
+    },
+    "2026-08-19": {
+      "live_files": 2,
+      "physical_hash_candidates": 0,
+      "missing_compressed_bytes": 271901327
+    },
+    "2026-08-20": {
+      "live_files": 1,
+      "physical_hash_candidates": 0,
+      "missing_compressed_bytes": 268317102
+    },
+    "2026-08-21": {
+      "live_files": 1,
+      "physical_hash_candidates": 0,
+      "missing_compressed_bytes": 267308346
+    },
+    "2026-08-22": {
+      "live_files": 2,
+      "physical_hash_candidates": 0,
+      "missing_compressed_bytes": 269829327
+    },
+    "2026-08-23": {
+      "live_files": 2,
+      "physical_hash_candidates": 0,
+      "missing_compressed_bytes": 270877319
+    },
+    "2026-08-24": {
+      "live_files": 1,
+      "physical_hash_candidates": 0,
+      "missing_compressed_bytes": 269038444
+    },
+    "2026-08-25": {
+      "live_files": 2,
+      "physical_hash_candidates": 0,
+      "missing_compressed_bytes": 273329534
+    },
+    "2026-08-26": {
+      "live_files": 1,
+      "physical_hash_candidates": 0,
+      "missing_compressed_bytes": 252097422
+    },
+    "2026-08-27": {
+      "live_files": 4,
+      "physical_hash_candidates": 0,
+      "missing_compressed_bytes": 779980452
+    },
+    "2026-08-28": {
+      "live_files": 4,
+      "physical_hash_candidates": 0,
+      "missing_compressed_bytes": 866585256
+    },
+    "2026-08-29": {
+      "live_files": 4,
+      "physical_hash_candidates": 0,
+      "missing_compressed_bytes": 786204554
+    },
+    "2026-08-30": {
+      "live_files": 4,
+      "physical_hash_candidates": 0,
+      "missing_compressed_bytes": 815408628
+    },
+    "2026-08-31": {
+      "live_files": 3,
+      "physical_hash_candidates": 0,
+      "missing_compressed_bytes": 692090726
+    },
+    "2026-09-01": {
+      "live_files": 12,
+      "physical_hash_candidates": 0,
+      "missing_compressed_bytes": 809882564
+    },
+    "2026-09-02": {
+      "live_files": 26,
+      "physical_hash_candidates": 0,
+      "missing_compressed_bytes": 429265327
+    },
+    "2026-09-03": {
+      "live_files": 21,
+      "physical_hash_candidates": 0,
+      "missing_compressed_bytes": 257588291
+    },
+    "2026-09-04": {
+      "live_files": 22,
+      "physical_hash_candidates": 0,
+      "missing_compressed_bytes": 768498972
+    },
+    "2026-09-05": {
+      "live_files": 19,
+      "physical_hash_candidates": 0,
+      "missing_compressed_bytes": 810832101
+    },
+    "2026-09-06": {
+      "live_files": 33,
+      "physical_hash_candidates": 0,
+      "missing_compressed_bytes": 3461676219
+    },
+    "2026-09-07": {
+      "live_files": 31,
+      "physical_hash_candidates": 0,
+      "missing_compressed_bytes": 867764557
+    },
+    "2026-09-08": {
+      "live_files": 73,
+      "physical_hash_candidates": 29,
+      "missing_compressed_bytes": 486564814
+    },
+    "2026-09-09": {
+      "live_files": 61,
+      "physical_hash_candidates": 2,
+      "missing_compressed_bytes": 735264615
+    }
+  },
+  "limitations": "Delta and manifest read independently. Project URI selection cross-checked against add actions. Exact one-file URI/schema/ordinal/element metadata checked; index contents not decoded. Compressed file bytes are not projected I/O or build cost."
+}


### PR DESCRIPTION
Documentation and evidence only.

Between 18:45 and 22:12 on the raised knobs, the fleet gained 98 hash entries while the unified project's Sep 8 gained 5 and Sep 1–7 stayed at zero for a third consecutive reading. At 1.4 files/hour the dashboard week is roughly five days out.

Corrects the earlier diagnosis: the oldest-first reservation is not the whole cause. `fair_tantivy_backfill_work` round-robins projects **equally**, so the unified project gets ~1/12 of every pass despite holding most of the queried data and most of the backlog. Removing the reservation (#249) is ~3x on the band, not the order of magnitude it needs; backlog-weighting the split is the remaining lever, deliberately held back so #249 can be measured alone.

Also records the first production evidence that the shipped cache is live: `histogram_snapshots` 0 → 13 and `histogram_delta_cache_hits` 0 → 3.