### PR TITLE
Unwedge production deploys, and attribute tantivy's ~10 cores

### DIFF
--- a/docs/plans/2026-09-13-rollup-maintenance-prior-art.md
+++ b/docs/plans/2026-09-13-rollup-maintenance-prior-art.md
@@ -3,6 +3,17 @@
 2026-09-13. Prompted by the measured 10x verdict: BaseRollup alone would want
 **25-39 of 48 cores** at ten times today's writes. That is not a tuning problem.
 
+> **CORRECTION (same day).** The cost premise below — the 25-39 cores, and the
+> 1,490:1 ratio it rests on — is **not sound**, and neither is the later 2,158:1
+> reading. `progress_rows` is a plan-tree liveness proxy, not a count of rows of
+> work, and `worker_secs` is wall time a worker *held*, including every wait —
+> both stated at `observability.rs:81`. Directly measured, the entire
+> `maintenance-wor` pool is **5.7-7.0 cores for all operations combined**.
+> See `2026-09-13-where-the-28-cores-actually-go.md`. The *direction* of this
+> document is unaffected; the arithmetic that motivates its urgency must be
+> re-derived, and the cardinality measurement it gates the design on is still
+> the right next step.
+
 ## The number that names the defect
 
 `work.BaseRollup.progress_rows / rows_ingested_total` ≈ **1,490:1**. Every

--- a/docs/plans/2026-09-13-the-backlog-drain-arithmetic.md
+++ b/docs/plans/2026-09-13-the-backlog-drain-arithmetic.md
@@ -3,24 +3,53 @@
 2026-09-13, after #271 reached production (permit acquisition went from
 **0.036% to 46%**; the lane had been wedged, not slow).
 
-## The lane works now. It still cannot finish today.
+## FIRST: the "1 TB backlog" is ~100 GB on disk
 
-`sealed_compaction_debt_bytes` = **1.17 TB**. #271 caps a packing bin at what
-one sort can decode: `COORDINATOR_PER_SORT_BUDGET_BYTES` (1.25 GiB) /
-`DECODED_BYTES_PER_COMPRESSED` (12) = **~107 MB compressed**.
+`sealed_compaction_debt_bytes` sums **`task.estimated_decoded_bytes`**
+(`maintenance_coordinator.rs:3433`) — DECODED bytes, not bytes stored. At this
+codebase's own `DECODED_BYTES_PER_COMPRESSED` = 12, the **1.19 TB reads as
+~99 GB of actual stored data** across 196 pending tasks, i.e. ~507 MB
+compressed each.
 
-```
-1.17 TB / 107 MB           ≈ 11,000 bins
-observed: a 65.7 MB bin staged in 67 s -> ~110 s at the 107 MB cap
-K = 2 permits
-  => 2 x (3600/110) ≈ 65 bins/hour
-  => 11,000 / 65    ≈ 170 hours ≈ 7 days
-```
+This is the same compressed-vs-decoded confusion #271 exists to fix, showing up
+one level higher — in the number everyone quotes as "the backlog". Any plan
+sized against 1.19 TB of *files* is wrong by ~12x. **I made exactly that error
+first**, estimating 11,000 bins and ~7 days before reading the accumulator.
 
-**Draining this backlog "today" is not physically available at K=2**, whatever
-else is fixed. The honest framing is: the lane has gone from *stalled forever*
-to *finishing in about a week*, and the remaining question is what compresses
-that week.
+Corrected: ~99 GB / ~107 MB per bin ≈ **950 bins**, which at the observed
+24-105 bins/hour is **hours, not days**.
+
+## The lane works now, but the debt is not falling at anything like that rate
+
+Observed over 100 minutes on the fixed build: `sealed_compaction_debt_bytes`
+moved **0.5 GB** and `pending_sealed_consolidation` held flat at **196** — while
+SealedConsolidation completed ~48 units/hour. Two mechanisms are visible and
+neither is the sort stall #271 fixed:
+
+- **Tasks retry rather than retire.** `retry.HotPacking.compaction_debt_remaining`
+  = 54 and `retry.SealedConsolidation.compaction_debt_remaining` = 7: a unit
+  does a few bins and re-queues, so the pending COUNT is not a work-remaining
+  gauge.
+- **The bins being staged are tiny.** Every staged bin measured 42-47 files at
+  ~1.4 MB each, ~63 MB total. That is correct hygiene (file-count reduction) but
+  moves almost no bytes.
+
+### A refusal that looks like a #271 side effect and is NOT
+
+`pack_value_refused` reads **433 in 2 hours against 6 in the previous 9**, which
+invites the story that capping bins pushed them under
+`refuse_low_value_bin`'s 3-file threshold. **The rate refutes it**: rows per
+refusal is **898,650,262 / 433 = 2.08 M**, against the old process's
+13,863,476 / 6 = **2.31 M**. Same bin shape, not a smaller one.
+
+The raw counts never compared — the lane was *dead* for the older window, so it
+was not attempting bins to refuse. **Refusals per attempt is the only comparable
+figure, and it is unchanged.** Worth keeping as the template: whenever a lane
+goes from stalled to running, every one of its counters jumps, and none of those
+jumps is evidence by itself.
+
+What remains true is that ~2 M-row, sub-3-file bins are being refused and their
+bytes cannot consolidate — but that is pre-existing, not caused by #271.
 
 ### Where the dose-response came from
 

