### PR TITLE
Bound how long a unit may hold the hygiene rewrite permit

### DIFF
--- a/docs/plans/2026-09-12-hygiene-starvation-and-the-10x-write-question.md
+++ b/docs/plans/2026-09-12-hygiene-starvation-and-the-10x-write-question.md
@@ -1,0 +1,137 @@
+# The hygiene lanes are dead, and what that says about 10x writes
+
+2026-09-12, measured against production.
+
+## Part 1 — HotPacking and SealedConsolidation do no work at all
+
+`timefusion_stats`, on a 55-minute process:
+
+| lane | worker-seconds | rate |
+|---|---:|---|
+| BaseRollup | 7,740 | ~2.5 cores |
+| Dedup | 801 | ~0.26 cores |
+| DerivedRollup | 118 | ~0.04 cores |
+| **HotPacking** | **0** | — |
+| **SealedConsolidation** | **0** | — |
+| **Repair** | **0** | — |
+
+Over 60 minutes, 623 units started: **425 BaseRollup, 130 Dedup, 67
+DerivedRollup, 1 HotPacking, 1 SealedConsolidation.** Against that:
+`sealed_compaction_debt_bytes` = **1.1 TB**, 196 hygiene cells planned every
+60-second pass, and `maintenance_hygiene_debt_unclaimed` firing 14 times per 15
+minutes.
+
+The cycle is not the cause — `CYCLE_BALANCED` gives each hygiene operation one
+slot in ten, coverage is not short (median 30 days against a threshold of 14) so
+neither the debt-slot nor the derived-reserve cap is engaged, and the
+`most_indebted_unclaimed` diagnostic reports `outranked_by`, meaning a claimable
+task exists.
+
+### The mechanism
+
+Three facts compose into a dead lane:
+
+1. **`light_rewrite_sem` prices 3 permits** —
+   `coordinator_share(8 GiB) / COORDINATOR_PER_SORT_BUDGET(1.25 GiB) −
+   repair_holdback(3)`, floored against `cores/4`.
+2. **The permit is taken BEFORE the claim**
+   (`run_coordinator_compaction_selected`). That is deliberate and correct: the
+   alternative spends the unit's whole deadline queueing inside `stage_hot_bin`,
+   which prod measured on 2026-08-25 as 350-750 s of every 900 s deadline.
+   Refusing to claim is work-conserving — the worker goes and does rollup.
+3. **Nothing bounds how long a unit may hold that permit.** `run_until_idle` is
+   an IDLE window, not a budget: it fires only after a full deadline with zero
+   progress, so a unit that emits one progress tick per window runs forever.
+
+So one non-converging unit removes a third of the lane's capacity for as long as
+it survives. Production had exactly that:
+
+```
+operation=SealedConsolidation  outcome=Some(Running)  ran_secs=7634
+```
+
+**7,634 seconds — 8.5x its 900 s deadline — completing nothing**, on a day-wide
+consolidation of the shared project. `maintenance_coordinator_unit_timed_out`
+fired **zero** times in two hours. `compaction_permits_unavailable` reached
+1,812 in 55 minutes, which is the refusals being counted while the acquisitions
+behind them were 2 per hour.
+
+### Fixed here
+
+`coordinator_operation_lifetime_cap` gives the permit-holding lanes an absolute
+wall-clock ceiling of 4x their idle deadline. Killing such a unit loses nothing:
+the `TaskLease` requeues it on drop and `abandon_running` bisects it, which is
+what a whale day-wide unit needs — children that fit. Rollup and dedup keep
+idle-only semantics, because they hold no permit and rollup cost is set by input
+FILE COUNT, so bisecting it converges on nothing.
+
+Two counters close the instrument gap that made this take forty minutes to find
+rather than one: `compaction_permits_acquired` (the denominator
+`compaction_permits_unavailable` never had) and
+`maintenance_unit_lifetime_capped`.
+
+## Part 2 — can we take 10x the writes?
+
+**No. Not today, and CPU is the least of the reasons.**
+
+Current load, same 55-minute process: **1,448 rows/s** ingested, buffer pressure
+**9%**, `backpressure_engaged_total` and `backpressure_rejected_total` both
+**0**, zero flush failures. At 1x the write path is comfortable.
+
+### What scales, and what breaks first
+
+| resource | at 1x | at 10x | verdict |
+|---|---|---|---|
+| CPU | ~1,800-2,500% of 4,800% | BaseRollup ~25 cores of 48, plus dedup and hygiene | **tight, not fatal** |
+| MemBuffer | pressure 9% | ~90% of the hard limit | **no margin** |
+| Disk write bandwidth | 284-341 MB/s at 43-54% util | ~3 GB/s asked of an array that saturates near 600-700 MB/s | **~5x short — the wall** |
+| Hygiene lanes | 0 worker-seconds, 1.1 TB behind | 10x the file production | **diverges without bound** |
+
+### The disk is the wall, and amplification is why
+
+The array is **much healthier than on 09-11** — md3 now runs 43-54% utilisation
+with `w_await` **1.6-1.8 ms** and queue depth 12-23, against 99-100%,
+63-620 ms and 212-620 then. The tantivy-scratch move and the journal `fsync`
+reductions bought that.
+
+But the ratio has not moved. Durable ingest contributes ~4.8 MB/s
+(`flush_freed_bytes_total` 15.7 GB / 55 min, and that is DECODED bytes, so the
+true on-disk figure is smaller and the ratio larger). The device writes ~300 MB/s
+sustained. **The box writes on the order of 60 bytes for every byte of ingest
+that lands.**
+
+Ten times the ingest at the same amplification asks for ~3 GB/s from a device
+that saturates around 600-700 MB/s. **Faster disks do not fix this; a smaller
+multiplier does.**
+
+The largest single channel is now measurable, and it is not maintenance rewrites:
+
+```
+foyer.admit_read_miss_bytes: 158.5 GB -> 232.6 GB over 90 s = 824 MB/s
+```
+
+Foyer admitting read-miss bytes into the L2 disk cache, at **824 MB/s** on a
+warming process — more than the whole device does in steady state. And
+`l2_used_bytes` reads **638 GB against a 600 GB configured cap**, which is the
+over-cap condition the 09-11 doc already flagged as a misconfiguration. An L2
+that is over its cap admits, evicts, misses and re-admits; that loop is
+self-sustaining and is paid entirely in disk writes.
+
+### So the order of work for 10x
+
+1. **Hygiene throughput** — fixed here, needs verification. At 10x this is not
+   optional: file production is 10x and the lane is currently at zero.
+2. **Foyer L2 admission policy.** Measure `admit_read_miss_bytes` against
+   `evictions` on a mature process. If the cache is thrashing over its cap, this
+   is the single biggest write channel and the cheapest to cut — a cache that
+   cannot hold its working set should decline admission, not churn.
+3. **MemBuffer headroom.** 9% at 1x leaves nothing at 10x. Either the budget
+   grows or the flush interval shortens — and shortening it produces more files,
+   which lands back on (1).
+4. Only then, per-unit maintenance cost. The 09-11 fix order
+   (`verify_blob` double-unpack, unattributed DataFusion spill) still applies and
+   is not re-derived here.
+
+CPU headroom is real: the box runs at roughly half of 48 cores with BaseRollup
+down to ~2.5 cores after today's rollup work. The constraint is bytes to disk,
+not instructions.

