### PR TITLE
Stop rescanning the whole journal on every checkpoint

### DIFF
--- a/docs/plans/2026-09-11-the-journal-lock-is-the-next-ceiling.md
+++ b/docs/plans/2026-09-11-the-journal-lock-is-the-next-ceiling.md
@@ -1,0 +1,109 @@
+# The maintenance journal lock is the next 10x ceiling
+
+2026-09-11. Found while verifying the rollup no-op skip, which makes units
+cheaper and therefore makes this the binding constraint sooner.
+
+## The measurement
+
+`timefusion_stats`, component `block`, two independent processes:
+
+| | 11h process | 34 min post-deploy |
+|---|---:|---:|
+| `journal_hold.count` | 1,347,689 | 69,082 |
+| `journal_hold.avg_us` | 5,859 | 5,452 |
+| `journal_hold.total_ms` | 7,896,251 | 376,687 |
+| `journal_hold.max_ms` | 3,682 | 1,855 |
+| `journal_lock_wait.total_ms` | 4,697,938 | 131,744 |
+| `journal_lock_wait.max_ms` | 3,271 | 2,631 |
+
+**The lock is HELD for ~19% of wall-clock time**, on both processes:
+7,896s of 39,600s, and 377s of 2,040s. Workers additionally spent 4,698s
+*waiting* for it over the 11h process.
+
+## Why it is a ceiling and not just a cost
+
+`Database::journal()` takes `self.maintenance_tasks`, a single
+`std::sync::Mutex<TaskJournal>` (`database/mod.rs:3308`). Every claim, enqueue,
+invalidate, publish, complete, retry and cursor update in the whole maintenance
+system serializes through it — `checkpoint()` alone has 46 call sites.
+
+And `checkpoint()`, called on each of those, does this **while holding the
+mutex**:
+
+1. serializes the dirty records,
+2. `wal.write_all()` then **`wal.sync_all()` — a real fsync**,
+3. rewrites the ENTIRE snapshot via `compact()` whenever the WAL passes
+   `JOURNAL_COMPACT_BYTES`,
+4. `publish_statistics()`.
+
+The existing comment is explicit that this was already understood as a latency
+source — "the `fsync` here is the blocking syscall that
+`block.journal_hold.max_ms = 2,380` on prod was measuring (2026-08-24)" — and
+the fix applied then was `without_blocking_the_worker`, which moves the syscall
+off the tokio worker. It deliberately did **not** change the locking: "the mutex
+is still held across it, so durability ordering is unchanged."
+
+That solved the symptom it was aimed at (a held tokio worker stalling unrelated
+tasks, which is what `SELECT 1` costing seconds looked like). It does not touch
+the throughput ceiling, because the lock duty cycle is unchanged.
+
+**The arithmetic.** 69,082 acquisitions in 34 minutes is 2,032/min at 5.45 ms
+each = 11.1 s of lock per minute = 18.5% duty cycle. Duty cycle scales linearly
+with task rate and the lock is global, so:
+
+| load | journal lock duty cycle |
+|---|---:|
+| 1x (today) | ~19% |
+| 5x | ~93% |
+| 10x | **185% — impossible** |
+
+Maintenance throughput cannot reach 10x with this design regardless of cores,
+pool sizes or per-unit cost. It is the first hard wall on the stated 10-100x
+goal that is a *serialization* limit rather than a capacity one, which is why it
+deserves attention before another round of per-unit tuning.
+
+Note the no-op skip (shipped today, `6b533469`) *raises* the pressure here: it
+removes ~50 seconds of work from a unit while leaving its journal traffic — a
+claim, a complete, and their checkpoints — intact. Cheaper units mean more units
+per second mean more lock acquisitions per second. Good change, but it spends
+its winnings partly into this.
+
+## The prior art, and why it fits
+
+Group commit. Postgres (`commit_delay`/`commit_siblings`), RocksDB's WAL group
+leader, and ClickHouse's batched system-log flushes all solve exactly this:
+many small durable appends contending on one sync.
+
+The shape here:
+
+- Hold the mutex only long enough to mutate the in-memory journal and push the
+  dirty records onto a shared buffer. Release.
+- One writer task drains the buffer, does a single `write_all` + `sync_all` for
+  the whole batch, and wakes the waiters whose records are now durable.
+- A caller that needs durability awaits its batch; a caller that does not
+  (most of the 46 sites are bookkeeping, not acked writes) does not wait at all.
+- `compact()` moves out of the hot path entirely — it is a periodic maintenance
+  action on the journal, not something a task completion should ever pay for.
+
+Amortization is the whole point: 2,032 fsyncs/min becomes ~60 (one per 1 s
+batch, say), and the duty cycle stops tracking the task rate.
+
+**Before building it**, get the number this document does not have: the fsync's
+share of the 5.45 ms. The average spans cheap acquisitions (`checkpoint()`
+early-returns when nothing is dirty) and expensive ones, so the group-commit
+win is bounded by a figure nobody has measured yet. Split `journal_hold` into
+dirty and clean acquisitions, or time `sync_all` separately — one cheap
+instrumentation pass answers it, and it decides whether this is a 5x lever or a
+1.2x one.
+
+## Risk
+
+Durability ordering is the thing to be careful with. The current design is
+trivially correct: the mutex covers the mutation and its fsync together, so no
+observer can see a journal state that is not durable. A group-commit version
+must keep "a task is Complete in memory" from outliving "its record is durable"
+in any way a crash could expose. The safe formulation is that the in-memory
+mutation is published only after its batch syncs, which is what the waiters
+above are for.
+
+This is not a change to make unattended.