--- a/docs/plans/2026-09-13-the-backlog-drain-arithmetic.md
+++ b/docs/plans/2026-09-13-the-backlog-drain-arithmetic.md
@@ -1,0 +1,101 @@
+# What it actually takes to drain the 1.17 TB sealed backlog
+
+2026-09-13, after #271 reached production (permit acquisition went from
+**0.036% to 46%**; the lane had been wedged, not slow).
+
+## The lane works now. It still cannot finish today.
+
+`sealed_compaction_debt_bytes` = **1.17 TB**. #271 caps a packing bin at what
+one sort can decode: `COORDINATOR_PER_SORT_BUDGET_BYTES` (1.25 GiB) /
+`DECODED_BYTES_PER_COMPRESSED` (12) = **~107 MB compressed**.
+
+```
+1.17 TB / 107 MB           ≈ 11,000 bins
+observed: a 65.7 MB bin staged in 67 s -> ~110 s at the 107 MB cap
+K = 2 permits
+  => 2 x (3600/110) ≈ 65 bins/hour
+  => 11,000 / 65    ≈ 170 hours ≈ 7 days
+```
+
+**Draining this backlog "today" is not physically available at K=2**, whatever
+else is fixed. The honest framing is: the lane has gone from *stalled forever*
+to *finishing in about a week*, and the remaining question is what compresses
+that week.
+
+### Where the dose-response came from
+
+Measured live in prod, every sealed/hot bin in a 3-hour window, against the
+1.25 GiB decoded sort budget:
+
+| bin | compressed | decoded (x12) | ratio | outcome |
+|---|---:|---:|---:|---|
+| 18 files | 65.7 MB | 0.73 GiB | 0.59x | staged in **67 s** |
+| 24 files | 153 MB | 1.71 GiB | 1.37x | staged in **29.2 min** |
+| 40 files | 249 MB | 2.78 GiB | 2.22x | **never staged** |
+| 45 files | 227 MB | 2.53 GiB | 2.02x | **never staged** |
+
+Monotonic, with an intermediate point 26,000x slower than the under-budget bin.
+This is the strongest evidence yet for the compressed-vs-decoded confusion
+described in `2026-09-12`'s hygiene-lane note.
+
+## K = 2, and it cannot be configured
+
+`light_optimize_k` is `mem_bound.min(cpu_bound).min(hot_project_count).max(1)`:
+
+- `cpu_bound` = cores/4 = **7** — not binding.
+- `mem_bound` = `slices - min(holdback 3, slices - LIGHT_MIN_SLICES)` where
+  `slices` = `coordinator_share_bytes / 1.25 GiB`.
+
+Tabulating the actual arithmetic:
+
+| slices | holdback applied | **K** |
+|---:|---:|---:|
+| 3 (28 cores, today) | 1 | **2** |
+| 4 | 2 | **2** |
+| 5 | 3 | **2** |
+| 6 | 3 | 3 |
+| 7 | 3 | 4 |
+
+`slices` = `jobs x 512 MiB / 1.25 GiB` and `jobs` = cores/3, so **K stays at 2
+from 28 cores all the way to ~48**, and reaching the 4 light permits the
+config's own comment calls the bench optimum ("6 concurrent sorts... 4 light +
+2 repair") would need **~53 cores**. The LIGHT_MIN_SLICES fix shipped on 09-12
+stopped K collapsing to 1; it did not make the holdback yield above the floor.
+
+**There is no env knob.** `TIMEFUSION_LIGHT_OPTIMIZE_CONCURRENCY` is marked
+*formerly* in `config.rs` — the field is gone, so setting it parses as nothing.
+CLAUDE.md still documents it as live. Same for
+`TIMEFUSION_MAINTENANCE_REWRITE_CONCURRENCY`, which **prod's container actually
+sets** (`=2`) and which is likewise dead.
+
+## The candidate change, and the reason it is not shipped unattended
+
+The holdback reserves up to 3 slices for the repair lane. Over the 9 hours
+measured, repair did **zero** work: `pending_repair = 0` and
+`work.Repair.worker_secs = 0` throughout — the comment at `config.rs:687` even
+records "`pending_repair` was 0 throughout". So the lane that owns 1.17 TB of
+debt is capped at 2 concurrent sorts to reserve budget for a lane that ran
+nothing.
+
+Making the holdback demand-aware — yield it when no repair is pending — takes
+K from 2 to 3 at today's core count, a ~50% drain improvement (7 days → ~4.7).
+`light_optimize_k` already takes a runtime argument (`hot_project_count`), so
+there is a clean place to put it.
+
+**Not shipped in this pass** because over-committing this exact pool is the
+documented cause of three separate "Resources exhausted" incidents, the
+transition (repair becomes pending while three light sorts are in flight) needs
+a bounded over-commit argument, and it cannot be validated against real memory
+pressure on MinIO. It wants a staging run, and it is a 1.5x lever on a problem
+whose shape is now understood — not the 10x one.
+
+## The bigger lever is CPU, and it is not in this lane
+
+The box runs at **25.0 of 28 cores**. Tantivy holds **~10 of them (39%)** while
+indexing 2-7x the ingest row rate, for reasons not yet attributed
+(`2026-09-13-where-the-28-cores-actually-go.md`). Reclaiming that is the
+largest single source of headroom available — but note it does **not** directly
+drain this backlog, because the sealed lane is permit-bound, not CPU-starved.
+Raising the container cap 28 → 32 (already in
+`deploy/caprover-service-override.yml`, still needs applying in CapRover) adds
+~14% CPU and, per the table above, **changes K not at all**.

