### PR TITLE
Cap a packing bin at what one sort can decode

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -225,6 +225,29 @@ const PER_SORT_BUDGET_BYTES: usize = 2 * GIB;
 /// At 1.25 GiB `light_optimize_k` yields 5, plus the one repair permit = **6**
 /// — the measured optimum, and one rung below the measured cliff.
 const COORDINATOR_PER_SORT_BUDGET_BYTES: usize = 5 * GIB / 4;
+
+/// The largest COMPRESSED bin one coordinator sort can decode inside its budget.
+///
+/// A packing target is expressed in compressed bytes and a sort budget in
+/// decoded ones, so the two only agree if something divides by the decode ratio
+/// — and nothing did. `COORDINATOR_SEALED_TARGET_BYTES` is 256 MiB, which at
+/// `DECODED_BYTES_PER_COMPRESSED` = 12 is **3 GiB decoded against a 1.25 GiB
+/// budget — 2.4x**, and 2.39x is the rung `repair_pool_holdback_slices` already
+/// records as having FAILED on the bench.
+///
+/// Prod 2026-09-13 was living it. Every sealed bin at ~255-259 MB compressed
+/// (2.39x and 2.43x) started staging and never finished — one held a permit for
+/// 2 h 04 m at an effective 35 KB/s — while every bin at or under 16 MB
+/// (<=0.15x) completed normally. With only two light permits, two such bins are
+/// the whole lane.
+///
+/// This is the byte-budget shape the rollup lane already guards with
+/// `MAX_DECODED_BYTES` and the dedup lane with its own preflight; the packer was
+/// the one that bounded compressed input against a decoded budget and never
+/// converted between them.
+pub fn coordinator_bin_compressed_cap_bytes() -> i64 {
+    (COORDINATOR_PER_SORT_BUDGET_BYTES / crate::database::DECODED_BYTES_PER_COMPRESSED as usize) as i64
+}
 /// Concurrent target-sized repair rewrites the repair budget must hold.
 ///
 /// A repair unit is exactly ONE file (`coordinator_compaction_files` takes 1
@@ -4284,5 +4307,42 @@ mod light_permit_floor_tests {
         let share_slices = budget.coordinator_share_bytes() / COORDINATOR_PER_SORT_BUDGET_BYTES;
         assert!(share_slices < LIGHT_MIN_SLICES, "precondition: this box cannot hold two sorts");
         assert_eq!(budget.max_light_optimize_k(), 1, "and must not be pushed to two");
+    }
+}
+
+#[cfg(test)]
+mod bin_decode_budget_tests {
+    use super::*;
+
+    /// A packing bin must fit ONE SORT once decoded.
+    ///
+    /// Targets are compressed bytes, sort budgets are decoded bytes, and nothing
+    /// converted between them. `COORDINATOR_SEALED_TARGET_BYTES` is 256 MiB,
+    /// which at `DECODED_BYTES_PER_COMPRESSED` = 12 is 3 GiB against a 1.25 GiB
+    /// budget — **2.4x**, and `repair_pool_holdback_slices` already records
+    /// 2.39x as the rung that FAILED on the bench.
+    ///
+    /// Prod 2026-09-13 lived it: every sealed bin at ~255-259 MB compressed
+    /// (2.39x, 2.43x) started staging and never finished — one held a light
+    /// permit for 2 h 04 m at an effective 35 KB/s — while every bin at or under
+    /// 16 MB (<=0.15x) completed. With two permits, two such bins are the lane.
+    ///
+    /// Can-fail proof, run red then restored: dropping the `.min(...)` at the
+    /// call site leaves the effective cap at 256 MiB and this goes red at 2.40x.
+    #[test]
+    fn a_bin_capped_for_packing_still_fits_one_sort_decoded() {
+        let cap = coordinator_bin_compressed_cap_bytes();
+        let decoded = cap as usize * crate::database::DECODED_BYTES_PER_COMPRESSED as usize;
+        assert!(
+            decoded <= COORDINATOR_PER_SORT_BUDGET_BYTES,
+            "a full bin decodes to {decoded} bytes against a {COORDINATOR_PER_SORT_BUDGET_BYTES}-byte sort budget"
+        );
+        // And the cap is what actually binds, i.e. it is below the output target
+        // we would otherwise pack to — otherwise this guard is decorative.
+        assert!(cap < crate::database::COORDINATOR_HOT_TARGET_BYTES, "the decode cap ({cap}) must bind below the packing target, or it changes nothing");
+        // The prod shapes, stated so the boundary is not re-derived by hand.
+        let ratio = |mb: i64| (mb * 1024 * 1024 * crate::database::DECODED_BYTES_PER_COMPRESSED) as f64 / COORDINATOR_PER_SORT_BUDGET_BYTES as f64;
+        assert!(ratio(255) > 2.0, "the stalled prod bins were well past one sort budget");
+        assert!(ratio(cap / (1024 * 1024)) <= 1.0, "a bin at the new cap is not");
     }
 }

