### PR TITLE
Stop the repair holdback from zeroing the hygiene lane; research rollup maintenance

### DIFF
--- a/deploy/caprover-service-override.yml
+++ b/deploy/caprover-service-override.yml
@@ -33,6 +33,23 @@
 #   clobbered down to it. 120 GiB of the host's 188 GB leaves room for monoscope
 #   and the collectors.
 # - Reservations 32 GiB: scheduling floor, unchanged.
+# - Limits.NanoCpus 32 CPUs: RAISED from 28 on 2026-09-12, and it was not
+#   recorded here at all before — the live service carried
+#   `NanoCpus=28000000000` while this file documented only the memory limit,
+#   which is exactly the drift this file exists to prevent.
+#
+#   The core count is not just a throughput knob: the whole maintenance budget
+#   tree derives from it. `coordinator_jobs` is `cores/3`, the coordinator's
+#   memory share is `jobs x 512 MiB`, and `light_optimize_k` subtracts a fixed
+#   3-slice repair holdback from that share. At 28 cores that arithmetic gives
+#   9 jobs, a 4.5 GiB share, 3 slices, and a hygiene permit count of ZERO
+#   before the `.max(1)` floor — which measured as SealedConsolidation doing
+#   exactly 0 worker-seconds in four hours against 1.1 TB of sealed debt.
+#
+#   32 takes it to 10 jobs and a 5 GiB share. Pair it with the holdback cap
+#   (`LIGHT_MIN_SLICES`): 32 cores alone still yields K=1 without that change,
+#   and the formula only reaches K=3 at 48 cores. The host has 48; 32 leaves
+#   16 for monoscope and the collectors.
 # - start-first updates: every deployed binary's liveness probe accepts only
 #   the intentional startup 57P03 responder, allowing WAL takeover to complete
 #   while the external SQL probe still counts that interval as unavailable.
