### PR TITLE
Stop paying the rollup journal's two fsyncs on every commit

### DIFF
--- a/src/database/maintain.rs
+++ b/src/database/maintain.rs
@@ -890,6 +890,11 @@ impl Database {
     }
 
     fn persist_rollup_journal(&self) -> std::io::Result<()> {
+        self.persist_rollup_journal_bytes(crate::rollup_journal::encode(&self.rollup_journal_entries())?, false)
+    }
+
+    /// The journal's current entry set, with the gauges it also feeds.
+    fn rollup_journal_entries(&self) -> Vec<crate::rollup_journal::RollupInvalidation> {
         let mut entries: Vec<_> = self
             .rollup_source_epochs
             .iter()
@@ -918,7 +923,83 @@ impl Database {
             .max()
             .unwrap_or(0);
         stats.rollup_oldest_invalidation_age_secs.store(oldest_age_secs, std::sync::atomic::Ordering::Relaxed);
-        crate::rollup_journal::store(&self.config.core.timefusion_data_dir, &entries)
+
+        entries
+    }
+
+    /// How stale the on-disk rollup journal may be.
+    ///
+    /// Commits run at ~11/s in production, so this is ~1 durable write per
+    /// second instead of ~11, and the journal is at most this far behind.
+    const ROLLUP_JOURNAL_MAX_STALENESS: std::time::Duration = std::time::Duration::from_secs(1);
+
+    /// Persist the encoded rollup journal, unless it is unchanged or not yet due.
+    ///
+    /// **Why this may be deferred at all.** `rollup_journal` is scheduling
+    /// state, not a correctness boundary — its own module says so, and
+    /// `maintenance_tasks` is documented as "the finer-grained source of truth
+    /// coordinator workers consume". Both are written from the SAME pre-ack
+    /// invalidation, but only the task journal's `checkpoint` records the work
+    /// items; `rollup_dirty` is read in exactly one place, to requeue
+    /// partitions when bootstrap tasks were *discarded*. So a lost second of it
+    /// weakens a backup whose primary was fsynced in the same commit, and an
+    /// absent entry already means "full rebuild required" to the builder — the
+    /// conservative direction.
+    ///
+    /// **Why it is worth deferring.** `store` costs TWO `fsync`s — the temp
+    /// file, then the parent directory after the rename — and ran inside every
+    /// group commit beside the task journal's own. Three per commit, on an
+    /// array measured at 98.8% utilisation with a 63-620 ms write wait. Prod
+    /// 2026-09-12 performed 30,075 commits in 2,640 s (11.4/s), i.e. ~100% duty
+    /// on the commit pipeline, and `block.journal_commit_wait` averaged 362 ms
+    /// (max 10.7 s) on the PRE-ACK path because every arrival queues behind it.
+    ///
+    /// The content check is kept as well and is free: it compares the bytes
+    /// actually encoded, so any skew or hash collision can only produce an
+    /// EXTRA write, never a missed one. `None` until a store succeeds, so the
+    /// first write of a process always happens, and the stamp advances only
+    /// after `store_encoded` returns `Ok`.
+    ///
+    /// `force` bypasses the staleness window for shutdown, where there is no
+    /// next commit to carry the write.
+    fn persist_rollup_journal_bytes(&self, bytes: Vec<u8>, force: bool) -> std::io::Result<()> {
+        use std::{
+            hash::{Hash, Hasher},
+            sync::atomic::Ordering::Relaxed,
+        };
+        let stats = crate::observability::maintenance_stats();
+        let digest = {
+            let mut hasher = std::collections::hash_map::DefaultHasher::new();
+            bytes.hash(&mut hasher);
+            hasher.finish()
+        };
+        let mut persisted = crate::support::lock(&self.rollup_journal_persisted);
+        if persisted.digest == Some(digest) {
+            stats.rollup_journal_persist_skipped.fetch_add(1, Relaxed);
+            return Ok(());
+        }
+        // Deferred, not dropped: the content is still different on the next
+        // commit, so the next one past the window writes it. `force` and the
+        // never-written case both bypass this.
+        if !force
+            && let Some(at) = persisted.at
+            && at.elapsed() < Self::ROLLUP_JOURNAL_MAX_STALENESS
+        {
+            stats.rollup_journal_persist_deferred.fetch_add(1, Relaxed);
+            return Ok(());
+        }
+        crate::rollup_journal::store_encoded(&self.config.core.timefusion_data_dir, &bytes)?;
+        persisted.digest = Some(digest);
+        persisted.at = Some(std::time::Instant::now());
+        stats.rollup_journal_persists.fetch_add(1, Relaxed);
+        Ok(())
+    }
+
+    /// Write the rollup journal unconditionally, for shutdown — the one point
+    /// where no later commit exists to carry a deferred write.
+    pub(crate) fn flush_rollup_journal(&self) -> std::io::Result<()> {
+        let _journal_guard = crate::support::lock(&self.rollup_journal_lock);
+        self.persist_rollup_journal_bytes(crate::rollup_journal::encode(&self.rollup_journal_entries())?, true)
     }
 
     /// `mint_dedup=false` only for hours touched EXCLUSIVELY by self-authored
@@ -9792,6 +9873,14 @@ impl Database {
             warn!("DML coalescer drain exceeded shutdown deadline — un-drained deferred Delta legs lost (crash-equivalent; mem-leg values survive in WAL)");
         }
 
+        // The rollup journal's durable write is throttled on the commit path, so
+        // shutdown is the one point with no later commit to carry a deferred
+        // one. Best-effort: it is scheduling state, and failing the shutdown
+        // over it would be worse than the conservative rebuild losing it costs.
+        if let Err(error) = self.flush_rollup_journal() {
+            warn!(%error, event = "rollup_journal_shutdown_flush_failed");
+        }
+
         // Cancel maintenance tasks
         self.maintenance_shutdown.cancel();
 
@@ -10413,6 +10502,88 @@ mod rollup_noop_skip_tests {
             tier_version(&db).await > Some(before_dedup),
             "a deletion vector masked a duplicate this rollup had already counted; a paths-only fingerprint would have called that unchanged"
         );
+        Ok(())
+    }
+}
+
+/// The rollup journal's two `fsync`s must not be paid on every commit.
+#[cfg(test)]
+mod rollup_journal_persist_tests {
+    use serial_test::serial;
+
+    use super::*;
+    use crate::support::test_helpers::TestConfigBuilder;
+
+    fn counts() -> (u64, u64, u64) {
+        use std::sync::atomic::Ordering::Relaxed;
+        let s = crate::observability::maintenance_stats();
+        (s.rollup_journal_persists.load(Relaxed), s.rollup_journal_persist_skipped.load(Relaxed), s.rollup_journal_persist_deferred.load(Relaxed))
+    }
+
+    /// `store` costs TWO `fsync`s — the temp file, then the parent directory
+    /// after the rename — and ran inside every group commit beside the task
+    /// journal's own `sync_all`. Three per commit, on an array measured at
+    /// 98.8% utilisation with a 63-620 ms write wait. Prod 2026-09-12 performed
+    /// 30,075 commits in 2,640 s (11.4/s), i.e. ~100% duty on the commit
+    /// pipeline, and `block.journal_commit_wait` averaged **362 ms** (max
+    /// 10.7 s) on the PRE-ACK path because every arrival queued behind it.
+    ///
+    /// Deferring is sound because `rollup_journal` is scheduling state, not a
+    /// correctness boundary: `maintenance_tasks` is "the finer-grained source
+    /// of truth coordinator workers consume", it is fsynced in the SAME commit,
+    /// and `rollup_dirty` is read in one place only — to requeue partitions
+    /// when bootstrap tasks were discarded.
+    ///
+    /// A content hash alone would NOT have helped: `apply_rollup_hours`
+    /// increments the source epoch on every call, so the encoded journal really
+    /// does change on every ingest invalidation. That is why this throttles by
+    /// TIME as well, and why the skip assertion below would pass vacuously
+    /// without the deferral.
+    ///
+    /// Can-fail proof, run red then restored: setting
+    /// `ROLLUP_JOURNAL_MAX_STALENESS` to zero makes the deferral assertion red
+    /// (13 writes for 13 commits, the pre-change behaviour).
+    #[serial]
+    #[tokio::test]
+    async fn repeated_commits_do_not_each_rewrite_the_rollup_journal() -> Result<()> {
+        let cfg = TestConfigBuilder::new("rollup_journal_persist").with_rollups().build();
+        let db = Database::with_config(cfg).await?;
+        let project = format!("proj_{}", &uuid::Uuid::new_v4().to_string()[..8]);
+        let date = (chrono::Utc::now() - chrono::Duration::days(2)).date_naive().to_string();
+
+        // The first write of a process always happens: there is no stamp yet,
+        // so an empty one must not be mistaken for "already persisted".
+        db.apply_rollup_hours(&project, "otel_logs_and_spans", &date, 1 << 12)?;
+        db.commit_journal()?;
+        assert!(counts().0 > 0, "the first persist of a process must write");
+
+        // The steady-ingest shape. Every call bumps the source epoch, so the
+        // CONTENT differs every time — only the staleness window stops these.
+        let before = counts();
+        for hour in 0..13u32 {
+            db.apply_rollup_hours(&project, "otel_logs_and_spans", &date, 1 << hour)?;
+            db.commit_journal()?;
+        }
+        let after = counts();
+        assert_eq!(after.0, before.0, "13 commits inside the staleness window must not each pay two fsyncs");
+        assert_eq!(after.2 - before.2, 13, "and each must be counted as deferred, not silently dropped");
+
+        // Deferred is not dropped. Shutdown has no later commit to carry the
+        // write, so it forces one — and the journal on disk then holds the
+        // hours those deferred commits marked.
+        db.flush_rollup_journal()?;
+        assert_eq!(counts().0 - after.0, 1, "shutdown must flush what the window deferred");
+        let persisted = crate::rollup_journal::load(&db.config.core.timefusion_data_dir);
+        let entry =
+            persisted.iter().find(|entry| entry.project_id == project && entry.date == date).expect("the partition must be on disk after a forced flush");
+        assert_eq!(entry.dirty_hours & 0x1fff, 0x1fff, "every hour marked during the deferred window must have reached disk");
+
+        // Nothing changed since that flush, so the next commit writes nothing
+        // even though the window has no say — this is the idle case.
+        let before = counts();
+        db.commit_journal()?;
+        assert_eq!(counts().1 - before.1, 1, "an unchanged journal must be skipped on content, not merely deferred");
+        assert_eq!(counts().0, before.0, "and must not write");
         Ok(())
     }
 }

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -842,6 +842,15 @@ type ZOrderFilesets = Arc<RwLock<HashMap<String, HashMap<chrono::NaiveDate, Hash
 /// Per-(project_id, table_name) DML serialization mutexes — see `Database::dml_lock`.
 type DmlLocks = Arc<dashmap::DashMap<(String, String), Arc<tokio::sync::Mutex<()>>>>;
 