--- a/docs/plans/2026-09-12-hygiene-starvation-and-the-10x-write-question.md
+++ b/docs/plans/2026-09-12-hygiene-starvation-and-the-10x-write-question.md
@@ -72,66 +72,76 @@ rather than one: `compaction_permits_acquired` (the denominator
 
 ## Part 2 — can we take 10x the writes?
 
-**No. Not today, and CPU is the least of the reasons.**
+**No — not today. The wall is CPU and the hygiene lane, not the disk.**
 
 Current load, same 55-minute process: **1,448 rows/s** ingested, buffer pressure
 **9%**, `backpressure_engaged_total` and `backpressure_rejected_total` both
 **0**, zero flush failures. At 1x the write path is comfortable.
 
+### A correction I made on myself, first
+
+My first pass said the disk was the wall and was **wrong**, because I measured a
+process that had just restarted. Recorded because it is the standing trap in
+this codebase and I walked into it anyway:
+
+| measured on | read-miss admission | md3 writes | md3 util |
+|---|---:|---:|---:|
+| 3-minute process | 824 MB/s | — | — |
+| 10-minute process (average since boot) | 482 MB/s | ~300 MB/s | 43-54% |
+| **14-minute process, 120 s delta** | **1.9 MB/s** | **8-10 MB/s** | **3.7-4.9%** |
+
+The first two are **cold-start cache warming**, not steady state. A lifetime
+average on a young process is dominated by its boot. Taking a delta on a warm
+one gives 1.9 MB/s of admission and a device at ~4% utilisation.
+
+This also settles the open question in
+[`2026-09-12-cache-admission-plan.md`](2026-09-12-cache-admission-plan.md), and
+not in favour of its leading candidate. The admission-source counters shipped
+today read `admit_write_capture_bytes` at **0.002 MB/s** against
+`admit_read_miss_bytes` — so write-capture is exonerated by its own instrument,
+matching the 474 KB/s / 80%-hit-before-evict verdict already recorded. The
+~500 MB/s that hunt was chasing is **cache re-warming after a restart**, which is
+a restart-frequency cost, not a steady-state throughput ceiling.
+
 ### What scales, and what breaks first
 
 | resource | at 1x | at 10x | verdict |
 |---|---|---|---|
-| CPU | ~1,800-2,500% of 4,800% | BaseRollup ~25 cores of 48, plus dedup and hygiene | **tight, not fatal** |
-| MemBuffer | pressure 9% | ~90% of the hard limit | **no margin** |
-| Disk write bandwidth | 284-341 MB/s at 43-54% util | ~3 GB/s asked of an array that saturates near 600-700 MB/s | **~5x short — the wall** |
-| Hygiene lanes | 0 worker-seconds, 1.1 TB behind | 10x the file production | **diverges without bound** |
+| CPU | 1,432-2,149% of 4,800% | BaseRollup alone 25-39 of 48 cores | **the wall** |
+| Hygiene lanes | 0 worker-seconds, 1.1 TB behind | 10x the file production | **the other wall** |
+| MemBuffer | pressure 9-13% | ~90-100% of the hard limit | **no margin** |
+| Disk write bandwidth | 8-10 MB/s at ~4% util (warm) | ~100 MB/s, ~40% util | fine |
 
-### The disk is the wall, and amplification is why
+Steady state on a 14-minute process: 1,470 rows/s, CPU **1,432-2,149% of 4,800%
+(30-45% of the box)**, memory 15-16 GB of 120 GB, buffer pressure 13%.
+BaseRollup costs **2.5-3.9 cores** (the lower figure on a mature process, the
+higher on one still burning its restart backlog).
 
-The array is **much healthier than on 09-11** — md3 now runs 43-54% utilisation
-with `w_await` **1.6-1.8 ms** and queue depth 12-23, against 99-100%,
-63-620 ms and 212-620 then. The tantivy-scratch move and the journal `fsync`
-reductions bought that.
+At 10x ingest, BaseRollup alone wants **25-39 of 48 cores**, before dedup, before
+the hygiene lanes that today do nothing and must then do ten times nothing, and
+before query. That does not fit.
 
-But the ratio has not moved. Durable ingest contributes ~4.8 MB/s
-(`flush_freed_bytes_total` 15.7 GB / 55 min, and that is DECODED bytes, so the
-true on-disk figure is smaller and the ratio larger). The device writes ~300 MB/s
-sustained. **The box writes on the order of 60 bytes for every byte of ingest
-that lands.**
-
-Ten times the ingest at the same amplification asks for ~3 GB/s from a device
-that saturates around 600-700 MB/s. **Faster disks do not fix this; a smaller
-multiplier does.**
-
-The largest single channel is now measurable, and it is not maintenance rewrites:
-
-```
-foyer.admit_read_miss_bytes: 158.5 GB -> 232.6 GB over 90 s = 824 MB/s
-```
-
-Foyer admitting read-miss bytes into the L2 disk cache, at **824 MB/s** on a
-warming process — more than the whole device does in steady state. And
-`l2_used_bytes` reads **638 GB against a 600 GB configured cap**, which is the
-over-cap condition the 09-11 doc already flagged as a misconfiguration. An L2
-that is over its cap admits, evicts, misses and re-admits; that loop is
-self-sustaining and is paid entirely in disk writes.
+The disk, by contrast, would go from ~4% to ~40% utilisation — uncomfortable but
+not a wall. The 09-11 measurement of 484 MB/s sustained on a **19-hour** process
+was real at the time; the tantivy-scratch move, the journal `fsync` reductions
+and write-capture gating have since taken steady-state writes down by roughly
+two orders of magnitude.
 
 ### So the order of work for 10x
 
-1. **Hygiene throughput** — fixed here, needs verification. At 10x this is not
-   optional: file production is 10x and the lane is currently at zero.
-2. **Foyer L2 admission policy.** Measure `admit_read_miss_bytes` against
-   `evictions` on a mature process. If the cache is thrashing over its cap, this
-   is the single biggest write channel and the cheapest to cut — a cache that
-   cannot hold its working set should decline admission, not churn.
-3. **MemBuffer headroom.** 9% at 1x leaves nothing at 10x. Either the budget
+1. **Hygiene throughput** — fixed here, needs verification. Not optional at 10x:
+   file production is 10x and the lane is currently at zero.
+2. **BaseRollup CPU per unit.** It is the single largest consumer and the one
+   that scales with data volume. Today's no-op skip and `#262` roughly halved it;
+   the remaining cost is real aggregation over 1,490x more rows than are
+   ingested, and that ratio is the lever.
+3. **MemBuffer headroom.** 9-13% at 1x leaves nothing at 10x. Either the budget
    grows or the flush interval shortens — and shortening it produces more files,
    which lands back on (1).
-4. Only then, per-unit maintenance cost. The 09-11 fix order
-   (`verify_blob` double-unpack, unattributed DataFusion spill) still applies and
-   is not re-derived here.
+4. **Restart frequency**, which is now a first-class cost rather than an
+   annoyance: each restart re-warms the cache at ~500-800 MB/s for minutes, and
+   the no-op rollup skip cannot fire until slices republish. Prod restarted
+   three times in two and a half hours today.
 
-CPU headroom is real: the box runs at roughly half of 48 cores with BaseRollup
-down to ~2.5 cores after today's rollup work. The constraint is bytes to disk,
-not instructions.
+Disk is no longer on this list, and that is a change from 09-11 worth noticing
+rather than assuming.

--- a/src/database/maintain.rs
+++ b/src/database/maintain.rs
@@ -217,7 +217,7 @@ mod liveness_clock_tests {
             }
             "committed"
         };
