### PR TITLE
Record the weighted-share measurement and Sep 8's tenfold payoff

### DIFF
--- a/docs/plans/2026-09-08-indexed-hash-histogram-plan.md
+++ b/docs/plans/2026-09-08-indexed-hash-histogram-plan.md
@@ -2106,3 +2106,33 @@ fast. It is the clearest remaining work item on the read path.
 
 Coverage at this reading: Sep 9 complete, Sep 8 at 63 of 73, Sep 1 through
 Sep 7 still zero, fleet entries 676.
+
+### Weighting measured, and Sep 8 pays off tenfold — 2026-09-10 04:45 UTC
+
+The weighting and the builder change deployed together at 02:42 as
+sha256:792094edfa73e283792157f4c63e7c1dfdac7cd942a8f9897d1c7e. Over the mature
+window 03:38 to 04:45 the band gained 25 files, which is 22 an hour against
+the 4.6 an hour measured under newest-first alone. Sep 8 reached 73 of 73 and
+Sep 7 went from zero to 22 of 31. Fleet entries rose 690 to 747. Build
+throughput reached 286 an hour, up from 223.
+
+Attribution between the two changes is not separable, because the docs-merge
+supersede trap forced them into one deploy. Both were expected to raise the
+same number and both are still in place.
+
+Sep 8, complete and freshly indexed, answers a full twenty-four hour day in
+123 to 291 ms on count(*) against 1,449 to 2,079 ms on count(timestamp).
+That is roughly ten times faster, and better than Sep 9's 2.3x because these
+index blobs were built minutes earlier and are still in the local cache. The
+gap between the two is the cold-fetch cost, not a difference in the index.
+
+The transient penalty is visible in the same reading and behaves exactly as
+predicted. Sep 7, part-covered at 22 of 31, took 20,035 ms on count(*) against
+1,199 ms on count(timestamp). Sep 6, uncovered, took 13,048 and 11,581 ms,
+which is bytes rather than routing. So a date is slow while it transits and
+fast once it lands, and nothing about that needs a code change.
+
+Remaining band at this reading is 115 files across Sep 1 to Sep 7, about five
+hours at the measured rate. Memory is 26.8 GiB of the 120 GiB cap with no
+restarts since 02:42, so neither the raised concurrency nor the larger byte
+budget is pressuring the box.