--- a/docs/plans/2026-09-13-where-the-28-cores-actually-go.md
+++ b/docs/plans/2026-09-13-where-the-28-cores-actually-go.md
@@ -1,0 +1,117 @@
+# Where prod's 28 cores actually go
+
+2026-09-13, measured on a 9-hour-mature process (uptime 32,120 s), ingest
+~1,400 rows/s.
+
+## The container is CPU-saturated
+
+`cpu.max` is `2800000 100000` — a **28-core** cap. The cgroup's own
+`usage_usec` delta reads **25.00 cores**, i.e. **89% of the ceiling**. This is
+not the 2026-09-04 situation where query CPU was indistinguishable from idle;
+the box is genuinely out of CPU.
+
+## Attribution, and how to measure it without lying
+
+| pool | cores | share |
+|---|---:|---:|
+| tantivy (`thrd-tantivy-in`, `merge_thread_0`, `thread-tantivy-`) | 9.7-10.2 | **~39%** |
+| `tokio-rt-worker` (queries, ingest, async maintenance) | 8.0-9.1 | ~34% |
+| `maintenance-wor` | 5.7-7.0 | ~25% |
+| jemalloc/foyer/etc | ~0.5 | ~2% |
+| **TOTAL** | **24.0-25.8** | reconciles with cgroup |
+
+**Two measurement traps, both hit before the numbers above were trusted:**
+
+1. **Aggregating by thread NAME double-counts a churning pool.** Summing
+   per-comm in snapshot A and snapshot B separately, then differencing, credits
+   a newly-spawned thread's entire lifetime to the delta. Tantivy churns
+   threads constantly, so it read 17-18 cores. **Join per TID**, then aggregate.
+2. **`snap()` itself took longer than the sleep.** One `awk` per file over 2,893
+   threads is ~2,900 processes; dividing by the intended 15 s rather than the
+   measured elapsed inflated everything. The first "corrected" run still summed
+   to 38 cores against a 25-core cgroup. **A per-thread total that exceeds the
+   cgroup is a broken instrument, not a finding** — reconcile before believing.
+
+The working recipe is one `awk` over `/proc/<pid>/task/*/stat`, stamped with
+`date +%s.%N` on both sides, joined on TID.
+
+## Tantivy is ~39% of the box, and it is not insert cost
+
+| | rows/s |
+|---|---:|
+| ingested | ~1,400 |
+| **indexed by tantivy** | **3,100-9,400** (bursty; big builds dominate) |
+
+Indexing runs at **2-7x the ingest row rate**. Spending ~10 cores to index
+1,400 rows/s would be ~134 rows/s/core, one to two orders of magnitude below
+what tantivy actually does — which is independent evidence the cost is not
+ingest-proportional.
+
+The mass is concentrated: in one 30-minute window, **6 builds of ≥300 k rows
+carried 4.80 M rows while 100 smaller builds carried 0.82 M** — 85% of the work
+in 6% of the builds. The largest were 1,074,522 / 971,277 / 935,760 rows, and
+**one project's 711,283-row build appeared twice in the same window.**
+
+### What it is NOT — refuted, with the instrument that refuted each
+
+- **NOT re-indexing maintenance rewrite output.** The obvious hypothesis, given
+  ~36x write amplification. `reindex_wave_outputs` already carries coverage
+  forward instead of rebuilding, and prod measured **256 carried, 0 rebuilt
+  across 98 waves in 90 minutes — a 100% carry rate.** The counter for this was
+  already in the tree; the hypothesis died in one query.
+- **NOT the post-optimize path** (`compact.rs:237`): zero such log lines in 120
+  minutes.
+- **NOT a historical backfill backlog.** `tantivy_coverage_census` reads
+  `uncovered=708 today=627 week=34 older=47`, and `older` is *shrinking*
+  (50 → 49 → 47). The uncovered set is today's churn, not history.
+
+### What remains open
+
+The flush callback (`server/mod.rs:153`) is documented as "the write layer
+invokes this callback after commit" — ingest only — and should therefore track
+ingest at ~1,400 rows/s. It does not account for a 2-7x rate, and the repeated
+711,283-row build is unexplained. The remaining candidates are
+`spawn_deferred_tantivy_reindex` (`mod.rs:3904`) and `backfill_table_indexes`
+(`mod.rs:4301`).
+
+**Do not size a fix before this is named.** Note that `tantivy_backfill_built`
+sitting frozen does NOT exonerate backfill: only the `mod.rs:4344` site
+increments it, and the deferred path at 3904 increments nothing.
+
+## Correction: the rollup prior-art doc's headline numbers are not sound
+
+`2026-09-13-rollup-maintenance-prior-art.md` opens with "BaseRollup alone would
+want **25-39 of 48 cores** at ten times today's writes", derived from
+`work.BaseRollup.progress_rows / rows_ingested_total` ≈ 1,490:1 (and a later
+reading of 2,158:1). **Both counters mean something other than what that
+inference needs**, per `observability.rs:81`:
+
+> `worker_secs`/`killed_secs` are wall time a worker held for this operation.
+> `progress_rows` is the liveness counter's tally — summed over every operator
+> in the plan tree, so it is a same-shape trend proxy, **NOT a count of rows of
+> work**.
+
+So `progress_rows` is not rows read, and `worker_secs` is wall-held including
+every wait on a semaphore, the sort pool, or the journal lock — not CPU. Two
+independent checks confirm the extrapolation cannot stand:
+
+- 92.2 B `progress_rows` against 3,044 s of published `scan_ms` implies 30 M
+  rows/s, which is not physical.
+- `work.BaseRollup.worker_secs` = 119,740 s against **6,004 s** of published
+  end-to-end duration across all 1,732 publications — a 20x gap that is waiting,
+  not work.
+
+**The real figure is the measured one: the whole `maintenance-wor` pool is
+5.7-7.0 cores, all operations combined.** Any 10x CPU claim has to be re-derived
+from that. The prior-art doc's *direction* (merge partial aggregates instead of
+re-reading raw, per ClickHouse/Druid/TimescaleDB/IVM) is unaffected — it is the
+cost premise that needs redoing, and the cardinality measurement that doc
+already gates the design on is still the right next step.
+
+## Why this matters for the 1.2 TB backlog
+
+`sealed_compaction_debt_bytes` is 1.185 TB and the sealed lane gets ~1.4% of
+maintenance worker time. Reclaiming tantivy's ~10 cores is the largest single
+source of headroom on the box — but headroom is not the backlog fix: the sealed
+lane is permit- and stall-bound, not CPU-starved, so more cores alone will not
+drain it.

