### PR TITLE
Record the mature-process rate and the basis for shipping backlog weighting

### DIFF
--- a/docs/plans/2026-09-08-indexed-hash-histogram-plan.md
+++ b/docs/plans/2026-09-08-indexed-hash-histogram-plan.md
@@ -1994,3 +1994,36 @@ This measurement is not yet a clean rate. It spans a restart, and the first
 twenty-five minutes of any process are spent re-enumerating. A mature-process
 window is being measured to 01:45 UTC before deciding whether the
 backlog-weighted share in the follow-up is needed at all.
+
+### The mature-process rate, and why weighting still shipped — 2026-09-10 01:46 UTC
+
+The restart flattered the first reading, as expected. Over the mature window
+00:15 to 01:46 the fleet gained 81 manifest hash entries and Sep 8 gained
+seven, which is 4.6 an hour rather than the 18 an hour the post-restart burst
+suggested. Sep 9 gained 19 and Sep 10 gained 13. Sep 1 through Sep 7 is still
+zero, because newest-first is still working down Sep 9.
+
+The unified project took 39 of those 81 entries, about 48%. That is already
+far better than the one twelfth equal round-robin gave it, because its files
+ARE the newest ones and newest-first now reaches them. So the earlier
+"1/12 of every pass" framing describes the pre-#249 world and should not be
+quoted for the current one.
+
+Sep 10 is today and is excluded from backfill, so its 13 came from the flush
+path indexing new files at birth and cost the pass nothing. Backfill-eligible
+unified work is therefore Sep 9's remaining 42 files, then Sep 8's 17, then
+the 166 across Sep 1 to Sep 7. At the measured 26 entries an hour on
+backfill-eligible dates that is about thirteen hours, so the dashboard band
+would converge around midday rather than by morning.
+
+On that basis the backlog weighting merged as #251 rather than being held
+overnight. A pass places about 48 files; weighting is expected to move the
+unified share from roughly 23 of them to the high thirties, which is about
+1.6x on the band and turns thirteen hours into eight. The cost is one restart,
+whose first twenty-five minutes are re-enumeration.
+
+What this does NOT establish: the weighting's effect in production. That needs
+its own mature-process window, measured the same way, and the result should be
+compared against the 4.6 an hour recorded here. Fleet build throughput held at
+223 an hour across this window (450 builds in the 121 minutes since the
+restart), so build rate is not the constraint on the band — placement is.

