### PR TITLE
Carry the no-op skip across restarts, and shed abandoned journal history

### DIFF
--- a/src/database/maintain.rs
+++ b/src/database/maintain.rs
@@ -3288,6 +3288,13 @@ impl Database {
                 (crate::maintenance_coordinator::TAG_SLICE_START, key.slice.start_micros.to_string()),
                 (crate::maintenance_coordinator::TAG_SLICE_END, key.slice.end_micros.to_string()),
                 (crate::maintenance_coordinator::TAG_SOURCE_FINGERPRINT, source_fp.to_string()),
+                // Persisted so the no-op skip survives a restart. Without it,
+                // coverage rebuilt from these tags carries `content_fp: None`
+                // and nothing can be skipped until the slice has published once
+                // more in the new process — and production restarts on every
+                // non-docs push (three times in two and a half hours on
+                // 2026-09-12), so uptime is the scarce resource.
+                (crate::maintenance_coordinator::TAG_CONTENT_FINGERPRINT, content_fp.to_string()),
                 (crate::maintenance_coordinator::TAG_GENERATION, generation.clone()),
                 // Absent (older generations) means the read path cannot verify
                 // this slice and must refuse it, so write the sentinel rather
@@ -5130,141 +5137,155 @@ impl Database {
             // New generations carry complete coverage identity in Delta Add
             // tags. Recovery reads only the transaction log; no rollup data
             // scan competes with foreground queries at startup.
-            let (tagged, paths_by_identity, measures_by_identity, witness_reasons, witnessed) = match self.resolve_table("default", &target).await {
-                Ok(table) => {
-                    let table = table.read().await;
-                    // `source_rows` is part of the KEY so a partition rebuilt against a
-                    // different source count cannot merge with the older evidence.
-                    // A SET, not a count: the per-identity `num_records` sum this
-                    // used to carry fed exactly one `debug!` line and a placeholder
-                    // zero on the ledger-seeded path, so it was a field that read
-                    // as measured on one route and unset on another while meaning
-                    // nothing on either.
-                    let mut groups: std::collections::HashSet<TaggedSliceIdentity> = std::collections::HashSet::new();
-                    // Paths per tagged identity, keyed exactly like `groups` so the
-                    // FILTERED loop below can recover them. The ledger must not be
-                    // written from this raw loop: the filters that follow
-                    // (`rollup_slice_complete`, and the `generation_id` match) are
-                    // what decide whether a slice is READABLE, and a ledger written
-                    // before them claims coverage the read path refuses — the one
-                    // failure this design must never have.
-                    let mut paths_by_identity: HashMap<TaggedSliceIdentity, (String, Vec<String>)> = HashMap::new();
-                    // Why each witness-less identity has no witness, and which
-                    // identities DO carry one — keyed WITHOUT `source_rows`, so a
-                    // slice whose files disagree (a rewrite that stripped the tag
-                    // off some of them) is distinguishable from one that never had
-                    // it. Different repair entirely, indistinguishable in a count.
-                    let mut witness_reasons: HashMap<SliceKey, UnverifiableReason> = HashMap::new();
-                    let mut witnessed: std::collections::HashSet<SliceKey> = std::collections::HashSet::new();
-                    // Not part of the identity: two files of one slice that
-                    // disagree about their measures are still the same slice,
-                    // and folding measures into the key would instead make them
-                    // two entries racing for one coverage slot.
-                    let mut measures_by_identity: HashMap<TaggedSliceIdentity, Option<BTreeSet<String>>> = HashMap::new();
-                    for add in table.snapshot()?.log_data().iter() {
-                        let action = add_action(&add);
-                        // An untagged file proves no coverage, so this loop has
-                        // always skipped it. Skipping SILENTLY is what let 352 of
-                        // them accumulate over a month: `slice_retires` can now
-                        // retire one, but only when something publishes that
-                        // partition, and a sealed day that already has coverage is
-                        // never republished — nothing would ever enqueue it.
-                        // Remember the partition so the rebuild can be requested
-                        // below, which is what makes the tail self-healing rather
-                        // than a manual list someone has to keep.
-                        // Both arms feed `uncovered_gaps`: the untagged file's
-                        // own statistics span is the work, and the tagged
-                        // ranges beside it are what is already done. `hi + 1`
-                        // because statistics bounds are inclusive while a slice
-                        // end is not.
-                        let file_partition = Self::maintenance_partition_from_action(&action.path, Some(&action.partition_values), "default");
-                        if let Some(partition) = file_partition.clone() {
-                            let tags = action.tags.as_ref();
-                            let tag = |name: &str| tags?.get(name).and_then(Option::as_deref)?.parse::<i64>().ok();
-                            match (tag(crate::maintenance_coordinator::TAG_SLICE_START), tag(crate::maintenance_coordinator::TAG_SLICE_END)) {
-                                (Some(start), Some(end)) => tagged_spans.entry(partition).or_default().push((start, end)),
-                                _ => {
-                                    untagged_files = untagged_files.saturating_add(1);
-                                    untagged_spans
-                                        .entry(partition)
-                                        .or_default()
-                                        .extend(action.stats.as_deref().and_then(crate::rollup::stats_time_range).map(|(lo, hi)| (lo, hi.saturating_add(1))));
+            let (tagged, paths_by_identity, measures_by_identity, content_fp_by_identity, witness_reasons, witnessed) =
+                match self.resolve_table("default", &target).await {
+                    Ok(table) => {
+                        let table = table.read().await;
+                        // `source_rows` is part of the KEY so a partition rebuilt against a
+                        // different source count cannot merge with the older evidence.
+                        // A SET, not a count: the per-identity `num_records` sum this
+                        // used to carry fed exactly one `debug!` line and a placeholder
+                        // zero on the ledger-seeded path, so it was a field that read
+                        // as measured on one route and unset on another while meaning
+                        // nothing on either.
+                        let mut groups: std::collections::HashSet<TaggedSliceIdentity> = std::collections::HashSet::new();
+                        // Paths per tagged identity, keyed exactly like `groups` so the
+                        // FILTERED loop below can recover them. The ledger must not be
+                        // written from this raw loop: the filters that follow
+                        // (`rollup_slice_complete`, and the `generation_id` match) are
+                        // what decide whether a slice is READABLE, and a ledger written
+                        // before them claims coverage the read path refuses — the one
+                        // failure this design must never have.
+                        let mut paths_by_identity: HashMap<TaggedSliceIdentity, (String, Vec<String>)> = HashMap::new();
+                        // Why each witness-less identity has no witness, and which
+                        // identities DO carry one — keyed WITHOUT `source_rows`, so a
+                        // slice whose files disagree (a rewrite that stripped the tag
+                        // off some of them) is distinguishable from one that never had
+                        // it. Different repair entirely, indistinguishable in a count.
+                        let mut witness_reasons: HashMap<SliceKey, UnverifiableReason> = HashMap::new();
+                        let mut witnessed: std::collections::HashSet<SliceKey> = std::collections::HashSet::new();
+                        // Not part of the identity: two files of one slice that
+                        // disagree about their measures are still the same slice,
+                        // and folding measures into the key would instead make them
+                        // two entries racing for one coverage slot.
+                        let mut measures_by_identity: HashMap<TaggedSliceIdentity, Option<BTreeSet<String>>> = HashMap::new();
+                        // The input set each identity was aggregated from. Several
+                        // files serve one identity and all carry the SAME value —
+                        // it is a property of the unit, not of the file — so any
+                        // disagreement means the tags cannot be trusted for this
+                        // purpose and the entry collapses to `None`, which declines
+                        // the skip. Absent on cells written before the tag existed.
+                        let mut content_fp_by_identity: HashMap<TaggedSliceIdentity, Option<u64>> = HashMap::new();
+                        for add in table.snapshot()?.log_data().iter() {
+                            let action = add_action(&add);
+                            // An untagged file proves no coverage, so this loop has
+                            // always skipped it. Skipping SILENTLY is what let 352 of
+                            // them accumulate over a month: `slice_retires` can now
+                            // retire one, but only when something publishes that
+                            // partition, and a sealed day that already has coverage is
+                            // never republished — nothing would ever enqueue it.
+                            // Remember the partition so the rebuild can be requested
+                            // below, which is what makes the tail self-healing rather
+                            // than a manual list someone has to keep.
+                            // Both arms feed `uncovered_gaps`: the untagged file's
+                            // own statistics span is the work, and the tagged
+                            // ranges beside it are what is already done. `hi + 1`
+                            // because statistics bounds are inclusive while a slice
+                            // end is not.
+                            let file_partition = Self::maintenance_partition_from_action(&action.path, Some(&action.partition_values), "default");
+                            if let Some(partition) = file_partition.clone() {
+                                let tags = action.tags.as_ref();
+                                let tag = |name: &str| tags?.get(name).and_then(Option::as_deref)?.parse::<i64>().ok();
+                                match (tag(crate::maintenance_coordinator::TAG_SLICE_START), tag(crate::maintenance_coordinator::TAG_SLICE_END)) {
+                                    (Some(start), Some(end)) => tagged_spans.entry(partition).or_default().push((start, end)),
+                                    _ => {
+                                        untagged_files = untagged_files.saturating_add(1);
+                                        untagged_spans.entry(partition).or_default().extend(
+                                            action.stats.as_deref().and_then(crate::rollup::stats_time_range).map(|(lo, hi)| (lo, hi.saturating_add(1))),
+                                        );
+                                    }
                                 }
                             }
-                        }
-                        let Some(tags) = action.tags.as_ref() else { continue };
-                        let tag = |name: &str| tags.get(name).and_then(Option::as_deref);
-                        if tag(crate::maintenance_coordinator::TAG_SOURCE) != Some(source) {
-                            continue;
-                        }
-                        let (Some(project), Some(generation), Some(source_fp), Some(slice_start), Some(slice_end)) = (
-                            tag(crate::maintenance_coordinator::TAG_PROJECT),
-                            tag(crate::maintenance_coordinator::TAG_GENERATION),
-                            tag(crate::maintenance_coordinator::TAG_SOURCE_FINGERPRINT).and_then(|value| value.parse::<u64>().ok()),
-                            tag(crate::maintenance_coordinator::TAG_SLICE_START).and_then(|value| value.parse::<i64>().ok()),
-                            tag(crate::maintenance_coordinator::TAG_SLICE_END).and_then(|value| value.parse::<i64>().ok()),
-                        ) else {
-                            // Tagged for THIS source, yet not identifiable: the file
-                            // is dropped from the tagged set and counted nowhere
-                            // else, so without this it is an invisible population.
-                            crate::database::rollup_unverifiable::IDENTITY_TAG_INCOMPLETE.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                            continue;
-                        };
-                        // Absent on generations written before the tag; `-1` is the
-                        // sentinel a build writes when the source reported no count.
-                        // Both become `None`, which the read path refuses to verify —
-                        // and `classify_witness` says WHICH, from the one place that
-                        // decides, so the split cannot fail to sum to the total.
-                        let witness = crate::database::rollup_unverifiable::classify_witness(tag(crate::maintenance_coordinator::TAG_SOURCE_ROWS));
-                        let source_rows = witness.ok();
-                        let slice_key = (project.to_owned(), slice_start, slice_end, generation.to_owned(), source_fp);
-                        match witness {
-                            Ok(_) => {
-                                witnessed.insert(slice_key);
+                            let Some(tags) = action.tags.as_ref() else { continue };
+                            let tag = |name: &str| tags.get(name).and_then(Option::as_deref);
+                            if tag(crate::maintenance_coordinator::TAG_SOURCE) != Some(source) {
+                                continue;
                             }
-                            // Lowest variant wins, so a slice seen under two
-                            // reasons attributes deterministically whatever order
-                            // the log lists its files in.
-                            Err(reason) => {
-                                witness_reasons.entry(slice_key).and_modify(|held| *held = (*held).min(reason)).or_insert(reason);
+                            let (Some(project), Some(generation), Some(source_fp), Some(slice_start), Some(slice_end)) = (
+                                tag(crate::maintenance_coordinator::TAG_PROJECT),
+                                tag(crate::maintenance_coordinator::TAG_GENERATION),
+                                tag(crate::maintenance_coordinator::TAG_SOURCE_FINGERPRINT).and_then(|value| value.parse::<u64>().ok()),
+                                tag(crate::maintenance_coordinator::TAG_SLICE_START).and_then(|value| value.parse::<i64>().ok()),
+                                tag(crate::maintenance_coordinator::TAG_SLICE_END).and_then(|value| value.parse::<i64>().ok()),
+                            ) else {
+                                // Tagged for THIS source, yet not identifiable: the file
+                                // is dropped from the tagged set and counted nowhere
+                                // else, so without this it is an invisible population.
+                                crate::database::rollup_unverifiable::IDENTITY_TAG_INCOMPLETE.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                                continue;
+                            };
+                            // Absent on generations written before the tag; `-1` is the
+                            // sentinel a build writes when the source reported no count.
+                            // Both become `None`, which the read path refuses to verify —
+                            // and `classify_witness` says WHICH, from the one place that
+                            // decides, so the split cannot fail to sum to the total.
+                            let witness = crate::database::rollup_unverifiable::classify_witness(tag(crate::maintenance_coordinator::TAG_SOURCE_ROWS));
+                            let source_rows = witness.ok();
+                            let slice_key = (project.to_owned(), slice_start, slice_end, generation.to_owned(), source_fp);
+                            match witness {
+                                Ok(_) => {
+                                    witnessed.insert(slice_key);
+                                }
+                                // Lowest variant wins, so a slice seen under two
+                                // reasons attributes deterministically whatever order
+                                // the log lists its files in.
+                                Err(reason) => {
+                                    witness_reasons.entry(slice_key).and_modify(|held| *held = (*held).min(reason)).or_insert(reason);
+                                }
+                            }
+                            // Absent means "no evidence", NOT "no measures" — the two
+                            // permit different queries, so an empty tag value must
+                            // still parse as `Some(∅)`. Several files can serve one
+                            // slice identity, and the slice can only be read for a
+                            // measure they ALL carry, hence the intersection.
+                            let measures = tag(crate::maintenance_coordinator::TAG_MEASURES)
+                                .map(|value| value.split(',').filter(|name| !name.is_empty()).map(str::to_owned).collect::<BTreeSet<String>>());
+                            let identity = (project.to_owned(), slice_start, slice_end, generation.to_owned(), source_fp, source_rows);
+                            let merged = match measures_by_identity.remove(&identity) {
+                                Some(seen) => seen.zip(measures).map(|(left, right)| &left & &right),
+                                None => measures,
+                            };
+                            measures_by_identity.insert(identity.clone(), merged);
+                            let content_fp = tag(crate::maintenance_coordinator::TAG_CONTENT_FINGERPRINT).and_then(|value| value.parse::<u64>().ok());
+                            let agreed = match content_fp_by_identity.remove(&identity) {
+                                Some(seen) if seen == content_fp => seen,
+                                Some(_) => None,
+                                None => content_fp,
+                            };
+                            content_fp_by_identity.insert(identity.clone(), agreed);
+                            groups.insert(identity);
+                            // Same facts, recorded explicitly. The date comes from the
+                            // file's own partition rather than from `slice_start`,
+                            // because a day-wide slice starts at midnight of the day it
+                            // covers while a file in `date=D` cannot hold rows outside
+                            // `D` — the partition is the stronger statement.
+                            if let Some((partition_project, _date)) = file_partition.as_ref() {
+                                // The date comes from the file's PARTITION, not from
+                                // `slice_start`: a file in `date=D` cannot hold rows
+                                // outside `D`, so the partition is the stronger
+                                // statement, and a day-wide slice beginning at midnight
+                                // would otherwise be indistinguishable from one that
+                                // merely starts there.
+                                let entry = paths_by_identity
+                                    .entry((project.to_owned(), slice_start, slice_end, generation.to_owned(), source_fp, source_rows))
+                                    .or_insert_with(|| ((*partition_project).to_owned(), Vec::new()));
+                                entry.1.push(action.path.clone());
                             }
                         }
-                        // Absent means "no evidence", NOT "no measures" — the two
-                        // permit different queries, so an empty tag value must
-                        // still parse as `Some(∅)`. Several files can serve one
-                        // slice identity, and the slice can only be read for a
-                        // measure they ALL carry, hence the intersection.
-                        let measures = tag(crate::maintenance_coordinator::TAG_MEASURES)
-                            .map(|value| value.split(',').filter(|name| !name.is_empty()).map(str::to_owned).collect::<BTreeSet<String>>());
-                        let identity = (project.to_owned(), slice_start, slice_end, generation.to_owned(), source_fp, source_rows);
-                        let merged = match measures_by_identity.remove(&identity) {
-                            Some(seen) => seen.zip(measures).map(|(left, right)| &left & &right),
-                            None => measures,
-                        };
-                        measures_by_identity.insert(identity.clone(), merged);
-                        groups.insert(identity);
-                        // Same facts, recorded explicitly. The date comes from the
-                        // file's own partition rather than from `slice_start`,
-                        // because a day-wide slice starts at midnight of the day it
-                        // covers while a file in `date=D` cannot hold rows outside
-                        // `D` — the partition is the stronger statement.
-                        if let Some((partition_project, _date)) = file_partition.as_ref() {
-                            // The date comes from the file's PARTITION, not from
-                            // `slice_start`: a file in `date=D` cannot hold rows
-                            // outside `D`, so the partition is the stronger
-                            // statement, and a day-wide slice beginning at midnight
-                            // would otherwise be indistinguishable from one that
-                            // merely starts there.
-                            let entry = paths_by_identity
-                                .entry((project.to_owned(), slice_start, slice_end, generation.to_owned(), source_fp, source_rows))
-                                .or_insert_with(|| ((*partition_project).to_owned(), Vec::new()));
-                            entry.1.push(action.path.clone());
-                        }
+                        (groups, paths_by_identity, measures_by_identity, content_fp_by_identity, witness_reasons, witnessed)
                     }
-                    (groups, paths_by_identity, measures_by_identity, witness_reasons, witnessed)
-                }
-                Err(_) => Default::default(),
-            };
+                    Err(_) => Default::default(),
+                };
             // Filled by the FILTERED loop below, then verified and written once
             // per tier. Nothing is recorded for a slice the read path would
             // refuse, because the ledger is meant to become the authority and an
@@ -5462,6 +5483,15 @@ impl Database {
                             },
                         );
                     }
+                    // The no-op skip's two halves, both recovered from the SAME
+                    // tags the rest of this loop trusts: the input set the cell
+                    // was aggregated from, and how many files it published. An
+                    // absent tag yields `None`/`0`, and either alone declines
+                    // the skip — so a cell written before this tag existed costs
+                    // one rebuild rather than freezing.
+                    let identity = (project_id.clone(), slice_start, slice_end, generation.clone(), source_fp, source_rows);
+                    let content_fp = content_fp_by_identity.get(&identity).copied().flatten();
+                    let output_files = paths_by_identity.get(&identity).map_or(0, |(_, paths)| u32::try_from(paths.len()).unwrap_or(u32::MAX));
                     self.rollup_slice_coverage.insert(
                         (project_id, source.to_string(), target.clone(), slice_start, slice_end),
                         RollupCoverage {
@@ -5471,8 +5501,8 @@ impl Database {
                             source_rows,
                             covered_through: slice_end,
                             measures: measures.map(|names| names.into_iter().collect()),
-                            content_fp: None,
-                            output_files: 0,
+                            content_fp,
+                            output_files,
                         },
                     );
                     recovered += 1;
@@ -10389,6 +10419,51 @@ mod rollup_noop_skip_tests {
         db.plan_rollup_backfill().await?;
         crate::support::advance_micros(16 * 60 * 1_000_000);
         db.drain_coordinator_rollups(64).await
+    }
+
+    /// The skip must survive a restart, or it is nearly useless in production.
+    ///
+    /// Coverage rebuilt from tier tags at boot carried `content_fp: None` and
+    /// `output_files: 0`, and either alone declines the skip — so NOTHING could
+    /// be skipped until a slice had published once more in the new process.
+    /// Production restarts on every non-docs push: three times in two and a half
+    /// hours on 2026-09-12, and `rollup_noop_rebuild_skipped_total` read **0** on
+    /// a 31-minute process against 38 on a 44-minute one. Uptime, not coverage,
+    /// was the binding constraint.
+    ///
+    /// The restart is a second `Database` over the same data dir, the same shape
+    /// `a_certification_survives_a_restart_and_still_grants_the_skip` uses.
+    ///
+    /// Can-fail proof, run red then restored: dropping `TAG_CONTENT_FINGERPRINT`
+    /// from the publish tag block leaves this red — no skip after the restart —
+    /// which is exactly the production behaviour being fixed.
+    #[serial]
+    #[tokio::test]
+    async fn a_restart_recovers_the_proof_the_skip_needs() -> Result<()> {
+        let mut cfg = (*TestConfigBuilder::new("rollup_noop_restart").with_buffer_mode(BufferMode::Enabled).with_rollups().build()).clone();
+        cfg.maintenance.timefusion_rollup_backfill_days = 7;
+        let cfg = Arc::new(cfg);
+        let project_id = format!("proj_{}", &uuid::Uuid::new_v4().to_string()[..8]);
+        let date = chrono::Utc::now().date_naive() - chrono::Duration::days(3);
+
+        {
+            let db = Arc::new(Database::with_config(Arc::clone(&cfg)).await?);
+            assert!(build_day(&db, &project_id, date, "seed").await? > 0, "no rollup unit ran, so nothing here says anything about restarts");
+        }
+
+        // A brand-new Database over the same data dir — a deploy, in miniature.
+        // Its coverage comes only from what the tier's tags carry.
+        let db = Arc::new(Database::with_config(cfg).await?);
+        db.recover_rollup_coverage("otel_logs_and_spans").await?;
+        let published_at = tier_version(&db).await.expect("the tier must exist after the first process published into it");
+
+        let before = skips();
+        remint_published_base_slices(&db)?;
+        crate::support::advance_micros(16 * 60 * 1_000_000);
+        db.drain_coordinator_rollups(64).await?;
+        assert!(skips() > before, "a slice re-minted after a restart must still be proved redundant from its tags");
+        assert_eq!(tier_version(&db).await, Some(published_at), "and must not write to the tier");
+        Ok(())
     }
 
     /// Prod 2026-09-11: BaseRollup held 59% of maintenance worker-seconds and

--- a/src/database/maintain.rs
+++ b/src/database/maintain.rs
@@ -4134,6 +4134,12 @@ impl Database {
             };
             let report = {
                 let mut journal = self.journal();
+                // Same pass, same tombstone mechanism: shed finished work whose
+                // slice the scheduler has already abandoned. A prod census on
+                // 2026-09-12 found 15,202 of 79,682 tasks (19.1%) in that state,
+                // and every commit serializes the set while `compact` rewrites
+                // all 51 MB of it under the global mutex.
+                journal.prune_retired_history(crate::support::now_micros());
                 let report = journal.coarsen_sealed_slices_capped(crate::support::now_micros(), &|project, _source, date| {
                     ceilings.get(&(project.to_string(), date.to_string())).or_else(|| ceilings.get(&("default".to_string(), date.to_string()))).copied()
                 });

--- a/src/maintenance_coordinator.rs
+++ b/src/maintenance_coordinator.rs
@@ -204,6 +204,15 @@ pub const TAG_PROJECT: &str = "timefusion.project";
 pub const TAG_SLICE_START: &str = "timefusion.slice_start_micros";
 pub const TAG_SLICE_END: &str = "timefusion.slice_end_micros";
 pub const TAG_SOURCE_FINGERPRINT: &str = "timefusion.source_fingerprint";
+/// The INPUT FILE SET this cell was aggregated from, deletion vectors included —
+/// the no-op-rebuild proof, persisted so it survives a restart.
+///
+/// Distinct from [`TAG_SOURCE_FINGERPRINT`], which hashes paths alone and is
+/// therefore blind to a deletion vector superseding an `Add` under the same
+/// path. Written by the publish site and read back by `recover_rollup_coverage`;
+/// absent on cells written before this tag existed, which yields `None` and
+/// declines the skip exactly as a missing proof should.
+pub const TAG_CONTENT_FINGERPRINT: &str = "timefusion.content_fingerprint";
 /// How many rows the SOURCE DATE PARTITION held when this slice was built —
 /// the `num_records` sum, exactly as `partition_stats_bounded` computes it.
 ///

--- a/src/maintenance_coordinator.rs
+++ b/src/maintenance_coordinator.rs
@@ -3381,10 +3381,51 @@ impl TaskJournal {
     /// normal size threshold. Migrations that remove tasks cannot represent
     /// those deletions as append-only WAL records, so they must force this
     /// compaction before startup continues.
+    /// Drop FINISHED tasks whose slice is past the abandonment horizon.
+    ///
+    /// Nothing pruned the journal, so retired keys accumulated forever: a
+    /// `docker cp` census of the production journal on 2026-09-12 read 79,682
+    /// tasks, **99.2% of them Complete or Superseded**, with **15,202 (19.1%)
+    /// finished and older than `STARVATION_HORIZON_MICROS`** — including one
+    /// 1,344 days old. Every commit serializes that set, and `compact` rewrites
+    /// all 51 MB of it under the global mutex, which is where
+    /// `journal_hold.max_ms` spikes of 3.5 s come from.
+    ///
+    /// The horizon is the right cut because the scheduler has ALREADY abandoned
+    /// this work — `publish_statistics` counts it as `beyond_horizon_tasks`
+    /// rather than as backlog — and because the data itself is past the 30-day
+    /// retention, so no query can reach it. Only FINISHED tasks go: pending work
+    /// past the horizon stays, because that gauge is how the abandoned debt is
+    /// sized and removing it would hide the debt rather than pay it.
+    ///
+    /// Losing a finished task means `rollup_slice_complete` answers false for
+    /// that slice, and `recover_rollup_coverage` then `continue`s past it — it
+    /// does NOT enqueue a rebuild, so this cannot start a rework storm. The
+    /// cost is that a >31-day-old slice reads raw, and there is nothing left
+    /// there to read.
+    ///
+    /// Goes through `retain_tasks`, so each drop leaves a `JournalRecord::Removed`
+    /// tombstone and survives a restart on the cheap append — the same contract
+    /// `coarsen_sealed_slices_capped` relies on, and the reason this belongs on
+    /// the periodic hygiene pass rather than inside `compact`. `compact` is a
+    /// migration primitive that several callers use purely to persist a removal;
+    /// giving it a retention policy would make every one of them age-sensitive.
+    pub fn prune_retired_history(&mut self, now_micros: i64) -> usize {
+        let dropped = self.retain_tasks(|task| {
+            !matches!(task.state, TaskState::Complete | TaskState::Superseded)
+                || now_micros.saturating_sub(task.key.slice.end_micros) <= STARVATION_HORIZON_MICROS
+        });
+        if dropped != 0 {
+            crate::observability::maintenance_stats().journal_retired_tasks_pruned.fetch_add(dropped as u64, std::sync::atomic::Ordering::Relaxed);
+        }
+        dropped
+    }
+
     pub fn compact(&mut self) -> anyhow::Result<()> {
         if let Some(parent) = self.path.parent() {
             fs::create_dir_all(parent)?;
         }
+
         // Derived work is left out of the authoritative snapshot too, so a
         // reload starts with none of it and `plan_compaction_debt` re-derives
         // exactly what storage says is needed within its next 60 s pass.
@@ -4518,6 +4559,80 @@ mod tests {
             40,
             "an explicit publish must still report the true pending count"
         );
+    }
+
+    /// The hygiene pass must shed FINISHED work past the abandonment horizon,
+    /// keep everything else, and make the drop survive a restart.
+    ///
+    /// Nothing pruned it, so retired keys accumulated forever. A `docker cp`
+    /// census of the production journal on 2026-09-12: 79,682 tasks, **99.2%
+    /// Complete or Superseded**, **15,202 (19.1%) finished and older than the
+    /// horizon** — one of them 1,344 days old. `compact` rewrites all 51 MB
+    /// under the global mutex, which is where `journal_hold.max_ms` spikes of
+    /// 3.5 s come from.
+    ///
+    /// Three things must NOT be pruned, and each is asserted: pending work past
+    /// the horizon (that is the abandoned-debt gauge, and hiding it is not
+    /// paying it), retrying work past the horizon, and finished work inside it.
+    ///
+    /// Can-fail proof, run red then restored: dropping the state test prunes the
+    /// pending task and the `beyond_horizon` assertion goes red; dropping the
+    /// age test prunes the recent one and the survivor count goes red.
+    #[test]
+    fn hygiene_sheds_finished_work_past_the_horizon_and_nothing_else() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut journal = TaskJournal::load(dir.path()).expect("journal");
+        let now = 400 * DAY_MICROS;
+        let at = |days_ago: i64| {
+            let end = now - days_ago * DAY_MICROS;
+            (end - DAY_MICROS, end)
+        };
+        let mut add = |name: &str, days_ago: i64, state: TaskState| {
+            let (start, end) = at(days_ago);
+            let mut t = task(name, start, end, Operation::BaseRollup);
+            t.state = state;
+            journal.upsert(t);
+        };
+        add("old-complete", 40, TaskState::Complete);
+        add("old-superseded", 40, TaskState::Superseded);
+        add("old-pending", 40, TaskState::Pending);
+        add("old-retry", 40, TaskState::Retry);
+        add("fresh-complete", 2, TaskState::Complete);
+        add("fresh-pending", 2, TaskState::Pending);
+        // Persist FIRST, or the durability assertion at the end is vacuous: an
+        // unpersisted task cannot resurrect, so the tombstones would never be
+        // what kept it gone. (Measured — the assertion passed with
+        // `retain_tasks` bypassed until this checkpoint was added.)
+        journal.checkpoint().expect("persist the whole set before pruning any of it");
+
+        assert_eq!(journal.prune_retired_history(now), 2, "exactly the two finished-and-past-the-horizon tasks");
+        let survivors: Vec<&str> = journal.tasks().map(|t| t.key.project_id.as_str()).collect();
+        assert!(!survivors.contains(&"old-complete") && !survivors.contains(&"old-superseded"));
+        assert!(
+            survivors.contains(&"old-pending") && survivors.contains(&"old-retry"),
+            "abandoned work past the horizon is the debt gauge and must survive: {survivors:?}"
+        );
+        assert!(survivors.contains(&"fresh-complete") && survivors.contains(&"fresh-pending"), "work inside the horizon must survive: {survivors:?}");
+
+        // The index must still find what is left, or every later lookup silently
+        // misses — the failure a bare `retain` on the vector would have caused.
+        for name in ["old-pending", "fresh-complete"] {
+            let (start, end) = at(if name == "old-pending" { 40 } else { 2 });
+            let key = task(name, start, end, Operation::BaseRollup).key;
+            assert_eq!(journal.state(&key), Some(if name == "old-pending" { TaskState::Pending } else { TaskState::Complete }), "{name} must still be indexed");
+        }
+        assert_eq!(journal.prune_retired_history(now), 0, "a second pass has nothing left to drop");
+
+        // The drop must be DURABLE on the cheap append. `coarsen_sealed_slices`
+        // had exactly this bug: a pass removed tasks, persisted nothing, and the
+        // next restart undid it — prod took `pending_base_rollup` 88,618 -> 2,294
+        // with the on-disk journal byte-identical. Going through `retain_tasks`
+        // is what leaves the `Removed` tombstone that prevents it here.
+        journal.checkpoint().expect("checkpoint the tombstones");
+        let reloaded = TaskJournal::load(dir.path()).expect("reload");
+        let names: Vec<&str> = reloaded.tasks().map(|t| t.key.project_id.as_str()).collect();
+        assert!(!names.contains(&"old-complete") && !names.contains(&"old-superseded"), "pruned tasks must not resurrect after a restart: {names:?}");
+        assert_eq!(names.len(), 4, "and nothing else may vanish with them: {names:?}");
     }
 
     /// Only outstanding ROLLUP work may veto a rollup backfill.

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -1070,6 +1070,14 @@ atomic_stats! {
         /// however busy maintenance gets. Tracking the checkpoint rate instead
         /// means the throttle is not firing.
         journal_stats_publishes as "journal_stats_publishes_total",
+        /// Finished tasks dropped from the journal because their slice is past
+        /// the abandonment horizon. A prod census on 2026-09-12 found 15,202 of
+        /// 79,682 (19.1%) in that state, so the first compaction after a deploy
+        /// should move this sharply once and then only trickle.
+        ///
+        /// Read `tasks_complete` alongside it: if this climbs while that does
+        /// not fall, something is re-creating the keys being pruned.
+        journal_retired_tasks_pruned as "journal_retired_tasks_pruned_total",
         /// Base files a DERIVED unit refused for an obsolete generation, split by
         /// whether refusing them actually cost anything.
         ///


### PR DESCRIPTION
Two journal/coverage hygiene changes in one deploy, because a restart is itself the cost the first one is about. Their signals are disjoint, so attribution is not muddied.

---

## 1. Carry the no-op skip's proof across a restart

The skip could not fire until a slice had published **again in the current process**: coverage rebuilt from tier tags at boot carried `content_fp: None` and `output_files: 0`, and either alone declines it.

That is close to fatal in production, where a restart happens on every non-docs push — **three in two and a half hours on 2026-09-12**, and `rollup_noop_rebuild_skipped_total` read **0** on a 31-minute process against 38 on a 44-minute one. **Uptime, not coverage, was the binding constraint** on a lane holding 59% of maintenance worker-seconds.

`TAG_CONTENT_FINGERPRINT` now persists the input fingerprint beside `TAG_SOURCE_FINGERPRINT`; `recover_rollup_coverage` reads it back alongside the file count already in `paths_by_identity`. **Both halves are required** — recovering one without the other changes nothing.

Several files serve one identity and all carry the same value (it is a property of the unit, not the file), so disagreement collapses to `None` rather than picking a winner. Pre-tag cells also yield `None`: one rebuild, not a freeze.

**Can-fail proof**: `a_restart_recovers_the_proof_the_skip_needs` uses a second `Database` over the same data dir. Dropping the tag from the publish block leaves it red.

---

## 2. Shed finished work the scheduler already abandoned

**Measured first, and it corrects my own earlier note.** A `docker cp` census of the production journal: 79,682 tasks, **99.2% Complete or Superseded**, **15,202 (19.1%) finished and past `STARVATION_HORIZON_MICROS`** — one 1,344 days old.

But I had called this "unbounded growth" and **the census does not support that**: the mass is the 31-day working set, and the tail past 62 days is 428 tasks (0.5%). The honest size is a **one-time ~19%** with the tail capped thereafter. #263 already removed the per-commit scan cost; what remains is `compact` rewriting 51 MB under the global mutex, the source of the `journal_hold.max_ms` spikes.

Only **finished** tasks go. Pending and retrying work past the horizon stays — that gauge is how abandoned debt is sized, and hiding it is not paying it. Losing a finished task makes `rollup_slice_complete` answer false and `recover_rollup_coverage` `continue` past it; it does **not** enqueue a rebuild, so no rework storm.

It runs on the periodic hygiene pass beside `coarsen_sealed_slices_capped`, **not inside `compact`** — `compact` is a migration primitive several callers use purely to persist a removal, and giving it a retention policy made all of them age-sensitive (`bootstrap_backlog_migration_keeps_publications_and_runs_once` went red on exactly that). Going through `retain_tasks` gets the `Removed` tombstone, so the drop survives a restart on the cheap append.

**Can-fail proofs**, each run red and restored: dropping the state test prunes the pending task; dropping the age test prunes the fresh one; bypassing `retain_tasks` resurrects pruned tasks after a reload.

> That last assertion was **vacuous when first written** — it passed with `retain_tasks` bypassed, because tasks never checkpointed cannot resurrect. It now persists the whole set before pruning any of it.

---

`cargo lint` clean, full suite **1530/1530**, `make ci-signoff` green on all five checks.

## Watching it

- `rollup_noop_rebuild_skipped_total` should be **non-zero within minutes of a restart**, not after ~35 minutes. That is the whole point of (1).
- `journal_retired_tasks_pruned_total` should jump once on the first hygiene pass (expect ~15k) then trickle; read `tasks_complete` beside it — if this climbs while that does not fall, something is re-creating the pruned keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)