--- a/src/database/maintain.rs
+++ b/src/database/maintain.rs
@@ -3850,11 +3850,17 @@ impl Database {
         if key.operation == Operation::Repair {
             return Ok(candidates.into_iter().filter(|add| !self.repair_verified_sorted.contains(&add.path)).take(1).map(|add| add.path).collect());
         }
+        // Bounded by what ONE SORT CAN DECODE, not only by the output size we
+        // would like. See `coordinator_bin_compressed_cap_bytes`: a 256 MiB
+        // compressed target decodes to ~3 GiB against a 1.25 GiB per-sort
+        // budget, and prod 2026-09-13 had every bin at that size stall
+        // indefinitely while every small one completed.
         let target = match key.operation {
             Operation::HotPacking => COORDINATOR_HOT_TARGET_BYTES,
             Operation::SealedConsolidation => COORDINATOR_SEALED_TARGET_BYTES,
             _ => return Ok(Vec::new()),
-        };
+        }
+        .min(crate::config::coordinator_bin_compressed_cap_bytes());
         let unsorted_candidates = candidates.iter().filter(|add| !add.is_sorted_run).count();
         let under_target_candidates = candidates.iter().filter(|add| add.size < target).count();
         // The PACKER's own two smallest under-target files. `plan_compaction_debt`


### PR DESCRIPTION
## The inconsistency

Packing targets are **compressed** bytes; sort budgets are **decoded** bytes. Nothing converted between them.

`COORDINATOR_SEALED_TARGET_BYTES` is 256 MiB, which at `DECODED_BYTES_PER_COMPRESSED = 12` is **3 GiB against a 1.25 GiB per-sort budget — 2.4×**. `repair_pool_holdback_slices` already records **2.39× as the rung that FAILED on the bench**.

## Production was living in it, and the split is clean

| bin | decoded | ratio | outcome |
|---|---|---|---|
| 255 MB / 61 files | 2.99 GiB | **2.39×** | **stalled** |
| 259 MB / 51 files | 3.04 GiB | **2.43×** | **stalled** |
| 16 MB / 12 files | 0.19 GiB | 0.15× | completed |
| 4 MB / 52 files | 0.05 GiB | 0.04× | completed |

Every bin packed to the target stalled; every bin comfortably inside one sort budget finished. One stalled bin held a light rewrite permit for **2 h 04 m at an effective 35 KB/s** — and with two permits, two such bins are the entire lane. That is why `SealedConsolidation` recorded **0 worker-seconds over four hours** against 1.1 TB of debt.

> I called 255 MB "small" earlier and argued *against* bounding the unit on that basis. That compared **compressed** input against a **decoded** budget — wrong by the decode ratio. This PR is the correction.

## The fix

The cap is the byte-budget guard the other lanes already have — the rollup lane via `MAX_DECODED_BYTES` + `split_time_task`, dedup via its own preflight. The packer was the one bounding compressed input against a decoded budget without converting.

Output files become ~107 MiB rather than 256 MiB: some consolidation ratio traded for units that finish.

## Verification

`a_bin_capped_for_packing_still_fits_one_sort_decoded` pins **both** halves — a full bin fits one sort once decoded, **and** the cap actually binds below the packing target, or the guard would be decorative. Run red then restored: with the cap left at 256 MiB it reports 3,221,225,472 bytes decoded against a 1,342,177,280-byte budget.

## Sign-off status — please let CI gate this one

`fmt` and `clippy` are attested locally. **`test`, `pg-smoke` and `e2e` are not**, and I have not published attestations for them, because this machine's clock is unstable: the host jumped **16 minutes during a 20-second sleep**, which makes MinIO reject every request with `RequestTimeTooSkewed` → 403.

The best local run before the drift set in was **1537/1538**, with the single failure being that S3 signature artifact rather than an assertion. Every earlier `1537/1538`-style result I reported today was most likely the same cause, not the suite parallelism I attributed it to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)