--- a/docs/plans/evidence/2026-09-08-hashes/production-20260910-0445-physical-hash-coverage.json
+++ b/docs/plans/evidence/2026-09-08-hashes/production-20260910-0445-physical-hash-coverage.json
@@ -1,0 +1,191 @@
+{
+  "at": "2026-09-10T04:45:34.033124+00:00",
+  "project": "00000000-0000-0000-0000-000000000000",
+  "delta_version": 559423,
+  "live_project_files": 333,
+  "manifest_entries": 11960,
+  "manifest_hash_entries": 747,
+  "by_date": {
+    "2026-08-06": {
+      "live_files": 1,
+      "physical_hash_candidates": 1,
+      "missing_compressed_bytes": 0
+    },
+    "2026-08-07": {
+      "live_files": 1,
+      "physical_hash_candidates": 1,
+      "missing_compressed_bytes": 0
+    },
+    "2026-08-08": {
+      "live_files": 1,
+      "physical_hash_candidates": 1,
+      "missing_compressed_bytes": 0
+    },
+    "2026-08-09": {
+      "live_files": 1,
+      "physical_hash_candidates": 1,
+      "missing_compressed_bytes": 0
+    },
+    "2026-08-10": {
+      "live_files": 1,
+      "physical_hash_candidates": 1,
+      "missing_compressed_bytes": 0
+    },
+    "2026-08-11": {
+      "live_files": 1,
+      "physical_hash_candidates": 1,
+      "missing_compressed_bytes": 0
+    },
+    "2026-08-12": {
+      "live_files": 1,
+      "physical_hash_candidates": 1,
+      "missing_compressed_bytes": 0
+    },
+    "2026-08-13": {
+      "live_files": 2,
+      "physical_hash_candidates": 2,
+      "missing_compressed_bytes": 0
+    },
+    "2026-08-14": {
+      "live_files": 1,
+      "physical_hash_candidates": 1,
+      "missing_compressed_bytes": 0
+    },
+    "2026-08-15": {
+      "live_files": 1,
+      "physical_hash_candidates": 1,
+      "missing_compressed_bytes": 0
+    },
+    "2026-08-16": {
+      "live_files": 1,
+      "physical_hash_candidates": 1,
+      "missing_compressed_bytes": 0
+    },
+    "2026-08-17": {
+      "live_files": 1,
+      "physical_hash_candidates": 1,
+      "missing_compressed_bytes": 0
+    },
+    "2026-08-18": {
+      "live_files": 2,
+      "physical_hash_candidates": 2,
+      "missing_compressed_bytes": 0
+    },
+    "2026-08-19": {
+      "live_files": 2,
+      "physical_hash_candidates": 1,
+      "missing_compressed_bytes": 122990670
+    },
+    "2026-08-20": {
+      "live_files": 1,
+      "physical_hash_candidates": 0,
+      "missing_compressed_bytes": 268317102
+    },
+    "2026-08-21": {
+      "live_files": 1,
+      "physical_hash_candidates": 0,
+      "missing_compressed_bytes": 267308346
+    },
+    "2026-08-22": {
+      "live_files": 2,
+      "physical_hash_candidates": 0,
+      "missing_compressed_bytes": 269829327
+    },
+    "2026-08-23": {
+      "live_files": 2,
+      "physical_hash_candidates": 0,
+      "missing_compressed_bytes": 270877319
+    },
+    "2026-08-24": {
+      "live_files": 1,
+      "physical_hash_candidates": 0,
+      "missing_compressed_bytes": 269038444
+    },
+    "2026-08-25": {
+      "live_files": 2,
+      "physical_hash_candidates": 0,
+      "missing_compressed_bytes": 273329534
+    },
+    "2026-08-26": {
+      "live_files": 1,
+      "physical_hash_candidates": 0,
+      "missing_compressed_bytes": 252097422
+    },
+    "2026-08-27": {
+      "live_files": 4,
+      "physical_hash_candidates": 0,
+      "missing_compressed_bytes": 779980452
+    },
+    "2026-08-28": {
+      "live_files": 4,
+      "physical_hash_candidates": 0,
+      "missing_compressed_bytes": 866585256
+    },
+    "2026-08-29": {
+      "live_files": 4,
+      "physical_hash_candidates": 0,
+      "missing_compressed_bytes": 786204554
+    },
+    "2026-08-30": {
+      "live_files": 4,
+      "physical_hash_candidates": 0,
+      "missing_compressed_bytes": 815408628
+    },
+    "2026-08-31": {
+      "live_files": 3,
+      "physical_hash_candidates": 0,
+      "missing_compressed_bytes": 692090726
+    },
+    "2026-09-01": {
+      "live_files": 4,
+      "physical_hash_candidates": 0,
+      "missing_compressed_bytes": 782433363
+    },
+    "2026-09-02": {
+      "live_files": 26,
+      "physical_hash_candidates": 0,
+      "missing_compressed_bytes": 429265327
+    },
+    "2026-09-03": {
+      "live_files": 21,
+      "physical_hash_candidates": 0,
+      "missing_compressed_bytes": 257588291
+    },
+    "2026-09-04": {
+      "live_files": 22,
+      "physical_hash_candidates": 0,
+      "missing_compressed_bytes": 768498972
+    },
+    "2026-09-05": {
+      "live_files": 19,
+      "physical_hash_candidates": 0,
+      "missing_compressed_bytes": 810832101
+    },
+    "2026-09-06": {
+      "live_files": 14,
+      "physical_hash_candidates": 0,
+      "missing_compressed_bytes": 3393308871
+    },
+    "2026-09-07": {
+      "live_files": 31,
+      "physical_hash_candidates": 22,
+      "missing_compressed_bytes": 26251084
+    },
+    "2026-09-08": {
+      "live_files": 73,
+      "physical_hash_candidates": 73,
+      "missing_compressed_bytes": 0
+    },
+    "2026-09-09": {
+      "live_files": 76,
+      "physical_hash_candidates": 76,
+      "missing_compressed_bytes": 0
+    },
+    "2026-09-10": {
+      "live_files": 1,
+      "physical_hash_candidates": 0,
+      "missing_compressed_bytes": 170364147
+    }
+  },
+  "limitations": "Delta and manifest read independently. Project URI selection cross-checked against add actions. Exact one-file URI/schema/ordinal/element metadata checked; index contents not decoded. Compressed file bytes are not projected I/O or build cost."
+}


### PR DESCRIPTION
Documentation and evidence only.

Mature window 03:38 → 04:45 on the combined deploy: the band gained 25 files, **22/hour against 4.6/hour** under newest-first alone. Sep 8 reached 73/73, Sep 7 went 0 → 22 of 31, fleet 690 → 747, build throughput 286/hour against 223.

Attribution between #251 and #252 is not separable — the docs-merge supersede trap forced them into one deploy.

**Sep 8, complete and freshly indexed, answers a full day in 123–291 ms against 1,449–2,079 ms — about 10x.** Better than Sep 9's 2.3x because these blobs were built minutes earlier and are still cached locally; the gap between the two dates *is* the cold-fetch cost.

The transient penalty behaves as predicted: Sep 7 at 22/31 took 20,035 ms native against 1,199 ms ordinary, while uncovered Sep 6 took 13,048 and 11,581 — bytes, not routing. A date is slow while it transits and fast once it lands.

Remaining band 115 files, ~5 hours. Memory 26.8 of 120 GiB, no restarts since 02:42.