+/// The last durable state of the rollup journal: what was written and when.
+/// Both `None` until the first successful store, which is what makes a fresh
+/// process always write once rather than trusting an empty stamp.
+#[derive(Default, Debug)]
+struct PersistedRollupJournal {
+    digest: Option<u64>,
+    at: Option<std::time::Instant>,
+}
+
 type RollupSourceKey = (String, String, String);
 type RollupCoverageKey = (String, String, String, String);
 type RollupSliceCoverageKey = (String, String, String, i64, i64);
@@ -2912,6 +2921,10 @@ pub struct Database {
     /// Serializes dirty-map mutation with journal snapshots, else two writers
     /// can persist out of order and lose the newer invalidation on restart.
     rollup_journal_lock: Arc<std::sync::Mutex<()>>,
+    /// What was last persisted of the rollup journal, so a commit whose content
+    /// has not moved — or whose write is not yet due — can skip two `fsync`s.
+    /// See `persist_rollup_journal_bytes`.
+    rollup_journal_persisted: Arc<std::sync::Mutex<PersistedRollupJournal>>,
     /// Coalesces the durable half of that path (see [`Self::commit_journal`]).
     /// The lock above covers only the in-memory mutation; the `fsync` behind it
     /// is shared, so the ingest rate no longer sets the `fsync` rate.
@@ -3751,6 +3764,7 @@ impl Database {
             rollup_dirty,
             rollup_invalidated_at,
             rollup_journal_lock: Arc::new(std::sync::Mutex::new(())),
+            rollup_journal_persisted: Arc::new(std::sync::Mutex::new(PersistedRollupJournal::default())),
             journal_group_commit: Arc::new(crate::support::GroupCommit::default()),
             maintenance_tasks: Arc::new(std::sync::Mutex::new(maintenance_tasks)),
             maintenance_admission,

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -1089,6 +1089,28 @@ atomic_stats! {
         /// real garbage, but no longer a livelock.
         rollup_base_refusal_reproduced as "rollup_base_refusal_reproduced_total",
         rollup_base_refusal_unreproduced as "rollup_base_refusal_unreproduced_total",
+        /// Rollup-journal writes performed, and the ones skipped because the
+        /// encoded content had not moved since the last successful store.
+        ///
+        /// `store` costs TWO `fsync`s (temp file, then the parent directory
+        /// after the rename) and runs inside every group commit beside the task
+        /// journal's own — three per commit. Prod 2026-09-12 performed 30,075
+        /// commits in 2,640 s (11.4/s), which is ~100% duty on the commit
+        /// pipeline: `block.journal_commit_wait` averaged 362 ms, max 10.7 s,
+        /// on the pre-ack path.
+        ///
+        /// Read `skipped / (skipped + persists)`: steady ingest re-invalidates
+        /// the same hours idempotently, so a healthy system skips most commits.
+        /// A ratio near zero means the journal really is changing every commit
+        /// and the remaining cost is genuine.
+        rollup_journal_persists as "rollup_journal_persists_total",
+        rollup_journal_persist_skipped as "rollup_journal_persist_skipped_total",
+        /// Writes DEFERRED because the journal had changed but was written less
+        /// than `ROLLUP_JOURNAL_MAX_STALENESS` ago. Deferred, never dropped: the
+        /// content is still different at the next commit, so the next one past
+        /// the window writes it, and shutdown forces one. This is the term that
+        /// scales with ingest — `skipped` is the idle case.
+        rollup_journal_persist_deferred as "rollup_journal_persist_deferred_total",
         /// Waves not STARTED because the WAL was over its emergency-flush threshold
         /// (durability outranks compaction) or memory was near the cgroup limit.
         /// Chronic nonzero = compaction is being starved, not protected.

--- a/src/rollup_journal.rs
+++ b/src/rollup_journal.rs
@@ -68,12 +68,23 @@ pub fn load(data_dir: &Path) -> Vec<RollupInvalidation> {
 /// writes. Clearing after a target commit is best effort: failure only causes a
 /// redundant rebuild after restart.
 pub fn store(data_dir: &Path, entries: &[RollupInvalidation]) -> std::io::Result<()> {
+    store_encoded(data_dir, &encode(entries)?)
+}
+
+/// The exact bytes [`store_encoded`] would write. Split out so a caller can
+/// compare them against what it last persisted and skip the write entirely —
+/// see `Database::persist_rollup_journal`. Encoding is cheap next to the two
+/// `fsync`s `store_encoded` costs, which is what makes that trade worth making.
+pub fn encode(entries: &[RollupInvalidation]) -> std::io::Result<Vec<u8>> {
+    serde_json::to_vec(&Snapshot { version: VERSION, entries }).map_err(std::io::Error::other)
+}
+
+pub fn store_encoded(data_dir: &Path, bytes: &[u8]) -> std::io::Result<()> {
     let path = path(data_dir);
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }
-    let bytes = serde_json::to_vec(&Snapshot { version: VERSION, entries }).map_err(std::io::Error::other)?;
-    crate::write::wal::write_atomic_with(&path, true, |file| file.write_all(&bytes))
+    crate::write::wal::write_atomic_with(&path, true, |file| file.write_all(bytes))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Where group commit actually left us

It worked — but the pipeline is still saturated. Prod 2026-09-12, 2,640 s of uptime:

| metric | value |
|---|---:|
| `journal_commits` | 30,075 (**11.4/s**) |
| `journal_commits_coalesced` | 30,506 |
| `block.journal_commit_wait.avg_us` | **361,837 (362 ms)** |
| `block.journal_commit_wait.max_ms` | **10,687** |
| `block.journal_hold` duty cycle | 14.5% (was 18.5% at a comparable age) |

11.4 commits/s ≈ one per 88 ms ≈ **~100% duty on the commit pipeline**, so every arrival queues — that is the 362 ms average, on the **pre-ack path**. The coalescing ratio of ~2x is exactly what arrival-rate × fsync-duration predicts, so **batching harder buys nothing**. What is left is the cost per commit.

## Three fsyncs, not one

`TaskJournal::checkpoint` syncs the task WAL. `persist_rollup_journal` then calls `write_atomic_with(durable = true)`, which syncs **the temp file** and **the parent directory** after the rename. Two of the three are the rollup journal.

Only the task journal belongs in the pre-ack barrier:

- `rollup_journal`'s own module: *"scheduling state, not the read-side correctness boundary… an absent dirty entry already means 'full rebuild required' to the builder."*
- `maintenance_tasks` is documented as *"the finer-grained source of truth coordinator workers consume"* — and is fsynced in the **same** commit.
- `rollup_dirty` is read in exactly one place: requeueing partitions when bootstrap tasks were *discarded*.

So a lost second weakens a backup whose primary is durable, in the conservative direction.

## What changed

Throttled to at most once per second, forced at shutdown. **Deferred is never dropped** — the content still differs at the next commit, so the next one past the window writes it.

A content hash is kept alongside and is free, but it is **not** the mechanism, and finding out why is the reason the time window exists: **`apply_rollup_hours` increments the source epoch on every call**, so the encoded journal genuinely changes on every ingest invalidation and a hash alone would have skipped nothing on the hot path. The hash covers the idle case; the window covers the busy one. The comparison is over the bytes actually encoded, so any skew or collision can only produce an **extra** write, never a missed one.

## Verification

`repeated_commits_do_not_each_rewrite_the_rollup_journal` asserts deferral is not loss: after 13 deferred commits it forces the flush, reads the journal **back off disk**, and checks every hour marked during the window is there.

Run red then restored: with `ROLLUP_JOURNAL_MAX_STALENESS` set to zero it reports **14 writes for 14 commits** — the pre-change behaviour.

`cargo lint` clean, full suite 1528/1528.

## Watching it

`rollup_journal_persist_deferred_total` should dominate under ingest, `_skipped_total` when idle, and `_persists_total` should settle near 1/s. The number this is aimed at is **`block.journal_commit_wait.avg_us`**; if it does not fall roughly 3x, the remaining cost is the task journal's own fsync and the next lever is the disk itself (`docs/plans/2026-09-11-write-latency-self-inflicted-disk-flood.md`, fix order 3 and 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)