### PR TITLE
Pull MinIO from quay.io, not Docker Hub

### DIFF
--- a/tests/e2e/harness.rs
+++ b/tests/e2e/harness.rs
@@ -22,10 +22,23 @@ use uuid::Uuid;
 /// MinIO release with atomic conditional PUT support. The testcontainers
 /// module's older default can overwrite racing Delta commits. Modern MinIO
 /// prints its readiness banner on stderr, hence the custom image below.
+/// MinIO's images come from quay.io, NOT Docker Hub.
+///
+/// `minio/minio:RELEASE.2025-09-07T16-13-09Z` 404s — MinIO stopped publishing
+/// that tag to Docker Hub, and testcontainers reports it as
+/// `pull access denied ... repository does not exist or may require docker login`,
+/// which reads like a credentials problem and is not one.
+///
+/// This was invisible for as long as it has been broken, because the harness
+/// resolves MinIO local-first: any developer with a `minio` binary on PATH never
+/// reaches the Docker fallback, and a locally-attested `e2e` makes CI SKIP the
+/// job. CI only ran it — and failed — once an attestation was absent.
+/// `ci/compose.yml` already pulls from quay.io; these two call sites did not.
+pub const MINIO_IMAGE: &str = "quay.io/minio/minio";
 pub const MINIO_TAG: &str = "RELEASE.2025-09-07T16-13-09Z";
 
 pub fn pinned_minio_image() -> GenericImage {
-    GenericImage::new("minio/minio", MINIO_TAG).with_wait_for(WaitFor::message_on_stderr("API:"))
+    GenericImage::new(MINIO_IMAGE, MINIO_TAG).with_wait_for(WaitFor::message_on_stderr("API:"))
 }
 
 pub const FROZEN_START_MICROS: i64 = 1_900_000_000_000_000; // ~2030-03-15

--- a/tests/suite/sqllogictest.rs
+++ b/tests/suite/sqllogictest.rs
@@ -318,7 +318,9 @@ mod sqllogictest_tests {
             // PUT, which makes Delta commit versions non-atomic (see MINIO_TAG).
             // GenericImage because the MinIO module waits for "API:" on stdout,
             // and modern images banner on stderr (see e2e::harness).
-            let minio = GenericImage::new("minio/minio", "RELEASE.2025-09-07T16-13-09Z")
+            // quay.io, NOT Docker Hub: the `minio/minio` tag 404s. Same reason
+            // and same registry as `tests/e2e/harness.rs::MINIO_IMAGE`.
+            let minio = GenericImage::new("quay.io/minio/minio", "RELEASE.2025-09-07T16-13-09Z")
                 .with_wait_for(WaitFor::message_on_stderr("API:"))
                 .with_cmd(["server", "/data"])
                 .with_env_var("MINIO_ROOT_USER", "minioadmin")


### PR DESCRIPTION
CI's **E2E job fails on every run**:

```
failed to pull the image 'minio/minio:RELEASE.2025-09-07T16-13-09Z' ...
pull access denied for minio/minio, repository does not exist or may require 'docker login': denied
```

MinIO no longer publishes that tag to Docker Hub. Verified directly:

| | |
|---|---|
| `docker pull minio/minio:RELEASE.2025-09-07T16-13-09Z` | **404** |
| `docker pull quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z` | **OK** |

`ci/compose.yml` has been pulling from quay.io all along — only these two testcontainers call sites were not. The error text is actively misleading: *"may require docker login"* reads as credentials and is a registry-moved problem.

## Why this stayed invisible

Two mechanisms composed to hide it. The harness resolves MinIO **local-first**, so anyone with a `minio` binary on PATH never reaches the Docker fallback — and a **locally-attested `e2e` makes CI skip the job**. Recent master runs read `skipped`, `skipped`, `skipped`, then `failure`: the failure is simply the first run where no local attestation existed to skip it.

**Local sign-off was masking a broken CI path**, which is worth knowing beyond this fix — it is the same shape as attesting a check that never exercised the code path CI uses.

CI is the right place to verify this one, since it is the environment with no local `minio` binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)