-        let result = super::run_until_idle(std::time::Duration::from_secs(30), progress, work).await;
+        let result = super::run_until_idle_capped(std::time::Duration::from_secs(30), None, progress, work).await;
         assert_eq!(result.ok(), Some("committed"), "100s of steady progress must survive a 30s idle window");
     }
 
@@ -235,7 +235,7 @@ mod liveness_clock_tests {
             }
             "committed"
         };
-        assert_eq!(super::run_until_idle(std::time::Duration::from_secs(30), Arc::clone(&progress), work).await.ok(), Some("committed"));
+        assert_eq!(super::run_until_idle_capped(std::time::Duration::from_secs(30), None, Arc::clone(&progress), work).await.ok(), Some("committed"));
         assert_eq!(progress.load(Relaxed), 5_000, "the task-local reached the counter the clock reads");
     }
 
@@ -252,7 +252,7 @@ mod liveness_clock_tests {
             }
             Ok::<_, anyhow::Error>("committed")
         };
-        let result = super::run_until_idle(std::time::Duration::from_secs(30), progress, work).await??;
+        let result = super::run_until_idle_capped(std::time::Duration::from_secs(30), None, progress, work).await??;
         assert_eq!(result, "committed", "completed short queries must prevent a false idle timeout");
         Ok(())
     }