--- a/scripts/deploy/lease.py
+++ b/scripts/deploy/lease.py
@@ -10,13 +10,30 @@ import uuid
 LEASE_REF = 'refs/timefusion-deploy/lease'
 RECEIPT_REF = 'refs/timefusion-deploy/completed'
 
+# A holder that never released its lease wedges EVERY later rollout until a
+# person deletes the ref by hand. Prod 2026-09-13: a superseded rollout mutated
+# nothing, then its release push failed; the three runs behind it each waited
+# out the full timeout and failed, and production could not be deployed for ~5
+# hours. Releasing is bookkeeping, so it must neither fail a good rollout nor be
+# the only way the ref ever comes back.
+#
+# Only a lease that provably never reached a production mutation is reclaimable.
+# One retained for recovery carries `unresolved` and is left for a person.
+STALE_SECONDS = 1800
+
 
 @dataclass
 class RolloutGuard:
     owner: str
+    publish: 'callable' = None
     unresolved: bool = False
 
     def submitted(self):
+        # Announce BEFORE the first production mutation, and fail the rollout if
+        # the announcement does not land: a lease that never says it may be
+        # mutating is reclaimable, so mutating without it risks two concurrent
+        # rollouts. Aborting here is safe precisely because nothing has changed yet.
+        self.owner = self.publish(mutating=True)
         self.unresolved = True
 
     def verified(self):