--- a/src/maintenance_coordinator.rs
+++ b/src/maintenance_coordinator.rs
@@ -750,6 +750,10 @@ pub struct TaskJournal {
     /// Keys removed since the last write, pending a `Removed` tombstone.
     removed_tasks: HashSet<TaskKey>,
     dirty_cursors: HashSet<String>,
+    /// When the gauges were last recomputed, so `checkpoint` does not rescan the
+    /// whole task list on every claim and completion — see
+    /// [`TaskJournal::publish_statistics_throttled`].
+    stats_published_at: Option<std::time::Instant>,
     fair_cursors: HashMap<Operation, String>,
     /// `(source, project_id, date)` whose BASE tier is already built, as read
     /// from real rollup coverage by `plan_rollup_backfill` every 60s.
@@ -1031,6 +1035,7 @@ impl TaskJournal {
             dirty_tasks: HashSet::new(),
             removed_tasks: HashSet::new(),
             dirty_cursors: HashSet::new(),
+            stats_published_at: None,
             fair_cursors: HashMap::new(),
             base_tier_ready: HashSet::new(),
             tier_holes: HashSet::new(),
@@ -3323,8 +3328,44 @@ impl TaskJournal {
         if fs::metadata(&self.wal_path).is_ok_and(|metadata| metadata.len() >= JOURNAL_COMPACT_BYTES) {
             self.compact()?;
         }
-        self.publish_statistics();
+        self.publish_statistics_throttled();
         Ok(())
+    }
+
+    /// How often `checkpoint` may recompute the maintenance gauges.
+    ///
+    /// These are observability, read by `timefusion_stats` and the dashboards;
+    /// nothing consults them transactionally, so a bound of one second is
+    /// invisible to every consumer while removing 97% of the scans.
+    const STATS_PUBLISH_INTERVAL: std::time::Duration = std::time::Duration::from_secs(1);
+
+    /// `publish_statistics`, but at most once per [`Self::STATS_PUBLISH_INTERVAL`].
+    ///
+    /// `publish_statistics` is a FULL LINEAR SCAN of `snapshot.tasks`, and
+    /// `checkpoint` called it unconditionally — so it ran on every claim,
+    /// completion, retry and cursor update, while holding the one global
+    /// `Mutex<TaskJournal>` that all maintenance bookkeeping serializes on.
+    ///
+    /// Prod 2026-09-11 held 71,849 tasks (71,399 of them COMPLETE history that
+    /// moves no gauge but one counter) and took ~2,032 checkpoints per minute.
+    /// Measured locally at that exact size: **1.70 ms per call** — roughly a
+    /// third of the 5.45 ms average `journal_hold`, spent entirely on gauges.
+    /// The cost grows with journal HISTORY rather than with load, so it gets
+    /// worse while sitting still, and it is paid under a global lock whose duty
+    /// cycle (~19% of wall-clock) is the ceiling on maintenance throughput.
+    ///
+    /// Throttling is correct rather than merely cheap: the gauges describe the
+    /// journal's state, that state is republished on the next tick anyway, and
+    /// no reader can distinguish "published 900 ms ago" from "published now".
+    /// `publish_statistics` stays public and unthrottled for the callers that
+    /// do need an exact read immediately — chiefly tests.
+    fn publish_statistics_throttled(&mut self) {
+        let now = std::time::Instant::now();
+        if self.stats_published_at.is_some_and(|last| now.duration_since(last) < Self::STATS_PUBLISH_INTERVAL) {
+            return;
+        }
+        self.stats_published_at = Some(now);
+        self.publish_statistics();
     }
 
     /// Rewrite the authoritative snapshot even when the WAL is below its
@@ -3362,6 +3403,7 @@ impl TaskJournal {
     pub fn publish_statistics(&self) {
         use std::sync::atomic::Ordering::Relaxed;
         let stats = crate::observability::maintenance_stats();
+        stats.journal_stats_publishes.fetch_add(1, Relaxed);
         let mut counts = [0u64; 4];
         let mut backlog_bytes = 0u64;
         let mut sealed_debt_bytes = 0u64;
@@ -4424,6 +4466,49 @@ mod tests {
             operation,
         };
         MaintenanceTask::pending(key, 0, 0, 0)
+    }
+
+    /// `checkpoint` must not rescan the whole journal every time it is called.
+    ///
+    /// `publish_statistics` is O(tasks) and `checkpoint` ran it unconditionally,
+    /// while holding the single global `Mutex<TaskJournal>` that every claim,
+    /// completion and retry serializes on. Prod 2026-09-11 held 71,849 tasks —
+    /// 71,399 of them Complete history — and took ~2,032 checkpoints per minute;
+    /// the scan measured 1.70 ms at exactly that size, roughly a third of the
+    /// 5.45 ms average `journal_hold`. The cost grows with journal HISTORY, not
+    /// with load, so it worsens while the system sits still.
+    ///
+    /// Asserted on the SCAN COUNT rather than on a duration, because a timing
+    /// assertion on a shared CI box is a flake generator. Can-fail proof, run red
+    /// then restored: pointing `checkpoint` back at `publish_statistics` makes
+    /// this report 40 publishes for 40 checkpoints.
+    #[test]
+    fn checkpoint_does_not_rescan_the_journal_on_every_call() {
+        use std::sync::atomic::Ordering::Relaxed;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut journal = TaskJournal::load(dir.path()).expect("journal");
+        let publishes = || crate::observability::maintenance_stats().journal_stats_publishes.load(Relaxed);
+
+        // The first checkpoint must publish: a process that never checkpointed
+        // twice would otherwise export nothing at all.
+        journal.upsert(task("p", 0, 1, Operation::BaseRollup));
+        journal.checkpoint().expect("checkpoint");
+        let after_first = publishes();
+
+        for i in 1..40i64 {
+            journal.upsert(task("p", i, i + 1, Operation::BaseRollup));
+            journal.checkpoint().expect("checkpoint");
+        }
+        assert_eq!(publishes(), after_first, "39 further checkpoints inside one second must not rescan the journal 39 more times");
+
+        // Throttled, not disabled — the gauges still describe the journal.
+        journal.publish_statistics();
+        assert_eq!(publishes(), after_first + 1);
+        assert_eq!(
+            crate::observability::maintenance_stats().pending_base_rollup.load(Relaxed),
+            40,
+            "an explicit publish must still report the true pending count"
+        );
     }
 
     /// Only outstanding ROLLUP work may veto a rollup backfill.

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -1050,6 +1050,18 @@ atomic_stats! {
         /// claimed, so the ratio is the share of rollup work that was bookkeeping.
         /// Prod 2026-09-11 measured that share at 72.6% of BaseRollup bytes.
         rollup_noop_rebuild_skipped as "rollup_noop_rebuild_skipped_total",
+        /// How many times the maintenance gauges were actually recomputed.
+        ///
+        /// `publish_statistics` is a full linear scan of the journal, and
+        /// `checkpoint` used to call it unconditionally — every claim, completion
+        /// and retry, under the one global `Mutex<TaskJournal>`. Prod 2026-09-11:
+        /// 71,849 tasks, ~2,032 checkpoints/min, 1.70 ms per scan measured at
+        /// that size — about a third of the 5.45 ms average `journal_hold`.
+        ///
+        /// Read against the checkpoint rate: this should sit near one per second
+        /// however busy maintenance gets. Tracking the checkpoint rate instead
+        /// means the throttle is not firing.
+        journal_stats_publishes as "journal_stats_publishes_total",
         /// Waves not STARTED because the WAL was over its emergency-flush threshold
         /// (durability outranks compaction) or memory was near the cgroup limit.
         /// Chronic nonzero = compaction is being starved, not protected.


### PR DESCRIPTION
## The finding

`publish_statistics` is a **full linear scan of `snapshot.tasks`**, and `checkpoint` called it unconditionally — so it ran on every claim, completion, retry and cursor update, while holding the single global `Mutex<TaskJournal>` that all maintenance bookkeeping serializes on.

Production 2026-09-11:

- **71,849 tasks in the journal — 71,399 of them `Complete` history** that moves no gauge but one counter.
- **~2,032 checkpoints per minute.**
- **1.70 ms per scan**, measured locally at exactly that journal size — roughly **a third of the 5.45 ms average `journal_hold`**, spent entirely on gauges.

The cost grows with journal **history** rather than with load, so it gets worse while the system sits still.

## Why it matters beyond the 1.7 ms

The lock it is paid under is the ceiling on maintenance throughput. Measured on two independent processes:

| | 11h process | 34 min post-deploy |
|---|---:|---:|
| `journal_hold.total_ms` | 7,896,251 / 39,600 s wall | 376,687 / 2,040 s wall |
| duty cycle | **19.9%** | **18.5%** |

Duty cycle scales linearly with task rate on a global lock, so 5x load is ~93% and **10x is arithmetically impossible**. The no-op rollup skip shipped earlier today (`6b533469`) makes this bind *sooner*: it removes ~50 s of work from a unit while leaving its journal traffic intact.

## Why throttling is correct, not just cheap

The gauges describe the journal's state, they are republished on the next tick anyway, and nothing consults them transactionally — no reader can distinguish "published 900 ms ago" from "published now". `publish_statistics` stays public and unthrottled for callers needing an exact immediate read, chiefly tests.

## Verification

`checkpoint_does_not_rescan_the_journal_on_every_call` asserts on the **scan count**, not a duration (a timing assertion on a shared box is a flake generator).

- Run red then restored: pointing `checkpoint` back at `publish_statistics` reports **40 publishes for 40 checkpoints** instead of 1.
- It also asserts the throttle did not *disable* the gauges — an explicit publish still reports the true pending count.

`cargo lint` clean, full suite 1516/1516.

New counter `journal_stats_publishes_total`, read against the checkpoint rate: it should sit near one per second however busy maintenance gets. Tracking the checkpoint rate means the throttle is not firing.

## The rest of the problem

`docs/plans/2026-09-11-the-journal-lock-is-the-next-ceiling.md` records the larger remaining part — the per-operation **`fsync`** and the occasional full-snapshot **`compact()`**, both still under the global mutex — and why group commit (Postgres `commit_delay`, RocksDB's WAL group leader) is the fit. **That part is deliberately not in this PR**: it is durability-ordering-sensitive. The doc also names the measurement to take first, which nobody has: the fsync's share of the remaining hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)