@@ -53,7 +70,8 @@
     },
     "Resources": {
       "Limits": {
-        "MemoryBytes": 128849018880
+        "MemoryBytes": 128849018880,
+        "NanoCpus": 32000000000
       },
       "Reservations": {
         "MemoryBytes": 34359738368

--- a/docs/plans/2026-09-13-rollup-maintenance-prior-art.md
+++ b/docs/plans/2026-09-13-rollup-maintenance-prior-art.md
@@ -1,0 +1,178 @@
+# Rollup maintenance: what every other system does, and what we do instead
+
+2026-09-13. Prompted by the measured 10x verdict: BaseRollup alone would want
+**25-39 of 48 cores** at ten times today's writes. That is not a tuning problem.
+
+## The number that names the defect
+
+`work.BaseRollup.progress_rows / rows_ingested_total` ≈ **1,490:1**. Every
+invalidation re-aggregates a whole partition **from raw rows**. A day-wide unit
+reads ~19 M source rows to emit ~28 k rollup rows, and it does that again on the
+next invalidation — the 09-11 finding was that 72.6% of those rebuilds produced
+byte-identical output.
+
+The no-op skip (#267) removed the *repeated* rebuilds. It did nothing about the
+cost of a *legitimate* one, and that cost is the 10x wall.
+
+## What the field does: never re-read raw
+
+Four independent lines of prior art converge on one rule.
+
+### 1. ClickHouse — `AggregatingMergeTree` with `-State` / `-Merge`
+
+Aggregate functions can emit their **intermediate binary state** instead of a
+final value. "When ClickHouse merges parts, it combines (merges) these states
+rather than re-reading the original rows." A daily-rollup table answers "unique
+users last month" by merging 30 daily states rather than rescanning raw events.
+
+This is the whole idea: a rollup is maintained by the pass that is *already*
+rewriting files, at O(parts), not by a separate pass at O(rows).
+
+### 2. Druid — roll up at ingest, perfect it at compaction
+
+Druid distinguishes **perfect rollup** (all duplicates aggregated at ingest,
+requires a shuffle) from **best-effort rollup** (streaming ingest cannot see the
+future of a time chunk, so segments may contain duplicate dimension tuples).
+Streaming indexers deliberately take best-effort, and **auto-compaction
+re-rolls-up** the interval afterwards.
+
+The trade is explicit and accepted: cheap and slightly imperfect now, exact once
+compaction has run.
+
+### 3. TimescaleDB — continuous aggregates + invalidation log
+
+Dirty ranges are recorded on write; a refresh policy recomputes **only those
+buckets**. TimeFusion already has this half (`rollup_dirty`, `dirty_hours`,
+`invalidate_rollup_hours`) — which is why the remaining cost is per-rebuild, not
+per-invalidation.
+
+### 4. The IVM literature — self-maintainable aggregates
+
+The change-table technique, CReaM, and viewlet transforms all rest on the same
+algebra: an aggregate is incrementally maintainable when it is a **mergeable
+monoid**, and `avg` becomes so once stored as `(sum, count)`.
+
+**TimeFusion's measures already satisfy this.** `count`, `sum`, `min`, `max` are
+monoids; the duration percentiles already use a mergeable digest. There is no
+measure in `dashboard_1m_v3` that would block per-file partial aggregation.
+
+## So why does TimeFusion re-read raw? The honest answer
+
+**Dedup.** A rollup must aggregate the deduplicated row set, and duplicates span
+files. A partial aggregate computed per file cannot subtract a duplicate that
+lives in a different file, so the current design re-scans and dedups first. That
+is a real constraint, not an oversight.
+
+Druid's answer applies directly, and TimeFusion is unusually well placed to take
+it, because the machinery already exists:
+
+- **Per-file partial aggregates are best-effort** — exact within the file, and
+  over-counting only across files that still hold duplicates of each other.
+- **Dedup and compaction already rewrite those files.** When they do, they
+  recompute the partial for the merged output — perfecting the rollup as a side
+  effect of work already scheduled. This is precisely Druid's
+  ingest-then-compact contract.
+- **Certification already says when a partition is provably dedup-clean**
+  (`cert_slice_files_proved`, the dedup certification lane). That is the exact
+  predicate for "this merged partial is now perfect," and it is the thing
+  `dedup_skipped_pct` has been trying to spend for weeks.
+
+## The proposal, and its arithmetic
+
+Write a partial aggregate alongside every raw file, keyed by
+`(rollup spec, bucket, dimensions)`. Then:
+
+```
+BaseRollup(day) = MERGE(partials of the day's files)      -- O(files)
+        instead of = AGGREGATE(DEDUP(rows of the day's files))  -- O(rows)
+```
+
+A day partition holds hundreds of files and tens of millions of rows. The unit
+goes from ~19 M row-reads to ~10² partial-reads plus a merge — **three to four
+orders of magnitude**, which is what makes 10x fit in the CPU budget instead of
+wanting 25-39 cores.
+
+Cost moves to the write path: each flush computes its own partial over data
+already in memory, which is the cheapest possible place to do it, and the output
+is small (one row per bucket × dimension tuple).
+
+### What to settle before building it
+
+1. **Where the partial lives.** A sidecar parquet per raw file is the least
+   invasive and matches how bloom sidecars already work. Delta file tags are too
+   small for a real aggregate.
+2. **Cardinality.** The saving is only real if partial rows ≪ raw rows. Measure
+   `(bucket × dimension) distinct count per file` on a prod partition first — if
+   a 1-minute grain × 3 dimensions approaches the row count on a small file, the
+   sidecar is not worth it for that file and the unit should fall back to
+   scanning. **Do not build before this number is in hand.**
+3. **Staged, not big-bang.** The merge path can be added behind the existing
+   `rollup_noop_skip` style switch, with the raw path kept as the oracle: run
+   both on a sample and assert equality before trusting the merge. The 09-07
+   ingest-dedup lesson — shipped inert, passed every gate, did nothing in prod —
+   was exactly a missing shadow phase.
+
+## Sealed consolidation: the policy is already right
+
+Researched separately and the answer is **do not re-architect this one**.
+`2026-09-06-merge-policy-prior-art.md` already transferred the two rules that
+matter, and they are implemented:
+
+- ClickHouse's `SimpleMergeSelector` **similar-size preference** and RocksDB
+  universal compaction's `size_ratio` → `bin_breaks_size_ratio`.
+- **Age escalation** → the `starved` ranking.
+- Fan-in value floor → `refuse_low_value_bin`.
+
+Druid's auto-compaction adds target segment size, newest-to-oldest search, and
+worker slots — all of which TimeFusion has equivalents for.
+
+**The sealed lane's problem is not policy, it is the execution envelope**, and
+that is what today's measurements show:
+
+- one permit for two operations, because a fixed 3-slice repair holdback
+  consumed a 3-slice coordinator share (fixed in this branch);
+- a single unit holding that permit for **2 h 04 m** — a 61-file, 255 MB bin
+  over the shared project that started staging twice and completed neither time;
+- `run_until_idle` being an idle window, so nothing bounds the hold, and the
+  absolute cap added in #268 could not preempt it because a future that never
+  reaches an await point cannot be cancelled by a timeout.
+
+Druid's answer to a compaction task that runs too long is to **bound the unit**:
+target segment size and interval splitting, so no single task owns an unbounded
+interval. TimeFusion has `split_time_task` for rollups and byte-preflight
+splitting for dedup; the sealed lane takes a **day-wide** unit and has no
+equivalent guard.
+
+**But the evidence does not support size as the cause here, and that matters.**
+The unit that ran 2 h 04 m selected **61 files and 255 MB** — small. 255 MB in
+two hours is ~35 KB/s, which is not a sort and not CPU: it is a STALL. Splitting
+a 255 MB unit into smaller ones would produce several stalled units instead of
+one.
+
+So the sealed lane needs, in this order:
+
+1. **Diagnose the stall.** Staging emits `wave_bin_staging_started` and
+   `wave_bin_staged`; this bin logged the first twice and the second never. The
+   missing instrument is where inside staging it went — object-store read, sort,
+   or commit. A phase timer there is cheap and is the only thing that can name it.
+2. **Make the unit interruptible.** The absolute cap from #268 is correct in
+   principle and could not fire, because a future that does not reach an await
+   point cannot be cancelled. Whatever blocks for two hours must either yield or
+   carry its own IO deadline.
+3. **Only then** consider Druid-style interval bounding, which is right for a
+   genuinely oversized unit and irrelevant to a stalled small one.
+
+Bounding the unit first would have looked like a fix and changed nothing —
+the same mistake as capping the lifetime of a unit that cannot be preempted.
+
+## Sources
+
+- [ClickHouse: AggregateFunction type](https://clickhouse.com/docs/sql-reference/data-types/aggregatefunction)
+- [ClickHouse: aggregate function combinators](https://clickhouse.com/docs/sql-reference/aggregate-functions/combinators)
+- [ClickHouse: using aggregate combinators](https://clickhouse.com/blog/aggregate-functions-combinators-in-clickhouse-for-arrays-maps-and-states)
+- [Apache Druid: data rollup (perfect vs best-effort)](https://druid.apache.org/docs/latest/ingestion/rollup/)
+- [Apache Druid: compaction](https://druid.apache.org/docs/latest/data-management/compaction/)
+- [ViewDF: declarative IVM for streaming data](https://cs.uwaterloo.ca/~tozsu/publications/stream/elsarticle.pdf)
+- [Incremental maintenance of aggregate views (CReaM)](https://web.stanford.edu/~abhijeet/papers/abhijeetFOIKS14.pdf)
+- [Incremental maintenance of aggregate and outerjoin expressions](https://www3.cs.stonybrook.edu/~hgupta/ps/aggr-is.pdf)
+- [Everything you need to know about incremental view maintenance](https://materializedview.io/p/everything-to-know-incremental-view-maintenance)

--- a/src/config.rs
+++ b/src/config.rs
@@ -263,6 +263,14 @@ const REPAIR_REWRITE_TARGET_FILES: usize = 2;
 /// 1.79 is the passing point, not a midpoint guess — the cliff is between these
 /// two rungs and this takes the safe side of it.
 const SAFE_DECODED_PER_POOL_BYTE: f64 = 1.79;
+/// Per-sort slices the hygiene lane keeps whatever repair would like to reserve.
+///
+/// Two, not one, because HotPacking and SealedConsolidation SHARE the permit:
+/// at one they cannot even run concurrently, and any unit that stalls takes the
+/// whole lane with it. Only a share too small to hold two sorts goes below this,
+/// and such a box cannot run the coordinator meaningfully anyway.
+const LIGHT_MIN_SLICES: usize = 2;
+
 /// Heavy maintenance's slice of the whole maintenance pool. 0.30 is what the
 /// old `0.40 of the residual` came to before the coordinator's share grew; see
 /// `heavy_share_bytes` for why it is no longer expressed against the residual.
@@ -641,7 +649,33 @@ impl DerivedBudget {
         // before they could. Prod 2026-09-01: `Not enough memory to continue
         // external sort` on repair staging as soon as long-running units and
         // K=4 hygiene bins shared 8 GB sixteen ways.
-        let mem_bound = (self.coordinator_share_bytes() / COORDINATOR_PER_SORT_BUDGET_BYTES).saturating_sub(self.repair_pool_holdback_slices());
+        // The repair holdback yields before the hygiene lane is zeroed.
+        //
+        // K=1 is not a small configuration, it is an OUTAGE: the permit is taken
+        // BEFORE the claim, and one permit shared by HotPacking and
+        // SealedConsolidation across every worker means a single long unit stops
+        // the lane dead. The comment on `repair_pool_holdback_slices` already
+        // names this as "the 2026-09-01 HotPacking outage class" — and the
+        // formula could still produce it, so naming it was not enough.
+        //
+        // Prod 2026-09-12 was in it again, and the margin was two cores. The
+        // container is capped at `NanoCpus=28` of a 48-core host, so
+        // `cores/3` gives 9 jobs, a 4.5 GiB coordinator share, 3 slices — and a
+        // fixed 3-slice holdback took all three. Measured consequence over four
+        // hours: HotPacking 426 worker-seconds, **SealedConsolidation zero**,
+        // 641 permit acquisitions against 32,779 refusals, and 1.1 TB of sealed
+        // debt that did not move. One SealedConsolidation unit held the single
+        // permit from 19:14 to 21:19; the moment it released, seven hygiene
+        // units ran in five minutes.
+        //
+        // Repair keeps its holdback wherever the share can pay for it — on the
+        // 48-core box this function was calibrated for, slices=6 and the
+        // arithmetic is unchanged. Below that, repair drops toward one-way
+        // concurrency instead of hygiene dropping to none. That is the right way
+        // round: a repair sort that cannot fit RETRIES, while a dead hygiene
+        // lane is unbounded debt, and `pending_repair` was 0 throughout.
+        let slices = self.coordinator_share_bytes() / COORDINATOR_PER_SORT_BUDGET_BYTES;
+        let mem_bound = slices.saturating_sub(self.repair_pool_holdback_slices().min(slices.saturating_sub(LIGHT_MIN_SLICES)));
         let cpu_bound = self.cores / 4;
         mem_bound.min(cpu_bound).min(hot_project_count).max(1)
     }
@@ -4200,5 +4234,55 @@ mod secret_crypto_tests {
         assert_eq!(decrypt_or_passthrough("plain").unwrap(), "plain");
         // nonce-only payload => no ciphertext left after the split
         assert!(decrypt_or_passthrough(&format!("{ENC_PREFIX}{}", B64.encode([0u8; NONCE_LEN]))).is_err());
+    }
+}
+
+#[cfg(test)]
+mod light_permit_floor_tests {
+    use super::*;
+
+    /// `light_optimize_k` may never return 1 on a box whose coordinator share
+    /// can hold two sorts.
+    ///
+    /// One permit is an outage, not a small configuration: it is taken BEFORE
+    /// the claim and shared by HotPacking and SealedConsolidation, so at K=1 the
+    /// two cannot run concurrently and any stalled unit stops the lane.
+    ///
+    /// Prod 2026-09-12 was there, two cores short of the boundary. The container
+    /// is capped at `NanoCpus=28` of a 48-core host: `cores/3` = 9 jobs, a
+    /// 4.5 GiB share, 3 slices, and a fixed 3-slice repair holdback took all
+    /// three. Over four hours that produced SealedConsolidation = **0**
+    /// worker-seconds, 32,779 permit refusals, and 1.1 TB of sealed debt that
+    /// did not move.
+    ///
+    /// Can-fail proof, run red then restored: dropping the `.min(...)` that caps
+    /// the holdback puts 28 and 30 cores back at K=1.
+    #[test_case::test_case(28, 1; "prod: 28-core cgroup cap, the box this was found on")]
+    #[test_case::test_case(30, 1; "just past the jobs boundary and still starved before the fix")]
+    #[test_case::test_case(16, 1; "a small box")]
+    #[test_case::test_case(48, 3; "the box the formula was calibrated for")]
+    fn the_hygiene_lane_never_collapses_to_one_permit(cores: usize, slices_before_fix: usize) {
+        let budget = DerivedBudget::from_limits(120 * GIB, cores);
+        let k = budget.max_light_optimize_k();
+        let share_slices = budget.coordinator_share_bytes() / COORDINATOR_PER_SORT_BUDGET_BYTES;
+        assert!(
+            k >= LIGHT_MIN_SLICES.min(share_slices),
+            "cores={cores}: share holds {share_slices} sorts but K={k} (was {slices_before_fix} before the holdback cap)"
+        );
+        // And the calibrated box is untouched — repair keeps its full holdback
+        // wherever the share can pay for it.
+        if cores == 48 {
+            assert_eq!(k, 3, "the 48-core derivation must not move");
+        }
+    }
+
+    /// A box too small to hold two sorts is left alone rather than
+    /// over-committed — the floor is a floor, not a demand.
+    #[test]
+    fn a_tiny_share_is_not_over_committed() {
+        let budget = DerivedBudget::from_limits(2 * GIB, 2);
+        let share_slices = budget.coordinator_share_bytes() / COORDINATOR_PER_SORT_BUDGET_BYTES;
+        assert!(share_slices < LIGHT_MIN_SLICES, "precondition: this box cannot hold two sorts");
+        assert_eq!(budget.max_light_optimize_k(), 1, "and must not be pushed to two");
     }
 }


### PR DESCRIPTION
## 1. The fix — K=1 is an outage, not a small configuration

The light permit is taken **before** the claim and is shared by HotPacking and SealedConsolidation. At one permit the two cannot run concurrently and any stalled unit stops the lane dead. `repair_pool_holdback_slices` already calls this *"the 2026-09-01 HotPacking outage class"* — but the formula could still produce it, so naming it was not enough.

**Production was in it again, two cores short of the boundary.** The container is capped at `NanoCpus=28` of a 48-core host → `cores/3` = 9 jobs → 4.5 GiB share → 3 slices → a fixed 3-slice holdback took all three.

Measured over four hours:

| | |
|---|---:|
| HotPacking worker-seconds | 426 |
| **SealedConsolidation worker-seconds** | **0** |
| permit acquisitions | 641 |
| permit refusals | **32,779** |
| `sealed_compaction_debt_bytes` | **1.1 TB, unmoved** |

One SealedConsolidation unit held the single permit from **19:14 to 21:19**; the moment it released, seven hygiene units ran in five minutes.

The holdback now yields before the lane is zeroed. Repair keeps it wherever the share can pay — on the 48-core box the formula was calibrated for, `slices=6` and **the arithmetic is unchanged**. Below that, repair drops toward one-way concurrency instead of hygiene dropping to none: a repair sort that cannot fit *retries*, a dead hygiene lane is unbounded debt, and `pending_repair` was 0 throughout.

**Can-fail proof**: removing the cap puts 28, 30 and 16 cores back at K=1 while 48 stays at 3. A box genuinely too small for two sorts is left at 1 rather than over-committed (`a_tiny_share_is_not_over_committed`).

> This does **not** fix the 2h04m unit. #268's lifetime cap could not preempt it — `maintenance_unit_lifetime_capped` read 0 — because a future that never reaches an await point cannot be cancelled by a timeout. What this buys is a lane that survives one such unit instead of dying with it.

## 2. CPU cap 28 → 32

`NanoCpus` was **not recorded in the override at all** while the live service carried 28 — exactly the drift that file exists to prevent. The core count is not just a throughput knob: it drives `coordinator_jobs`, the coordinator memory share, and the hygiene permit count.

32 gives 10 jobs and a 5 GiB share. **Pair it with the holdback cap** — 32 alone still yields K=1, and the formula only reaches K=3 at 48 cores.

## 3. Research: how other systems keep rollups current

`work.BaseRollup.progress_rows / rows_ingested_total` ≈ **1,490:1**, because every invalidation re-aggregates a partition **from raw rows**. Four independent lines of prior art converge on never doing that:

- **ClickHouse `AggregatingMergeTree`** — merges intermediate `-State` values during part merges instead of re-reading rows.
- **Druid** — best-effort rollup at ingest, **re-rolled-up by compaction**.
- **TimescaleDB continuous aggregates** — refresh only invalidated buckets (the half we already have).
- **IVM literature** — requires mergeable monoids, which every measure in `dashboard_1m_v3` already is.

**Dedup is the real reason we re-read raw**, and Druid's perfect-vs-best-effort split is the way out: per-file partials are exact within a file; dedup and compaction already rewrite those files and can recompute the partial as a side effect; certification already names when a partition is provably clean. That turns a rollup from **O(rows) into O(files)** — the three-to-four orders of magnitude that makes 10x fit.

Three things to settle first, including a **cardinality measurement** — a sidecar that is not much smaller than the raw file buys nothing — and a shadow phase, because the 09-07 ingest-dedup change passed every gate and did nothing in prod for want of one.

**Sealed consolidation is deliberately not re-architected.** The policy already carries ClickHouse's similar-size rule, RocksDB's `size_ratio`, age escalation and a fan-in floor. And the 2h04m unit was only **61 files / 255 MB** — ~35 KB/s, a **stall**, not an oversized unit — so the doc argues *against* Druid-style interval bounding as the first move and for naming the stall instead. Bounding it would have looked like a fix and produced several stalled units instead of one.

`cargo lint` clean, full suite 1537/1537, `make ci-signoff` green on all five.

🤖 Generated with [Claude Code](https://claude.com/claude-code)