@@ -383,7 +383,7 @@ mod liveness_clock_tests {
     async fn work_that_writes_nothing_is_given_up_on() {
         let progress = Arc::new(AtomicU64::new(0));
         let stalled = async { std::future::pending::<&str>().await };
-        let result = super::run_until_idle(std::time::Duration::from_secs(30), progress, stalled).await;
+        let result = super::run_until_idle_capped(std::time::Duration::from_secs(30), None, progress, stalled).await;
         assert!(result.is_err(), "an idle unit must not hold its worker forever");
     }
 
@@ -779,10 +779,33 @@ fn plan_output_rows(plan: &dyn datafusion::physical_plan::ExecutionPlan) -> u64 
 /// `docs/plans/2026-08-31-how-other-systems-schedule-maintenance.md`). The
 /// counter is per-unit, never shared, so one worker's progress cannot excuse
 /// another's stall.
-async fn run_until_idle<T>(
-    idle: std::time::Duration, progress: Arc<std::sync::atomic::AtomicU64>, work: impl Future<Output = T>,
+/// Run `work` until it stops making progress for `idle`, or until `cap` of total
+/// wall clock has elapsed.
+///
+/// The idle window alone is the right shape for a unit that owns only a worker — a
+/// slow unit making progress should not be killed for being slow. It is the
+/// WRONG shape for a unit holding a scarce permit, because it places no upper
+/// bound on the hold at all.
+///
+/// Prod 2026-09-12 measured the consequence. A single day-wide
+/// `SealedConsolidation` over the shared project ran **7,634 s — 8.5x its 900 s
+/// deadline** — and returned `outcome=Some(Running)` having completed nothing,
+/// while `maintenance_coordinator_unit_timed_out` fired ZERO times. It holds one
+/// of only ~3 `light_rewrite_sem` permits for that entire time, and because that
+/// permit is taken BEFORE the claim, every other hygiene attempt is refused
+/// outright: `compaction_permits_unavailable` reached 1,812 in 55 minutes while
+/// HotPacking and SealedConsolidation together recorded **0 worker-seconds** and
+/// 2 claims in an hour, against 196 planned cells and 1.1 TB of sealed debt.
+///
+/// Killing such a unit is not lost work: the `TaskLease` requeues it on drop and
+/// `abandon_running` bisects it, which is exactly what a whale day-wide unit
+/// needs — smaller children that fit. The ceiling is generous on purpose, so it
+/// fires on units that are not converging rather than on merely slow ones.
+async fn run_until_idle_capped<T>(
+    idle: std::time::Duration, cap: Option<std::time::Duration>, progress: Arc<std::sync::atomic::AtomicU64>, work: impl Future<Output = T>,
 ) -> Result<T, tokio::time::error::Elapsed> {
     use std::sync::atomic::Ordering::Relaxed;
+    let started = std::time::Instant::now();
     // BOXED, not `pin!`ed on the stack. `work` is the coordinator's whole
     // dispatch future and this frame sits inside an already-deep async stack:
     // holding it inline overflowed the worker stack in a debug build
@@ -793,7 +816,9 @@ async fn run_until_idle<T>(
         match tokio::time::timeout(idle, &mut work).await {
             Ok(value) => return Ok(value),
             Err(elapsed) => match progress.load(Relaxed) {
-                moved if moved != last => last = moved,
+                // Progress moved, so the unit is alive — but a permit-holding
+                // lane still owes the rest of the fleet an upper bound.
+                moved if moved != last && cap.is_none_or(|cap| started.elapsed() < cap) => last = moved,
                 _ => return Err(elapsed),
             },
         }
@@ -3937,7 +3962,10 @@ impl Database {
         // reaching `stage_hot_bin`, so gating it would invent a starvation.
         let light_permit = match operation {
             Operation::HotPacking | Operation::SealedConsolidation => match Arc::clone(&self.light_rewrite_sem).try_acquire_owned() {
-                Ok(permit) => Some(permit),
+                Ok(permit) => {
+                    crate::observability::maintenance_stats().compaction_permits_acquired.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    Some(permit)
+                }
                 Err(_) => {
                     crate::observability::maintenance_stats().compaction_permits_unavailable.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                     return Ok(false);
@@ -4277,7 +4305,7 @@ impl Database {
             // answered from the timeout count alone, because a timeout says only
             // "longer than the deadline", never how much longer.
             let started = std::time::Instant::now();
-            let completed = match run_until_idle(timeout, Arc::clone(&progress), work).await {
+            let completed = match run_until_idle_capped(timeout, coordinator_operation_lifetime_cap(operation), Arc::clone(&progress), work).await {
                 Ok(result) => {
                     let elapsed = started.elapsed();
                     // Before `result?`: a unit that errors after 800s spent that
@@ -4302,7 +4330,17 @@ impl Database {
                     // Dropping the operation future drops its TaskLease. The
                     // claimed unit is durably requeued and all resource tokens
                     // are released before another project gets a turn.
-                    warn!(?operation, timeout_seconds = timeout.as_secs(), event = "maintenance_coordinator_unit_timed_out");
+                    let capped = coordinator_operation_lifetime_cap(operation).is_some_and(|cap| started.elapsed() >= cap);
+                    if capped {
+                        crate::observability::maintenance_stats().maintenance_unit_lifetime_capped.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    }
+                    warn!(
+                        ?operation,
+                        timeout_seconds = timeout.as_secs(),
+                        ran_secs = started.elapsed().as_secs(),
+                        capped,
+                        event = "maintenance_coordinator_unit_timed_out"
+                    );
                     // `killed_secs` is a strict subset of `worker_secs`: the
                     // share of the fleet's capacity that produced nothing.
                     crate::observability::count_maintenance_work(label, "worker_secs", started.elapsed().as_secs());
@@ -10666,5 +10704,88 @@ mod rollup_journal_persist_tests {
         assert_eq!(counts().1 - before.1, 1, "an unchanged journal must be skipped on content, not merely deferred");
         assert_eq!(counts().0, before.0, "and must not write");
         Ok(())
+    }
+}
+
+/// The absolute lifetime cap on permit-holding maintenance units.
+#[cfg(test)]
+mod unit_lifetime_cap_tests {
+    use std::{
+        sync::{
+            Arc,
+            atomic::{AtomicU64, Ordering::Relaxed},
+        },
+        time::Duration,
+    };
+
+    use super::{coordinator_operation_lifetime_cap, run_until_idle_capped};
+    use crate::maintenance_coordinator::Operation;
+
+    /// A unit that keeps reporting progress but never finishes must still be
+    /// stopped when it holds a permit the rest of the fleet is waiting on.
+    ///
+    /// `run_until_idle` is an IDLE window by design — a slow but converging unit
+    /// should not be killed for being slow. That is right when a unit costs only
+    /// its worker and wrong when it holds one of ~3 `light_rewrite_sem` permits,
+    /// because it bounds the hold at nothing at all.
+    ///
+    /// Prod 2026-09-12: one day-wide `SealedConsolidation` ran **7,634 s, 8.5x
+    /// its 900 s deadline**, returned `outcome=Some(Running)` having completed
+    /// nothing, and `maintenance_coordinator_unit_timed_out` fired ZERO times.
+    /// Meanwhile `compaction_permits_unavailable` hit 1,812 in 55 minutes,
+    /// HotPacking and SealedConsolidation recorded **0 worker-seconds** between
+    /// them, and 196 cells and 1.1 TB of sealed debt went unworked.
+    ///
+    /// Both directions, because a cap that fires on converging work is its own
+    /// outage.
+    ///
+    /// Can-fail proof, run red then restored: passing `None` for the cap — the
+    /// old `run_until_idle` behaviour — hangs the first case until the test
+    /// harness kills it, because that is precisely a unit that never stops.
+    #[tokio::test(start_paused = true)]
+    async fn a_progressing_unit_that_never_converges_is_still_stopped() {
+        let idle = Duration::from_millis(900);
+        let cap = Duration::from_millis(3_600);
+        let progress = Arc::new(AtomicU64::new(0));
+        let ticker = Arc::clone(&progress);
+        // Never returns, but reports progress inside every idle window — exactly
+        // the shape that ran for 7,634 s in production.
+        let forever = async move {
+            loop {
+                tokio::time::sleep(Duration::from_millis(100)).await;
+                ticker.fetch_add(1, Relaxed);
+            }
+        };
+        let started = tokio::time::Instant::now();
+        assert!(run_until_idle_capped(idle, Some(cap), progress, forever).await.is_err(), "a unit past its lifetime cap must be stopped");
+        assert!(started.elapsed() >= cap, "and not before the cap");
+
+        // The other direction: work that FINISHES inside the cap is untouched,
+        // including work slower than a single idle window.
+        let progress = Arc::new(AtomicU64::new(0));
+        let ticker = Arc::clone(&progress);
+        let converging = async move {
+            for _ in 0..12 {
+                tokio::time::sleep(Duration::from_millis(100)).await;
+                ticker.fetch_add(1, Relaxed);
+            }
+            7u32
+        };
+        assert_eq!(run_until_idle_capped(idle, Some(cap), progress, converging).await.ok(), Some(7), "converging work must not be killed");
+    }
+
+    /// Only the lanes that hold a permit get a cap. A rollup unit costs its
+    /// worker and nothing else, and rollup cost is set by input FILE COUNT —
+    /// bisecting it converges on nothing, which is why its deadline was
+    /// lengthened rather than shortened.
+    #[test]
+    fn only_the_permit_holding_lanes_are_capped() {
+        for operation in [Operation::HotPacking, Operation::SealedConsolidation, Operation::Repair] {
+            let cap = coordinator_operation_lifetime_cap(operation).expect("permit-holding lanes are capped");
+            assert_eq!(cap, crate::database::coordinator_operation_timeout(operation) * 4, "{operation:?}");
+        }
+        for operation in [Operation::BaseRollup, Operation::DerivedRollup, Operation::Dedup] {
+            assert!(coordinator_operation_lifetime_cap(operation).is_none(), "{operation:?} holds no permit and must keep idle-only semantics");
+        }
     }
 }

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -1443,6 +1443,28 @@ fn buffered_source_retry_delay(slice: crate::maintenance_coordinator::TimeSlice,
     u64::try_from(earliest.saturating_sub(now_micros)).map_or(FLOOR, |micros| std::time::Duration::from_micros(micros).max(FLOOR))
 }
 
+/// Absolute wall-clock ceiling for a unit, for the lanes that hold a permit the
+/// rest of the fleet is waiting on.
+///
+/// `None` means the idle window alone governs, which is right wherever a unit
+/// costs only its worker. The rewrite lanes are different: `light_rewrite_sem`
+/// prices ~3 permits and `run_coordinator_compaction_selected` takes one BEFORE
+/// it claims, so one unit that never converges removes a third of the lane's
+/// capacity for as long as it runs — and the idle window places no bound on that.
+///
+/// Four times the idle deadline. Generous enough that a slow-but-converging unit
+/// finishes, short enough that a day-wide whale is bisected into children that
+/// fit rather than holding the lane for hours. `Repair` is included: it does not
+/// take the permit up front, but `stage_hot_bin` AWAITS one, which is the same
+/// hold by a different route.
+fn coordinator_operation_lifetime_cap(operation: crate::maintenance_coordinator::Operation) -> Option<std::time::Duration> {
+    use crate::maintenance_coordinator::Operation;
+    match operation {
+        Operation::HotPacking | Operation::SealedConsolidation | Operation::Repair => Some(coordinator_operation_timeout(operation) * 4),
+        Operation::BaseRollup | Operation::DerivedRollup | Operation::Dedup => None,
+    }
+}
+
 fn coordinator_operation_timeout(operation: crate::maintenance_coordinator::Operation) -> std::time::Duration {
     use crate::maintenance_coordinator::Operation;
     match operation {

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -1178,6 +1178,23 @@ atomic_stats! {
         /// gauge, not a fault: read it against
         /// `maintenance_coordinator_unit_timed_out`, which it is meant to replace.
         compaction_permits_unavailable,
+        /// Packing/consolidation turns that DID take a `light_rewrite_sem` permit.
+        ///
+        /// The denominator `compaction_permits_unavailable` never had. On its own
+        /// a refusal count cannot distinguish healthy contention from a lane that
+        /// is dead: prod 2026-09-12 read 1,812 refusals in 55 minutes and it took
+        /// forty minutes of code reading to establish that the acquisitions behind
+        /// it were 2 per hour, against 196 planned cells and 1.1 TB of sealed
+        /// debt. Read `acquired / (acquired + unavailable)`.
+        compaction_permits_acquired,
+        /// Units killed by the absolute lifetime cap rather than by going idle —
+        /// see `coordinator_operation_lifetime_cap`.
+        ///
+        /// These are units that were making progress and still not converging. A
+        /// single one cost prod 7,634 s (8.5x its deadline) holding one of ~3
+        /// permits. Nonzero is the cap doing its job; it should be small, and if
+        /// it tracks the claim rate the units are being bisected too slowly.
+        maintenance_unit_lifetime_capped,
         /// Dashboard aggregates served from a rollup, split by how much of the
         /// window the rollup owned. The OTel counters carry the same numbers but
         /// cannot be read back in-process, and these two are the only signal that


### PR DESCRIPTION
## HotPacking and SealedConsolidation do no work at all

On a 55-minute production process both recorded **0 worker-seconds**. Over 60 minutes, 623 units started:

| | started |
|---|---:|
| BaseRollup | 425 |
| Dedup | 130 |
| DerivedRollup | 67 |
| **HotPacking** | **1** |
| **SealedConsolidation** | **1** |

Against `sealed_compaction_debt_bytes` = **1.1 TB**, 196 cells planned every 60-second pass, and `maintenance_hygiene_debt_unclaimed` firing 14× per 15 minutes.

**The cycle is not the cause.** `CYCLE_BALANCED` gives each hygiene operation one slot in ten; coverage is not short (median 30 days vs a threshold of 14) so neither the debt-slot nor derived-reserve cap engages; and `most_indebted_unclaimed` reports `outranked_by`, which means a claimable task exists.

## The mechanism — three facts compose into a dead lane

1. **`light_rewrite_sem` prices ~3 permits** — `coordinator_share(8 GiB) / PER_SORT(1.25 GiB) − repair_holdback(3)`.
2. **The permit is taken BEFORE the claim**, deliberately and correctly: claiming first and blocking inside `stage_hot_bin` spent 350-750 s of every 900 s deadline (prod 2026-08-25). Refusing to claim is work-conserving.
3. **Nothing bounds how long a unit may hold it.** `run_until_idle` is an *idle* window — it fires only after a full deadline with **zero** progress, so a unit emitting one tick per window runs forever.

Production had exactly that:

```
operation=SealedConsolidation  outcome=Some(Running)  ran_secs=7634
```

**7,634 s — 8.5× its 900 s deadline — completing nothing**, while `maintenance_coordinator_unit_timed_out` fired **zero** times in two hours. One such unit removes a third of the lane for as long as it lives. `compaction_permits_unavailable` hit 1,812 in 55 minutes while the acquisitions behind it were 2 per hour.

## The fix

`coordinator_operation_lifetime_cap` — an absolute ceiling of 4× the idle deadline, for the permit-holding lanes only.

This loses no work: `TaskLease` requeues on drop and `abandon_running` bisects, which is exactly what a whale day-wide unit needs — children that fit. Rollup and dedup keep idle-only semantics: they hold no permit, and rollup cost is set by input **file count**, so bisecting it converges on nothing.

Two counters close the gap that made this take forty minutes to diagnose instead of one:
- **`compaction_permits_acquired`** — the denominator `compaction_permits_unavailable` never had. A refusal count alone cannot distinguish healthy contention from a dead lane.
- **`maintenance_unit_lifetime_capped`** — units stopped by the ceiling rather than by going idle.

## Verification

Both directions pinned, each run red then restored:
- a unit reporting progress forever **is** stopped at the cap (with `None` it hangs until the harness kills it — which is the point);
- converging work slower than one idle window is **not** stopped;
- only the permit-holding lanes carry a cap.

`cargo lint` clean, full suite 1532/1532, `make ci-signoff` green on all five checks.

## Also: the 10x write answer, and a correction

`docs/plans/2026-09-12-hygiene-starvation-and-the-10x-write-question.md`.

**No, not at 10x — the wall is CPU and this lane, not the disk.** BaseRollup alone would want 25-39 of 48 cores; MemBuffer goes from 9-13% to ~90%.

My first pass said the disk was the wall and was **wrong** — I measured a process that had just restarted. A 120 s delta on a warm one gives **1.9 MB/s** of foyer read-miss admission and md3 at **3.7-4.9% utilisation**; the 482-824 MB/s figures were cold-start cache warming.

That also settles the open question in `2026-09-12-cache-admission-plan.md`, **against its leading candidate**: `admit_write_capture_bytes` reads **0.002 MB/s**, so write-capture is exonerated by the very instrument shipped to convict it. The ~500 MB/s that hunt was chasing is restart re-warming — a restart-frequency cost, not a steady-state ceiling.

## Watching it

`compaction_permits_acquired` should become non-trivial against `compaction_permits_unavailable`, and `work.HotPacking.worker_secs` / `work.SealedConsolidation.worker_secs` should leave zero. `maintenance_unit_lifetime_capped` should be small — if it tracks the claim rate, units are being bisected too slowly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)