@@ -49,10 +66,27 @@ class DeploymentLease:
         return self.git('-c', 'user.name=Timefusion deployment', '-c', 'user.email=deploy@timefusion.invalid',
                         'commit-tree', tree, *parents, '-m', 'Production rollout record')
 
+    def abandoned(self, commit):
+        """Whether `commit` is a dead holder's lease rather than a live or mutating one.
+
+        Fail-safe in every direction: an unreadable record, a missing
+        `mutating` key (an older writer, or one that never got to declare), or
+        `mutating` set all mean "leave it alone".
+        """
+        try:
+            self.git('fetch', '--no-write-fetch-head', '--no-tags', 'origin', LEASE_REF)
+            record = json.loads(self.git('show', commit + ':record.json'))
+        except (subprocess.CalledProcessError, ValueError):
+            return False
+        if record.get('mutating') is not False:
+            return False
+        return time.time() - record.get('started', time.time()) >= STALE_SECONDS
+
     @contextlib.contextmanager
     def hold(self, image, wait_seconds=2700):
-        owner = self.commit({'image': image, 'nonce': uuid.uuid4().hex,
-                             'run_id': os.environ.get('GITHUB_RUN_ID'), 'pid': os.getpid(), 'started': time.time()})
+        record = {'image': image, 'nonce': uuid.uuid4().hex, 'mutating': False,
+                  'run_id': os.environ.get('GITHUB_RUN_ID'), 'pid': os.getpid(), 'started': time.time()}
+        owner = self.commit(record)
         deadline = time.monotonic() + wait_seconds
         last_notice = 0
         while True:
@@ -64,19 +98,46 @@ class DeploymentLease:
                 occupied = self.remote(LEASE_REF)
                 if occupied is None or time.monotonic() >= deadline:
                     raise
-                if time.monotonic() - last_notice >= 30:
+                # Reclaim only against the exact commit just observed, so a
+                # holder that comes back to life between the read and the push
+                # keeps its lease.
+                if self.abandoned(occupied):
+                    print('Production lease ' + occupied[:12] + ' was abandoned; reclaiming.', flush=True)
+                    try:
+                        self.git('push', '--force-with-lease=' + LEASE_REF + ':' + occupied, 'origin', owner + ':' + LEASE_REF)
+                        break
+                    except subprocess.CalledProcessError:
+                        pass
+                elif time.monotonic() - last_notice >= 30:
                     print('Production lease ' + occupied[:12] + ' is occupied; waiting.', flush=True)
                     last_notice = time.monotonic()
                 time.sleep(5)
-        guard = RolloutGuard(owner)
+        def publish(**changes):
+            updated = self.commit(dict(record, **changes), parent=guard.owner)
+            self.git('push', '--force-with-lease=' + LEASE_REF + ':' + guard.owner, 'origin', updated + ':' + LEASE_REF)
+            return updated
+
+        guard = RolloutGuard(owner, publish)
         try:
             yield guard
         finally:
+            owner = guard.owner
             if guard.unresolved:
                 print('Rollout state is unresolved; retaining production lease ' + owner + ' for recovery.', flush=True)
             else:
-                # Never delete a lease whose owner has changed.
-                self.git('push', '--force-with-lease=' + LEASE_REF + ':' + owner, 'origin', ':' + LEASE_REF)
+                # Never delete a lease whose owner has changed. A transient
+                # failure here must not fail an otherwise-good rollout — the
+                # reclaim above is what recovers the ref when this loses.
+                for delay in (0, 2, 5):
+                    time.sleep(delay)
+                    try:
+                        self.git('push', '--force-with-lease=' + LEASE_REF + ':' + owner, 'origin', ':' + LEASE_REF)
+                        break
+                    except subprocess.CalledProcessError:
+                        pass
+                else:
+                    print('Could not release production lease ' + owner[:12]
+                          + '; a later rollout will reclaim it as abandoned.', flush=True)
 
     def complete(self, image, boot_micros):
         previous = self.remote(RECEIPT_REF)

