### PR TITLE
Mint a base rebuild only for refusals the current generation cannot reproduce

### DIFF
--- a/src/database/maintain.rs
+++ b/src/database/maintain.rs
@@ -2612,7 +2612,7 @@ impl Database {
         } else {
             Vec::new()
         };
-        let (snapshot, log_store, selected, estimated_bytes, source_rows, partition_identity, whole_file_bytes, content_fp) = {
+        let (snapshot, log_store, selected, estimated_bytes, source_rows, partition_identity, whole_file_bytes, content_fp, refused_spans, selected_spans) = {
             let table = from_table.read().await;
             let witness_guard = match &witness_table {
                 Some(table) => Some(table.read().await),
@@ -2646,6 +2646,8 @@ impl Database {
             let partition_identity = partition_stats.map(|stats| (stats.fingerprint, stats.min_ts, stats.max_ts));
             let partition_paths = dedup_partition_paths(snapshot.log_data().iter().map(|file| file.path().to_string()), &key.project_id, &date_string);
             let mut selected = Vec::new();
+            let mut refused_spans: Vec<Option<(i64, i64)>> = Vec::new();
+            let mut selected_spans: Vec<(i64, i64)> = Vec::new();
             let mut estimated = 0u64;
             let mut whole_file_bytes = 0u64;
             let mut content_fp = 0u64;
@@ -2728,7 +2730,24 @@ impl Database {
                         .is_some_and(|generation| base_generations.contains(generation))
                     {
                         skipped_generation += 1;
+                        // WHAT was refused, not just how many. A refusal only
+                        // costs something if no CURRENT-generation file
+                        // reproduces the same span — see the mint below. The
+                        // tagged range is the file's own claim; a file with no
+                        // tags falls back to its statistics, and one with
+                        // neither is unbounded and can never be shown
+                        // reproduced (`None`), which keeps the mint firing.
+                        refused_spans.push(slice_tag_range(&add).map(|(start, end)| (start, end.saturating_sub(1))).or_else(|| match add_ts_bounds(&add) {
+                            (Some(lo), Some(hi)) => Some((lo, hi)),
+                            _ => None,
+                        }));
                         continue;
+                    }
+                    // The span this ACCEPTED file vouches for, against which a
+                    // refusal is judged. Taken from the same tags the refusal
+                    // reads, so the two are the same kind of claim.
+                    if let Some(range) = slice_tag_range(&add) {
+                        selected_spans.push(range);
                     }
                 }
                 let decoded = estimated_decoded_bytes(add.size);
@@ -2745,7 +2764,7 @@ impl Database {
                 content_fp ^= file_content_hash(&path, add.deletion_vector.as_ref());
                 selected.push(path);
             }
-            (snapshot, table.log_store(), selected, estimated, source_rows, partition_identity, whole_file_bytes, content_fp)
+            (snapshot, table.log_store(), selected, estimated, source_rows, partition_identity, whole_file_bytes, content_fp, refused_spans, selected_spans)
         };
         let input_footprint = crate::maintenance_coordinator::InputFootprint::new(&selected, whole_file_bytes);
         // Same reason as the dedup preflight: record it on every claim, not only
@@ -2778,10 +2797,36 @@ impl Database {
                 "base files carry no slice tags; checked by timestamp range and materialization generation"
             );
         }
-        if skipped_generation > 0 {
-            // Excluding an unverified file is not evidence that its rows were
-            // empty. Rebuild this base range from its source and retry the
-            // derived unit, even if an in-memory coverage claim still spans it.
+        // Excluding an unverified file is not evidence that its rows were empty,
+        // so a refusal normally means: rebuild this base range from its source
+        // and retry the derived unit. #221 deliberately does that even when an
+        // in-memory coverage claim still spans the range, because that map is
+        // not trustworthy enough to authorize dropping rows.
+        //
+        // But a refusal whose span is ALREADY reproduced by the CURRENT-generation
+        // files this unit selected costs nothing to exclude, and demanding a
+        // rebuild for it is a livelock: the rebuild republishes the same slices
+        // and cannot retire the offending file, because `slice_retires` only
+        // retires a tagged file CONTAINED in the publishing slice and the
+        // offender is wider than the children the day is published as. Prod
+        // 2026-09-11 measured the result — derived units at attempts=78, minting
+        // a fresh base rebuild every `60 << 5` = 1920s forever, with
+        // `skipped_generation=1` doing it. ONE stale file.
+        //
+        // The test is made against `selected_spans` — the tags of the files this
+        // unit is actually reading out of the live tier snapshot — and NOT
+        // against `base_covered`, which comes from the coverage map #221 chose
+        // to distrust. `ranges_cover`'s `hi` is inclusive, which is why the
+        // refused spans were pushed with an inclusive end.
+        //
+        // A refusal with no readable span at all is `None` and is never counted
+        // as reproduced, so the unbounded case still mints. Excluding a file
+        // this way does not let the unit publish short either: the
+        // `uncovered(slice, base_covered)` gate below is the real safety net and
+        // still refuses a derived cell over a holey base.
+        let unreproduced = crate::rollup::unreproduced_refusals(&refused_spans, &selected_spans);
+        if unreproduced > 0 {
+            crate::observability::maintenance_stats().rollup_base_refusal_unreproduced.fetch_add(unreproduced, Relaxed);
             let base_spec = source_schema
                 .rollups
                 .iter()
@@ -2805,6 +2850,9 @@ impl Database {
             let attempts = self.journal().attempts(&key);
             retry("base_generation_unverified".to_owned(), std::time::Duration::from_secs(60u64 << attempts.min(5)))?;
             return Ok(true);
+        }
+        if skipped_generation > 0 {
+            crate::observability::maintenance_stats().rollup_base_refusal_reproduced.fetch_add(skipped_generation, Relaxed);
         }
         // A DERIVED unit's witness describes the RAW partition, but its INPUT is
         // the base tier — witness table != input table, which is the one

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -14386,6 +14386,98 @@ mod tests {
 
     /// Every live path in one tier partition, which is what "did the commit
     /// land?" means here.
+    /// A stale-generation base file whose span the CURRENT-generation files
+    /// already reproduce must not hold the derived tier hostage.
+    ///
+    /// Prod 2026-09-11: derived units sat at `attempts=78`, minting a fresh
+    /// day-wide base rebuild every `60 << 5` = 1920s — an exact 32-minute cycle —
+    /// over `skipped_generation=1`. ONE stale file. The rebuild can never clear
+    /// it, because `slice_retires` only retires a tagged file CONTAINED in the
+    /// publishing slice and the offender is wider than the children a day is
+    /// published as, so the loop is permanent. It cost 59% of maintenance
+    /// worker-seconds between them.
+    ///
+    /// Refusing to READ the file stays correct — `rollup_routing_rejects_legacy_materialization_generations`
+    /// pins that, and the `uncovered(slice, base_covered)` gate still refuses a
+    /// derived cell over a genuinely holey base. What changes is only whether the
+    /// refusal also DEMANDS a rebuild that provably cannot change the outcome.
+    ///
+    /// Can-fail proof, run red then restored: making `unreproduced_refusals`
+    /// return `refused.len()` — the previous always-mint behaviour — turns the
+    /// Complete assertion red with `base_generation_unverified`.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_stale_base_file_the_current_generation_reproduces_does_not_wedge_the_derived_tier() -> Result<()> {
+        use crate::maintenance_coordinator::{Operation, TAG_GENERATION, TaskState};
+        use deltalake::kernel::{
+            Action,
+            transaction::{CommitBuilder, TableReference},
+        };
+        use object_store::ObjectStoreExt as _;
+        let db = Arc::new(Database::with_config(create_test_config("rollup-stale-gen-reproduced")).await?);
+        db.cancel_maintenance();
+        let project = format!("stalegen_{}", uuid::Uuid::new_v4().simple());
+        let day = (Utc::now() - chrono::Duration::days(3)).date_naive();
+        for hour in [1, 7, 13, 19] {
+            let at = day.and_hms_opt(hour, 0, 0).expect("hour").and_utc().timestamp_micros();
+            let batch = json_to_batch(vec![test_span_ts(&format!("row-{hour}"), "op", &project, at)])?;
+            db.insert_records_batch(&project, "otel_logs_and_spans", vec![batch], true, None).await?;
+        }
+        let base_tier = get_schema("otel_logs_and_spans")
+            .and_then(|schema| schema.rollups.iter().find(|spec| spec.derive_from.is_none()).map(|spec| spec.table_name("otel_logs_and_spans")))
+            .expect("a base tier");
+        db.run_unit_once("otel_logs_and_spans", &project, day, Operation::BaseRollup, 24, 0).await?;
+
+        // A second copy of every base file, same slice tags, GENERATION mangled —
+        // the shape a spec change leaves behind. The originals stay live, so the
+        // current generation still reproduces every span the copies claim.
+        {
+            let tier = db.get_or_create_table(&project, &base_tier).await?;
+            let mut table = tier.read().await.clone();
+            let store = table.log_store().object_store(None);
+            #[allow(deprecated)]
+            let adds: Vec<_> = table.snapshot()?.log_data().iter().map(|file| file.add_action()).collect();
+            assert!(!adds.is_empty(), "the base unit must have published files for there to be a stale copy of one");
+            let mut actions = Vec::new();
+            for mut add in adds {
+                let path = format!("{}-stalegen.parquet", add.path.trim_end_matches(".parquet"));
+                store.copy(&deltalake::Path::from(add.path.clone()), &deltalake::Path::from(path.clone())).await?;
+                add.path = path;
+                add.data_change = false;
+                if let Some(tags) = add.tags.as_mut() {
+                    tags.insert(TAG_GENERATION.to_owned(), Some("stale-generation".to_owned()));
+                }
+                actions.push(Action::Add(add));
+            }
+            let op = deltalake::protocol::DeltaOperation::Write { mode: deltalake::protocol::SaveMode::Append, partition_by: None, predicate: None };
+            let finalized = CommitBuilder::default().with_actions(actions).build(Some(table.snapshot()? as &dyn TableReference), table.log_store(), op).await?;
+            table.state = Some(finalized.snapshot());
+            *tier.write().await = table;
+        }
+
+        let derived = db.run_unit_once("otel_logs_and_spans", &project, day, Operation::DerivedRollup, 24, 0).await?;
+        assert_eq!(
+            derived.state,
+            Some(TaskState::Complete),
+            "a stale file the live current-generation files already reproduce must not demand a base rebuild: {:?}",
+            derived.retry_reason
+        );
+        let stats = crate::observability::maintenance_stats();
+        assert!(
+            stats.rollup_base_refusal_reproduced.load(std::sync::atomic::Ordering::Relaxed) > 0,
+            "the refusal must still HAPPEN and be counted — this is about the mint, not about reading the stale file"
+        );
+
+        // And the derived tier holds the truth, not a short cell: four source rows.
+        let derived_tier = get_schema("otel_logs_and_spans")
+            .and_then(|schema| schema.rollups.iter().find(|spec| spec.derive_from.is_some()).map(|spec| spec.table_name("otel_logs_and_spans")))
+            .expect("a derived tier");
+        let mut ctx = Arc::clone(&db).create_session_context();
+        db.setup_session_context(&mut ctx)?;
+        let batches = ctx.sql(&format!("SELECT SUM(request_count) FROM {derived_tier} WHERE project_id='{project}'")).await?.collect().await?;
+        assert_eq!(batches[0].column(0).as_any().downcast_ref::<arrow::array::Int64Array>().expect("int64").value(0), 4);
+        Ok(())
+    }
+
     async fn live_paths(db: &Database, project: &str, tier: &str) -> std::collections::HashSet<String> {
         let table_ref = db.get_or_create_table(project, tier).await.expect("table");
         let table = table_ref.read().await;

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -1070,6 +1070,25 @@ atomic_stats! {
         /// however busy maintenance gets. Tracking the checkpoint rate instead
         /// means the throttle is not firing.
         journal_stats_publishes as "journal_stats_publishes_total",
+        /// Base files a DERIVED unit refused for an obsolete generation, split by
+        /// whether refusing them actually cost anything.
+        ///
+        /// `reproduced` — the CURRENT-generation files the unit selected already
+        /// cover the refused file's whole span, so excluding it loses no rows and
+        /// no rebuild is demanded. This is the livelock that was: prod 2026-09-11
+        /// had derived units at attempts=78 minting a base rebuild every 32
+        /// minutes over `skipped_generation=1`, and the rebuild could never clear
+        /// it because `slice_retires` only retires a file CONTAINED in the
+        /// publishing slice.
+        ///
+        /// `unreproduced` — a genuine hole in current-generation evidence. The
+        /// unit mints the base rebuild and retries, exactly as before.
+        ///
+        /// Chronically rising `reproduced` with a flat `rollup_tier_untagged_found`
+        /// means obsolete tier files are accumulating and nothing retires them —
+        /// real garbage, but no longer a livelock.
+        rollup_base_refusal_reproduced as "rollup_base_refusal_reproduced_total",
+        rollup_base_refusal_unreproduced as "rollup_base_refusal_unreproduced_total",
         /// Waves not STARTED because the WAL was over its emergency-flush threshold
         /// (durability outranks compaction) or memory was near the cgroup limit.
         /// Chronic nonzero = compaction is being starved, not protected.

--- a/src/rollup.rs
+++ b/src/rollup.rs
@@ -978,6 +978,43 @@ pub(crate) fn slice_retires(file: &LiveFile<'_>, publish: &SlicePublish<'_>) -> 
     }
 }
 
+/// How many obsolete-generation refusals a derived unit must actually pay for.
+///
+/// A derived unit refuses a base file whose materialization generation is not
+/// current, and historically ANY refusal made it demand a base rebuild and
+/// retry. That is a livelock whenever the refused file's span is already
+/// reproduced by the current-generation files the unit selected: the rebuild
+/// republishes the same slices and cannot retire the offender, because
+/// `slice_retires` only retires a tagged file CONTAINED in the publishing slice
+/// and the offender is wider than the children a day is published as. Prod
+/// 2026-09-11 sat at `attempts=78`, re-minting every 32 minutes, over
+/// `skipped_generation=1` — one stale file.
+///
+/// `refused` spans are INCLUSIVE of both ends (matching [`ranges_cover`]), and
+/// `None` means the file would not say what it holds — which can never be shown
+/// reproduced, so it always counts.
+///
+/// ```
+/// # use timefusion::rollup::unreproduced_refusals as unpaid;
+/// const H: i64 = 3_600_000_000;
+/// // The prod shape: one stale DAY-wide file over a day published as two halves.
+/// // Both halves are selected, they tile the day, so refusing it costs nothing.
+/// assert_eq!(unpaid(&[Some((0, 24 * H - 1))], &[(0, 12 * H), (12 * H, 24 * H)]), 0);
+/// // A real hole: the selected files stop at noon, the refusal reaches past it.
+/// assert_eq!(unpaid(&[Some((0, 24 * H - 1))], &[(0, 12 * H)]), 1);
+/// // A gap anywhere in the middle is still a hole.
+/// assert_eq!(unpaid(&[Some((0, 24 * H - 1))], &[(0, 6 * H), (7 * H, 24 * H)]), 1);
+/// // A file that cannot say what it holds always counts — never assume empty.
+/// assert_eq!(unpaid(&[None], &[(0, 24 * H)]), 1);
+/// // Nothing selected reproduces nothing.
+/// assert_eq!(unpaid(&[Some((0, H))], &[]), 1);
+/// // Counts the refusals that are unpaid, not whether any refusal happened.
+/// assert_eq!(unpaid(&[Some((0, H)), Some((20 * H, 30 * H))], &[(0, 24 * H)]), 1);
+/// ```
+pub fn unreproduced_refusals(refused: &[Option<(i64, i64)>], selected: &[(i64, i64)]) -> u64 {
+    refused.iter().filter(|span| !span.is_some_and(|span| ranges_cover(selected, span))).count() as u64
+}
+
 /// Whether the union of `ranges` covers every instant in `[lo, hi]`.
 ///
 /// `hi` is INCLUSIVE — it is a row's timestamp, straight from file statistics —


### PR DESCRIPTION
## The livelock

A derived unit refuses a base file whose materialization generation is not current, and any refusal then made it enqueue a fresh base rebuild and retry at `60 << attempts.min(5)`.

When the refused file's span is **already reproduced** by the current-generation files the unit selected, that is a livelock. The rebuild republishes the same slices and **cannot retire the offender**: `slice_retires` only retires a tagged file CONTAINED in the publishing slice, and the offender is wider than the children a day is published as.

Production was sitting in it on 2026-09-11 — derived units at `attempts=78`, minting a day-wide base rebuild every **1920s (an exact 32-minute cycle)**, driven by `skipped_generation=1`. One stale file per day, per project. Each cycle the base republished byte-identical output for 51-60s.

```
6  dashboard_1h_v2  87576849  skipped_generation=1
5  dashboard_1h_v2  28f62f01  skipped_generation=1
6  metrics_1h_v2    00000000  skipped_generation=1
1  dashboard_1h_v2  6297304f  skipped_generation=6
```

This is the companion to the no-op skip already on master (`6b533469`), which made the loop metadata-cheap but left it spinning. This stops the spin.

## What does NOT change

The refusal itself. The stale file is still **not read**, so #221's result stands, and the `uncovered(slice, base_covered)` gate still refuses a derived cell over a genuinely holey base. Only the *demand for a rebuild* changes.

The test is made against the tags of the files this unit actually selected out of the **live tier snapshot** — deliberately **not** against `base_covered`, which comes from the coverage map #221 chose to distrust. A refusal with no readable span is `None` and can never be shown reproduced, so the unbounded case still mints.

## Verification

The whole lib suite passed with the old always-mint behaviour restored — which is *why* the new test had to be written; nothing pinned the new behaviour.

- **reproduced → Complete**: `a_stale_base_file_the_current_generation_reproduces_does_not_wedge_the_derived_tier`. Run red under the old behaviour, failing with `base_generation_unverified`.
- **unreproduced → still mints**: the existing `rollup_routing_rejects_legacy_materialization_generations`.
- `unreproduced_refusals` carries a doctest for the boundary cases (day tiled by halves, hole at the end, hole in the middle, unreadable span, nothing selected).

`cargo lint` clean, full suite 1516/1516.

## Watching it

New counters split refusals by whether they cost anything: `rollup_base_refusal_reproduced_total` / `_unreproduced_total`. Rising `reproduced` against a flat `rollup_tier_untagged_found` means obsolete tier files are accumulating with nothing retiring them — real garbage, but no longer a livelock. **Retiring them is a separate, data-removing change and deliberately not in this PR.**

## Risk

This touches `4a55cfde` (#221, 2026-09-08), which was written to fix a live correctness bug. Its failure mode if wrong is silent short-publishing, which is why this is a PR for review rather than something shipped overnight. Background and measurements: `docs/plans/2026-09-11-the-rollup-lane-rebuilds-what-it-already-has.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)