--- a/docs/plans/evidence/2026-09-08-hashes/production-20260910-0146-physical-hash-coverage.json
+++ b/docs/plans/evidence/2026-09-08-hashes/production-20260910-0146-physical-hash-coverage.json
@@ -1,0 +1,191 @@
+{
+  "at": "2026-09-10T01:46:17.995193+00:00",
+  "project": "00000000-0000-0000-0000-000000000000",
+  "delta_version": 558665,
+  "live_project_files": 392,
+  "manifest_entries": 11816,
+  "manifest_hash_entries": 596,
+  "by_date": {
+    "2026-08-06": {
+      "live_files": 1,
+      "physical_hash_candidates": 1,
+      "missing_compressed_bytes": 0
+    },
+    "2026-08-07": {
+      "live_files": 1,
+      "physical_hash_candidates": 1,
+      "missing_compressed_bytes": 0
+    },
+    "2026-08-08": {
+      "live_files": 1,
+      "physical_hash_candidates": 1,
+      "missing_compressed_bytes": 0
+    },
+    "2026-08-09": {
+      "live_files": 1,
+      "physical_hash_candidates": 1,
+      "missing_compressed_bytes": 0
+    },
+    "2026-08-10": {
+      "live_files": 1,
+      "physical_hash_candidates": 1,
+      "missing_compressed_bytes": 0
+    },
+    "2026-08-11": {
+      "live_files": 1,
+      "physical_hash_candidates": 1,
+      "missing_compressed_bytes": 0
+    },
+    "2026-08-12": {
+      "live_files": 1,
+      "physical_hash_candidates": 1,
+      "missing_compressed_bytes": 0
+    },
+    "2026-08-13": {
+      "live_files": 2,
+      "physical_hash_candidates": 2,
+      "missing_compressed_bytes": 0
+    },
+    "2026-08-14": {
+      "live_files": 1,
+      "physical_hash_candidates": 1,
+      "missing_compressed_bytes": 0
+    },
+    "2026-08-15": {
+      "live_files": 1,
+      "physical_hash_candidates": 1,
+      "missing_compressed_bytes": 0
+    },
+    "2026-08-16": {
+      "live_files": 1,
+      "physical_hash_candidates": 1,
+      "missing_compressed_bytes": 0
+    },
+    "2026-08-17": {
+      "live_files": 1,
+      "physical_hash_candidates": 1,
+      "missing_compressed_bytes": 0
+    },
+    "2026-08-18": {
+      "live_files": 2,
+      "physical_hash_candidates": 2,
+      "missing_compressed_bytes": 0
+    },
+    "2026-08-19": {
+      "live_files": 2,
+      "physical_hash_candidates": 1,
+      "missing_compressed_bytes": 122990670
+    },
+    "2026-08-20": {
+      "live_files": 1,
+      "physical_hash_candidates": 0,
+      "missing_compressed_bytes": 268317102
+    },
+    "2026-08-21": {
+      "live_files": 1,
+      "physical_hash_candidates": 0,
+      "missing_compressed_bytes": 267308346
+    },
+    "2026-08-22": {
+      "live_files": 2,
+      "physical_hash_candidates": 0,
+      "missing_compressed_bytes": 269829327
+    },
+    "2026-08-23": {
+      "live_files": 2,
+      "physical_hash_candidates": 0,
+      "missing_compressed_bytes": 270877319
+    },
+    "2026-08-24": {
+      "live_files": 1,
+      "physical_hash_candidates": 0,
+      "missing_compressed_bytes": 269038444
+    },
+    "2026-08-25": {
+      "live_files": 2,
+      "physical_hash_candidates": 0,
+      "missing_compressed_bytes": 273329534
+    },
+    "2026-08-26": {
+      "live_files": 1,
+      "physical_hash_candidates": 0,
+      "missing_compressed_bytes": 252097422
+    },
+    "2026-08-27": {
+      "live_files": 4,
+      "physical_hash_candidates": 0,
+      "missing_compressed_bytes": 779980452
+    },
+    "2026-08-28": {
+      "live_files": 4,
+      "physical_hash_candidates": 0,
+      "missing_compressed_bytes": 866585256
+    },
+    "2026-08-29": {
+      "live_files": 4,
+      "physical_hash_candidates": 0,
+      "missing_compressed_bytes": 786204554
+    },
+    "2026-08-30": {
+      "live_files": 4,
+      "physical_hash_candidates": 0,
+      "missing_compressed_bytes": 815408628
+    },
+    "2026-08-31": {
+      "live_files": 3,
+      "physical_hash_candidates": 0,
+      "missing_compressed_bytes": 692090726
+    },
+    "2026-09-01": {
+      "live_files": 12,
+      "physical_hash_candidates": 0,
+      "missing_compressed_bytes": 809882564
+    },
+    "2026-09-02": {
+      "live_files": 26,
+      "physical_hash_candidates": 0,
+      "missing_compressed_bytes": 429265327
+    },
+    "2026-09-03": {
+      "live_files": 21,
+      "physical_hash_candidates": 0,
+      "missing_compressed_bytes": 257588291
+    },
+    "2026-09-04": {
+      "live_files": 22,
+      "physical_hash_candidates": 0,
+      "missing_compressed_bytes": 768498972
+    },
+    "2026-09-05": {
+      "live_files": 19,
+      "physical_hash_candidates": 0,
+      "missing_compressed_bytes": 810832101
+    },
+    "2026-09-06": {
+      "live_files": 14,
+      "physical_hash_candidates": 0,
+      "missing_compressed_bytes": 3393308871
+    },
+    "2026-09-07": {
+      "live_files": 31,
+      "physical_hash_candidates": 0,
+      "missing_compressed_bytes": 867764557
+    },
+    "2026-09-08": {
+      "live_files": 73,
+      "physical_hash_candidates": 56,
+      "missing_compressed_bytes": 323575096
+    },
+    "2026-09-09": {
+      "live_files": 76,
+      "physical_hash_candidates": 34,
+      "missing_compressed_bytes": 584296435
+    },
+    "2026-09-10": {
+      "live_files": 52,
+      "physical_hash_candidates": 17,
+      "missing_compressed_bytes": 43070483
+    }
+  },
+  "limitations": "Delta and manifest read independently. Project URI selection cross-checked against add actions. Exact one-file URI/schema/ordinal/element metadata checked; index contents not decoded. Compressed file bytes are not projected I/O or build cost."
+}


### PR DESCRIPTION
Documentation and evidence only.

Mature window 00:15 → 01:46: fleet +81 entries, Sep 8 +7 (4.6/hour, not the 18/hour the post-restart burst suggested), Sep 9 +19, Sep 10 +13, Sep 1–7 still zero.

**Corrects the "1/12 of every pass" framing** — that described the pre-#249 world. After newest-first the unified project already takes 48% of entries, because its files are the newest ones. Sep 10's gain came from the flush path, not backfill, so it cost the pass nothing.

Records why #251 shipped rather than waiting overnight: backfill-eligible unified work projects to ~13 hours at the measured rate, and weighting a ~48-file pass from ~23 to the high thirties turns that into ~8. Fleet build throughput held at 223/hour, so build rate is not the constraint — placement is.

States explicitly what is still unproven: the weighting's production effect needs its own mature-process window, compared against the 4.6/hour recorded here.