--- a/scripts/deploy/test_lease.py
+++ b/scripts/deploy/test_lease.py
@@ -1,8 +1,24 @@
+import contextlib
 import pathlib
 import subprocess
 import tempfile
 import unittest
+import lease as lease_module
 from lease import DeploymentLease, LEASE_REF, RECEIPT_REF
+
+
+@contextlib.contextmanager
+def repo():
+    """A bare origin with two independent checkouts holding leases against it."""
+    with tempfile.TemporaryDirectory() as directory:
+        root = pathlib.Path(directory)
+        remote, first, second = (root / name for name in ('remote', 'first', 'second'))
+        def git(*args):
+            subprocess.run(['git', *map(str, args)], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        git('init', '--bare', remote)
+        for checkout in (first, second):
+            git('clone', remote, checkout)
+        yield DeploymentLease(first), DeploymentLease(second)
 
 
 class LeaseTest(unittest.TestCase):
@@ -41,6 +57,50 @@ class LeaseTest(unittest.TestCase):
                 guard.submitted()
                 guard.verified()
             self.assertIsNone(a.remote(LEASE_REF))
+
+
+class AbandonedLeaseTest(unittest.TestCase):
+    """Prod 2026-09-13: a release push failed and wedged every deploy for ~5 hours."""
+
+    @contextlib.contextmanager
+    def stale_after(self, seconds):
+        previous, lease_module.STALE_SECONDS = lease_module.STALE_SECONDS, seconds
+        try:
+            yield
+        finally:
+            lease_module.STALE_SECONDS = previous
+
+    def test_a_failed_release_does_not_fail_the_rollout(self):
+        with repo() as (a, _):
+            with a.hold('image-a') as guard:
+                # Exactly the 09-13 shape: the rollout itself is fine, only the
+                # bookkeeping push loses. It must not turn a good rollout red.
+                a.git('push', '--force-with-lease=' + LEASE_REF + ':' + guard.owner, 'origin', ':' + LEASE_REF)
+            self.assertIsNone(a.remote(LEASE_REF))
+
+    def test_a_lease_that_never_mutated_is_reclaimed(self):
+        with repo() as (a, b), self.stale_after(0):
+            # A holder that died before releasing: the ref is left behind by a
+            # rollout that never declared a production mutation.
+            a.git('push', 'origin', a.commit({'image': 'image-a', 'mutating': False, 'started': 0}) + ':' + LEASE_REF)
+            self.assertIsNotNone(b.remote(LEASE_REF))
+            with b.hold('image-b', wait_seconds=30) as guard:
+                self.assertEqual(b.remote(LEASE_REF), guard.owner, 'the abandoned lease was not reclaimed')
+
+    def test_a_mutating_lease_is_never_reclaimed(self):
+        with repo() as (a, b), self.stale_after(0):
+            with contextlib.suppress(RuntimeError):
+                with a.hold('image-a') as guard:
+                    guard.submitted()
+                    raise RuntimeError('unknown remote state')
+            held = a.remote(LEASE_REF)
+            self.assertIsNotNone(held)
+            # Stale by the clock, but it declared that it may have changed
+            # production — stealing it would run two rollouts at once.
+            self.assertFalse(b.abandoned(held))
+            with self.assertRaises(subprocess.CalledProcessError):
+                with b.hold('image-b', wait_seconds=0):
+                    self.fail('reclaimed a lease that reached a production mutation')
 
 
 if __name__ == '__main__':

--- a/src/database/compact.rs
+++ b/src/database/compact.rs
@@ -234,7 +234,9 @@ impl Database {
                     let table_owned = table_name.to_string();
                     let (built, reindex_errs) = futures::stream::iter(added.into_iter().map(|(pid, rel, uri)| {
                         let (svc, store, table) = (svc.clone(), delta_store.clone(), table_owned.clone());
-                        async move { svc.build_index_for_file(&table, &pid, &rel, &uri, store).await }
+                        async move {
+                            svc.build_index_for_file(&table, &pid, &rel, &uri, store).instrument(tracing::info_span!("tantivy_build", cause = "optimize")).await
+                        }
                     }))
                     .buffer_unordered(self.config.tantivy.timefusion_tantivy_build_concurrency.max(1))
                     .fold((0usize, 0usize), |(built, errs), r| async move {

--- a/src/database/histogram.rs
+++ b/src/database/histogram.rs
@@ -1101,10 +1101,7 @@ mod tests {
             let table_ref = db.resolve_table(&project, table).await?;
             let store = table_ref.read().await.log_store().object_store(None);
             for uri in db.list_file_uris(&project, table).await? {
-                indexer
-                    .build_index_for_file(table, &project, parquet_rel_of_uri(&uri).context("missing relative path")?, &uri, store.clone())
-                    .instrument(tracing::info_span!("tantivy_build", cause = "histogram"))
-                    .await?;
+                indexer.build_index_for_file(table, &project, parquet_rel_of_uri(&uri).context("missing relative path")?, &uri, store.clone()).await?;
             }
             Ok::<_, anyhow::Error>(())
         };

--- a/src/database/histogram.rs
+++ b/src/database/histogram.rs
@@ -1101,7 +1101,10 @@ mod tests {
             let table_ref = db.resolve_table(&project, table).await?;
             let store = table_ref.read().await.log_store().object_store(None);
             for uri in db.list_file_uris(&project, table).await? {
-                indexer.build_index_for_file(table, &project, parquet_rel_of_uri(&uri).context("missing relative path")?, &uri, store.clone()).await?;
+                indexer
+                    .build_index_for_file(table, &project, parquet_rel_of_uri(&uri).context("missing relative path")?, &uri, store.clone())
+                    .instrument(tracing::info_span!("tantivy_build", cause = "histogram"))
+                    .await?;
             }
             Ok::<_, anyhow::Error>(())
         };

--- a/src/database/maintain.rs
+++ b/src/database/maintain.rs
@@ -8528,21 +8528,26 @@ impl Database {
         if !carried.is_empty() || !files.is_empty() {
             info!(table_name, carried = carried.len(), rebuilding = files.len(), event = "tantivy_wave_carried_forward");
         }
-        let (built, failed) = futures::stream::iter(files.into_iter().map(|(project, rel, uri)| {
-            let (svc, store, table) = (svc.clone(), store.clone(), table.clone());
-            async move { svc.build_index_for_file(&table, &project, &rel, &uri, store).await }
-        }))
-        .buffer_unordered(self.config.tantivy.timefusion_tantivy_build_concurrency.max(1))
-        .fold((0usize, 0usize), |(built, failed), result| async move {
-            match result {
-                Ok(()) => (built + 1, failed),
-                Err(error) => {
-                    warn!(table_name, %error, event = "tantivy_wave_reindex_failed");
-                    (built, failed + 1)
+        let (built, failed) =
+            futures::stream::iter(
+                files.into_iter().map(|(project, rel, uri)| {
+                    let (svc, store, table) = (svc.clone(), store.clone(), table.clone());
+                    async move {
+                        svc.build_index_for_file(&table, &project, &rel, &uri, store).instrument(tracing::info_span!("tantivy_build", cause = "wave")).await
+                    }
+                }),
+            )
+            .buffer_unordered(self.config.tantivy.timefusion_tantivy_build_concurrency.max(1))
+            .fold((0usize, 0usize), |(built, failed), result| async move {
+                match result {
+                    Ok(()) => (built + 1, failed),
+                    Err(error) => {
+                        warn!(table_name, %error, event = "tantivy_wave_reindex_failed");
+                        (built, failed + 1)
+                    }
                 }
-            }
-        })
-        .await;
+            })
+            .await;
         info!(table_name, built, failed, event = "tantivy_wave_reindex_complete");
     }
 

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -40,6 +40,7 @@ use serde::{Deserialize, Serialize};
 use sqlx::{PgPool, postgres::PgPoolOptions};
 use tokio::sync::RwLock;
 use tokio_util::sync::CancellationToken;
+use tracing::Instrument as _;
 use tracing::{Instrument, debug, error, field::Empty, info, instrument, warn};
 use url::Url;
 
@@ -3901,7 +3902,9 @@ impl Database {
                     let store = table.read().await.log_store().object_store(None);
                     let rel =
                         crate::tantivy::search::parquet_rel_of_uri(&file.uri).ok_or_else(|| anyhow::anyhow!("invalid deferred parquet URI {}", file.uri))?;
-                    svc.build_index_for_file(&file.table_name, &file.project_id, rel, &file.uri, store).await
+                    svc.build_index_for_file(&file.table_name, &file.project_id, rel, &file.uri, store)
+                        .instrument(tracing::info_span!("tantivy_build", cause = "deferred"))
+                        .await
                 }
                 .await;
                 match result {
@@ -4298,7 +4301,10 @@ impl Database {
             let mut pending_since: HashMap<String, std::time::Instant> = HashMap::new();
             let mut jobs = futures::stream::iter(work.into_iter().map(|(pid, rel, uri)| {
                 let (svc, store, table) = (svc.clone(), delta_store.clone(), table_owned.clone());
-                async move { (pid.clone(), svc.build_index_for_file_deferred(&table, &pid, &rel, &uri, store).await) }
+                async move {
+                    let built = svc.build_index_for_file_deferred(&table, &pid, &rel, &uri, store);
+                    (pid.clone(), built.instrument(tracing::info_span!("tantivy_build", cause = "backfill")).await)
+                }
             }))
             .buffer_unordered(self.config.tantivy.timefusion_tantivy_build_concurrency.max(1));
             // Flush on a TIMER, not only on build completions. The age bound is

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -150,7 +150,10 @@ pub fn tantivy_index_callback(db: &Database, indexer: Arc<crate::tantivy::search
             // One streamed build at a time per callback keeps multi-file commits bounded.
             for uri in added_files {
                 let relative = crate::tantivy::search::parquet_rel_of_uri(&uri).context("committed file has no relative Parquet path")?;
-                indexer.build_index_for_file(&table_name, &project_id, relative, &uri, Arc::clone(&store)).await?;
+                indexer
+                    .build_index_for_file(&table_name, &project_id, relative, &uri, Arc::clone(&store))
+                    .instrument(tracing::info_span!("tantivy_build", cause = "flush"))
+                    .await?;
             }
             Ok(())
         })


### PR DESCRIPTION
Two independent things found while chasing the 1.17 TB maintenance backlog.

## 1. A failed lease release wedged every production deploy for ~5 hours

Production had not been deployed since **00:23 UTC** despite three later "Build and Deploy" runs, **two of which GitHub reported as success**. Two stacked failure modes:

- **Supersede returns 0.** `run.py` prints *"A newer master commit superseded this rollout; production is unchanged"* and exits successfully. With several sessions pushing master, every rollout was superseded and prod never moved. A green deploy does not mean prod was deployed.
- **A failed lease RELEASE wedges everything.** One superseded run mutated nothing, then its release push failed. The ref survived; every later run waited its full timeout printing `Production lease 73219cc29f7d is occupied; waiting.` and failed. The identical command succeeded from a laptop, so the runner failure was environmental — exactly why bookkeeping must not be load-bearing.

Release now retries and, if it still loses, warns instead of failing an otherwise-good rollout. Because that alone would leave the ref behind, a later rollout reclaims a lease that is both stale and provably pre-mutation.

**The reclaim predicate is fail-safe in every direction**: the record carries `mutating: false` from acquisition; `guard.submitted()` republishes it as `true` *before* the first production mutation and fails the rollout if that does not land; an unreadable record or a missing key both mean leave it alone. A lease deliberately retained for recovery is never stolen.

Guards written to fail first — `test_a_failed_release_does_not_fail_the_rollout` reproduces the exact production traceback (`CalledProcessError` on the release push) against the old code.

## 2. Tantivy is ~39% of the box, for reasons nothing can currently name

Measured on a 9-hour process: the container runs at **25.0 of its 28-core cap**, and tantivy holds **~10 cores** while indexing **2-7x the ingest row rate**.

| pool | cores | share |
|---|---:|---:|
| tantivy | 9.7-10.2 | ~39% |
| `tokio-rt-worker` | 8.0-9.1 | ~34% |
| `maintenance-wor` | 5.7-7.0 | ~25% |

The obvious explanation is refuted by an instrument already in the tree: `reindex_wave_outputs` measured **256 carried / 0 rebuilt across 98 waves — 100% carry**. Not the post-optimize path (zero log lines in 2 h), and not a historical backlog (`older=47`, shrinking).

So a `cause` span at each build call site. Spans rather than a threaded argument because builds fan out through two spawned tasks and a shared primitive. Note `tantivy_backfill_built` cannot settle this on its own — only one of the two backfill sites increments it.

## Also: a correction

`2026-09-13-rollup-maintenance-prior-art.md` claimed BaseRollup wants 25-39 of 48 cores at 10x. That rests on `progress_rows` and `worker_secs`, which per `observability.rs:81` are a plan-tree liveness proxy and wall time *held*. The measured figure is **5.7-7.0 cores for all maintenance combined**. The doc's direction is unaffected; its cost premise is annotated.

Local: `cargo lint` clean, `cargo fmt` applied, `test` attested, both deploy test suites green.