### PR TITLE
Export how many hygiene rewrite permits exist, and how many are free

### DIFF
--- a/src/database/maintain.rs
+++ b/src/database/maintain.rs
@@ -3961,16 +3961,28 @@ impl Database {
         // 0s, returning at `repair_bin_already_sorted`/`take(1)` without ever
         // reaching `stage_hot_bin`, so gating it would invent a starvation.
         let light_permit = match operation {
-            Operation::HotPacking | Operation::SealedConsolidation => match Arc::clone(&self.light_rewrite_sem).try_acquire_owned() {
-                Ok(permit) => {
-                    crate::observability::maintenance_stats().compaction_permits_acquired.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                    Some(permit)
+            Operation::HotPacking | Operation::SealedConsolidation => {
+                // Sampled on BOTH arms, because a refusal count cannot say
+                // whether the permits are held or simply absent. Prod
+                // 2026-09-12 read 12 acquisitions against 6,948 refusals with
+                // `maintenance_unit_lifetime_capped` at 0 — so no hygiene unit
+                // was holding them and no long unit was being capped, which
+                // leaves "held by something else" and "there are none" as the
+                // only candidates. Those need opposite fixes and nothing in the
+                // process could tell them apart.
+                let stats = crate::observability::maintenance_stats();
+                stats.light_rewrite_permits_available.store(self.light_rewrite_sem.available_permits() as u64, std::sync::atomic::Ordering::Relaxed);
+                match Arc::clone(&self.light_rewrite_sem).try_acquire_owned() {
+                    Ok(permit) => {
+                        stats.compaction_permits_acquired.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        Some(permit)
+                    }
+                    Err(_) => {
+                        stats.compaction_permits_unavailable.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        return Ok(false);
+                    }
                 }
-                Err(_) => {
-                    crate::observability::maintenance_stats().compaction_permits_unavailable.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                    return Ok(false);
-                }
-            },
+            }
             _ => None,
         };
         let Some((task, _quarantine_slot)) = self.claim_coordinator_task(selection) else { return Ok(false) };

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -3712,6 +3712,10 @@ impl Database {
         // Captured before `cfg` is moved into the struct literal below.
         let maint_rewrite_permits = cfg.derived.rewrite_permits().max(1);
         let light_rewrite_permits = cfg.derived.max_light_optimize_k().max(1);
+        // Exported, not re-derived. The value comes from a five-function
+        // arithmetic chain and has silently collapsed to 1 before (prod
+        // 2026-09-01), taking the whole hygiene lane with it.
+        crate::observability::maintenance_stats().light_rewrite_permits_total.store(light_rewrite_permits as u64, std::sync::atomic::Ordering::Relaxed);
         let dml_merge_permits = cfg.maintenance.timefusion_dml_merge_concurrency.max(1);
         // In UNITS, not polls: one reader slot is `DECODE_UNITS_PER_READER`
         // units and a worst-case batch claims all of them, so the heap ceiling

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -1195,6 +1195,23 @@ atomic_stats! {
         /// permits. Nonzero is the cap doing its job; it should be small, and if
         /// it tracks the claim rate the units are being bisected too slowly.
         maintenance_unit_lifetime_capped,
+        /// `light_rewrite_sem` permits free, sampled whenever a hygiene turn asks
+        /// for one, and the TOTAL the semaphore was built with.
+        ///
+        /// `compaction_permits_unavailable` counts refusals and
+        /// `compaction_permits_acquired` counts successes, but neither can say
+        /// whether the permits are HELD or simply do not exist — and those need
+        /// opposite fixes. Prod 2026-09-12: 12 acquisitions against 6,948
+        /// refusals with zero units capped, which is consistent with both.
+        ///
+        /// `light_rewrite_permits_total` is derived at boot from
+        /// `coordinator_share / COORDINATOR_PER_SORT_BUDGET - repair_holdback`,
+        /// floored at 1 — an arithmetic chain across five functions that has
+        /// silently collapsed to 1 before (prod 2026-09-01, HotPacking stopped
+        /// being claimed at all). Exporting it means never deriving it by hand
+        /// again.
+        light_rewrite_permits_available,
+        light_rewrite_permits_total,
         /// Dashboard aggregates served from a rollup, split by how much of the
         /// window the rollup owned. The OTel counters carry the same numbers but
         /// cannot be read back in-process, and these two are the only signal that


### PR DESCRIPTION
Instrumentation only.

#268 added `compaction_permits_acquired` and it immediately showed the lifetime cap was **not** the answer. 26 minutes on the new build:

| | |
|---|---:|
| `compaction_permits_acquired` | **12** |
| `compaction_permits_unavailable` | **6,948** |
| `maintenance_unit_lifetime_capped` | **0** |
| `work.SealedConsolidation.worker_secs` | **0** |

So no hygiene unit was holding a permit, and no long-running unit was being capped. That leaves two candidates — **held by something else** or **there are none** — which need opposite fixes, and nothing in the process can tell them apart.

Two gauges do:

- **`light_rewrite_permits_available`**, sampled on both arms of the `try_acquire`.
- **`light_rewrite_permits_total`**, stored once at boot.

The total earns its place independently: it is derived through five functions (`coordinator_share / COORDINATOR_PER_SORT_BUDGET` minus the repair holdback, floored against `cores/4`, then at 1) and **that chain has silently collapsed to 1 before** — prod 2026-09-01, when HotPacking stopped being claimed at all. Deriving it by hand from config is how this afternoon was spent.

`cargo lint` clean, lib suite 1295/1295.

🤖 Generated with [Claude Code](https://claude.com/claude-code)