### PR TITLE
Why every dashboard query misses the rollup, and the prior art for both lanes

### DIFF
--- a/docs/plans/2026-09-13-the-backlog-drain-arithmetic.md
+++ b/docs/plans/2026-09-13-the-backlog-drain-arithmetic.md
@@ -26,6 +26,15 @@ moved **0.5 GB** and `pending_sealed_consolidation` held flat at **196** — whi
 SealedConsolidation completed ~48 units/hour. Two mechanisms are visible and
 neither is the sort stall #271 fixed:
 
+- **The gauge is a STOCK OF ESTIMATES and cannot show drain at all.**
+  `estimated_decoded_bytes` is set once when the task is created
+  (`maintenance_coordinator.rs:457`) and is never decremented as bins commit —
+  the only write after creation zeroes it wholesale (`:1222`). So the sum only
+  falls when a task leaves the pending set entirely. This resolves the
+  contradiction outright: committed bins imply ~18 GB/h of decoded work against
+  an observed 0.3 GB/h of gauge movement, because **the gauge is not measuring
+  work done.** A drain rate has to be computed from committed-bin `bytes_in` in
+  the logs; do not quote one from this counter.
 - **Tasks retry rather than retire.** `retry.HotPacking.compaction_debt_remaining`
   = 54 and `retry.SealedConsolidation.compaction_debt_remaining` = 7: a unit
   does a few bins and re-queues, so the pending COUNT is not a work-remaining

--- a/docs/plans/2026-09-13-the-backlog-drain-arithmetic.md
+++ b/docs/plans/2026-09-13-the-backlog-drain-arithmetic.md
@@ -128,3 +128,44 @@ drain this backlog, because the sealed lane is permit-bound, not CPU-starved.
 Raising the container cap 28 → 32 (already in
 `deploy/caprover-service-override.yml`, still needs applying in CapRover) adds
 ~14% CPU and, per the table above, **changes K not at all**.
+
+## Prior art: InfluxDB 3 bounds compaction by ROWS, not compressed bytes
+
+InfluxDB 3 (IOx) is the closest architectural relative TimeFusion has — Rust,
+DataFusion, Parquet, object storage — so its compactor is the most directly
+transferable prior art, and it differs from ours in exactly the place that hurt.
+
+- **Levels, not a single "sealed" pass.** L0 is newly ingested and uncompacted,
+  L1 is consolidated, L2 is compacted and non-overlapping. Promotion between
+  levels is gated on size boundaries (`--l1-consolidation-target-size`: a run set
+  is consumed at or below it, and promotion requires at least two run sets above
+  it). That is the same similar-size idea `bin_breaks_size_ratio` implements,
+  expressed as an explicit ladder.
+- **A separate, smaller target for the hot tail.** `--l1-hot-tail-target-size`
+  (default 250 MB) caps live tail rewrites during snapshot compaction, and the
+  larger tail is handed to L1 consolidation to seal. TimeFusion's split between
+  hot-tail packing and sealed consolidation is the same shape.
+- **The one that matters: `compactionRowLimit`, a soft limit of ~1,000,000 ROWS
+  per file the compactor writes.** The bound is on rows, not on compressed
+  bytes.
+
+**That last point is the lesson for #271.** TimeFusion caps a bin at
+`COORDINATOR_PER_SORT_BUDGET_BYTES / DECODED_BYTES_PER_COMPRESSED` — compressed
+bytes converted through a *fixed 12x estimate*. But the thing the sort actually
+costs is decoded rows, and the compression ratio is not 12x uniformly: it varies
+by column mix, by tenant, and by how well-sorted a file already is. A bin of
+identically-sized compressed input can decode to wildly different working sets.
+
+**Rows are exact, and TimeFusion already has them**: `TailAdd::rows` comes from
+Delta `numRecords` and `refuse_low_value_bin` already sums it to price a bin.
+Pricing the cap in rows rather than estimated-decoded-bytes removes the 12x
+estimate from the one decision that stalls the lane when it is wrong — which is
+the same class of error as the gauge correction above, and as #271 itself.
+
+This is a concrete follow-up, not a speculative one: the bound already exists,
+the input is already summed one function away, and the failure mode of the
+current estimate has now been measured twice.
+
+Sources: [InfluxDB 3 storage engine internals](https://docs.influxdata.com/influxdb3/clustered/reference/internals/storage-engine/),
+[InfluxDB 3 Enterprise configuration options](https://docs.influxdata.com/influxdb3/enterprise/reference/config-options/),
+[Timestream for InfluxDB v3 parameters](https://docs.aws.amazon.com/ts-influxdb/latest/ts-influxdb-api/API_InfluxDBv3EnterpriseParameters.html)

--- a/docs/plans/2026-09-13-the-backlog-drain-arithmetic.md
+++ b/docs/plans/2026-09-13-the-backlog-drain-arithmetic.md
@@ -158,7 +158,17 @@ transferable prior art, and it differs from ours in exactly the place that hurt.
   per file the compactor writes.** The bound is on rows, not on compressed
   bytes.
 
-**That last point is the lesson for #271.** TimeFusion caps a bin at
+**CORRECTION, found by reading before recommending: TimeFusion already does
+this.** `MAX_BIN_ROWS = 2_000_000` (`mod.rs:1487`) bounds a bin in rows, and its
+comment states the same principle in the same words — *"ROWS, not just bytes. A
+byte budget prices a bin by how much it will read; a rewrite costs what it must
+SORT AND WRITE, which is rows... price the work in the unit that costs."* That
+is within 2x of InfluxDB's ~1 M `compactionRowLimit`. The row bound is
+implemented, enforced in the packer loop, and mirrored in the planner/packer
+agreement test. **So this is convergent-evolution evidence that the design is
+right, not a gap to close.**
+
+TimeFusion still caps BYTES at
 `COORDINATOR_PER_SORT_BUDGET_BYTES / DECODED_BYTES_PER_COMPRESSED` — compressed
 bytes converted through a *fixed 12x estimate*. But the thing the sort actually
 costs is decoded rows, and the compression ratio is not 12x uniformly: it varies
@@ -178,3 +188,41 @@ current estimate has now been measured twice.
 Sources: [InfluxDB 3 storage engine internals](https://docs.influxdata.com/influxdb3/clustered/reference/internals/storage-engine/),
 [InfluxDB 3 Enterprise configuration options](https://docs.influxdata.com/influxdb3/enterprise/reference/config-options/),
 [Timestream for InfluxDB v3 parameters](https://docs.aws.amazon.com/ts-influxdb/latest/ts-influxdb-api/API_InfluxDBv3EnterpriseParameters.html)
+
+## The measured cliff is at ~1.0x, not 2x — and one bin still crossed it
+
+Drain measured the only way that works (committed-bin `bytes_in` from the logs,
+not the gauge): **16 bins / 30 min = 382.7 MB compressed = ~765 MB/h**. Against
+~99 GB that is ~129 hours, but treat it as an order of magnitude, not an ETA —
+it is one 30-minute window on a 2-hour-old process.
+
+The same window contains the sharpest dose-response yet:
+
+| bin | compressed | decoded / 1.25 GiB | staging |
+|---|---:|---:|---:|
+| 11 files | 63.1 MB | **0.59x** | **15 s** |
+| 13 files | **111.3 MB** | **1.07x** | **28.5 min** |
+
+**7% over budget cost 114x.** The earlier reading — 0.59x fast, 1.37x slow,
+2.0x+ never — put the knee somewhere below 1.37x; this puts it essentially AT
+1.0x. That is what a sort falling out of memory looks like, and it means the cap
+has no useful margin: being just over is nearly as bad as being far over.
+
+**And 111.3 MB is above the 107 MB cap #271 installed**, so something admitted a
+bin the cap should have refused. Candidates, none yet confirmed:
+
+- The packer loop pushes its FIRST candidate unconditionally (the `<2`-file
+  livelock guard), so a bin can exceed by one file's size. 13 files averaging
+  8.6 MB does not obviously fit that shape.
+- There are several packing paths with DIFFERENT budgets:
+  `select_coordinator_compaction_candidates` uses
+  `if has_unsorted { unsorted_bin_budget_bytes() } else { target }`, where the
+  unsorted budget is 768 MB decoded = **64 MB compressed** — *stricter* than the
+  cap, so that path is not it. `select_tail_bin` carries its own `cap`, and the
+  cron hot-tail packer is a separate lane again.
+
+**Next step is to identify which lane emitted that bin before changing any
+budget** — the log line does not say. Adding the operation/lane to
+`wave_bin_staged` is the cheap instrument, and it is the same mistake this
+document keeps recording: do not tune a budget until you know which budget was
+applied.

--- a/docs/plans/2026-09-13-where-the-28-cores-actually-go.md
+++ b/docs/plans/2026-09-13-where-the-28-cores-actually-go.md
@@ -115,3 +115,31 @@ maintenance worker time. Reclaiming tantivy's ~10 cores is the largest single
 source of headroom on the box — but headroom is not the backlog fix: the sealed
 lane is permit- and stall-bound, not CPU-starved, so more cores alone will not
 drain it.
+
+## UPDATE, post-#271: the cap now BINDS, and `nr_throttled` proves it
+
+With the hygiene lanes unblocked, cgroup CPU moved from **25.0** to **25.9-27.7
+of 28**, and `cpu.stat`'s `nr_throttled` increments **~85-102 per 12 s (~8/s)**.
+
+That second number is the one that matters. A cores figure near the cap is
+suggestive — scheduling noise, a burst, a bad sample. **A rising `nr_throttled`
+is proof**: the kernel is stopping runnable threads because the CFS quota is
+exhausted. Maintenance work is now being held back by the container's CPU limit
+rather than by a lock, a permit, or a stalled sort.
+
+Measure `nr_throttled` alongside `usage_usec` whenever asking "is the CPU cap
+binding?" — it is the difference between "busy" and "capped", and this codebase
+has mistaken the former for a finding before.
+
+Two consequences:
+
+- **Raising NanoCpus 28 -> 32 is now a measured fix**, not a guess. The value is
+  in `deploy/caprover-service-override.yml`; the repo file alone does not apply
+  it, it needs a CapRover admin update. Note it does **not** change
+  `light_optimize_k`, which stays at 2 from 28 cores to ~48 — it buys throughput
+  for the lanes that already run, not more sealed concurrency.
+- **Tantivy's ~10 cores is now directly displacing maintenance.** While the box
+  had headroom, the 39% share was a cost without a victim. Under throttling it
+  is not: every core tantivy holds is a core the backlog does not get. That
+  promotes the attribution work from "headroom project" to "on the critical
+  path", which is what the `cause` span shipped in #273 exists to resolve.

--- a/docs/plans/2026-09-13-why-every-query-misses-the-rollup.md
+++ b/docs/plans/2026-09-13-why-every-query-misses-the-rollup.md
@@ -60,7 +60,33 @@ not by the mechanism it sounds like — it is not file fragmentation making scan
 heavy, it is maintenance and ingest continuously invalidating the freshness
 proof so the rollup is never trusted.
 
-## The window that misses is TODAY, and that is what names the fix
+## It is NOT only the open day — a closed 8-day-old partition misses too
+
+A sampled miss carries `lo/hi` = 06:00-12:00 of the current day, which invites
+"this is just the open partition, and that is unavoidable". **Tested directly
+against a CLOSED day** — 2026-09-05, eight days old, one pinned project, so no
+cross-project intersection and no open-tail effect:
+
+```
+before  hits=2690  miss=13315
+query   SELECT count(*) ... project_id=<pinned> AND ts IN [2026-09-05, 09-06)
+after   hits=2690  miss=13329        -- +14 misses, ZERO hits
+```
+
+**A partition eight days old still fails the freshness proof.** Nothing is
+ingesting into 09-05; the only thing still changing it is **maintenance** —
+dedup dropping rows and consolidation rewriting file sets. That is the coupling
+demonstrated rather than inferred: **the backlog work is what keeps the rollup
+untrusted, and therefore what keeps queries slow.**
+
+It also means "prove a closed day once and stop re-proving it" is not sufficient
+on its own — a day is not settled while maintenance still has work queued
+against it. The proof has to be stable across the rewrites maintenance performs,
+which is what makes the dedup-certification predicate (`cert_slice_files_proved`)
+the right anchor: it already means "this partition is provably clean", which is
+a stronger and more durable statement than "its row count has not moved".
+
+## The open day is still the common case, and TimescaleDB names that half
 
 A sampled miss carries `lo = 1789272000000000`, `hi = 1789293600000000` —
 **06:00 to 12:00 of the current day**. The dashboards ask about the open

--- a/docs/plans/2026-09-13-why-every-query-misses-the-rollup.md
+++ b/docs/plans/2026-09-13-why-every-query-misses-the-rollup.md
@@ -236,7 +236,14 @@ recommendation".
    it returns answers a different question.
 2. **Feed** `LiveSource::logical` on the verify path — currently `None` at the
    only call site.
-3. **Oracle-compare** before trusting it: run both witnesses over real prod
+3. **Settle the 2026-09-04 count-pushdown undercount FIRST.** `COUNT(*)` was
+   measured silently **27% low** and the pushdown was disabled in `2f08c4a6`.
+   That is the same logical-count family a `Logical` witness would be stamped
+   from. Establish whether the defect was in the INDEX or in the pushdown before
+   stamping witnesses from it: if the index undercounts, `Logical` either never
+   validates (safe but useless) or validates against a wrong count, which is the
+   under-count class itself.
+4. **Oracle-compare** before trusting it: run both witnesses over real prod
    slices and assert the `Logical` verdict never says Valid where the raw path
    would disagree. The 08-22 slice-fingerprint attempt "routed nothing, failing
    safe as a permanent miss"; the opposite failure — routing something it should

--- a/docs/plans/2026-09-13-why-every-query-misses-the-rollup.md
+++ b/docs/plans/2026-09-13-why-every-query-misses-the-rollup.md
@@ -1,0 +1,166 @@
+# Why every dashboard query misses the rollup
+
+2026-09-13, measured on prod at ~2 h uptime.
+
+## The observation
+
+`rollup_hits_hybrid_total` sat **frozen at 2,690** across repeated samples while
+`rollup_misses_total` climbed ~120 per 50 s — **100% of routing attempts
+missing** — and the miss increment was matched almost exactly by
+`rollup_miss_stale_coverage_total`. Every dashboard query was falling back to a
+raw scan.
+
+This is not a data gap. The rollup rows are there and they are fresh:
+
+```sql
+SELECT count(*), min(timestamp), max(timestamp)
+  FROM otel_logs_and_spans_rollup_dashboard_1m_v3
+ WHERE project_id = '00000000-...' AND timestamp >= now() - interval '2 days';
+-- 168834 | 2026-09-11T12:01:00Z | 2026-09-13T10:59:00Z
+```
+
+Current to the minute. Queries are being refused a rollup that exists.
+
+## The cause, from the discriminator that was built for this
+
+`stale_coverage_metric` splits the refusal four ways, and the split is total:
+
+| sub-reason | count |
+|---|---:|
+| `rollup_stale_no_witness` | **0** |
+| `rollup_stale_no_source_rows` | **0** |
+| `rollup_stale_moved` | **2,618,297** |
+| — `grew` | 2,499,123 (95.4%) |
+| — `shrank` | 119,174 (4.6%) |
+
+**Every refusal is `moved`.** The freshness proof requires
+`coverage.source_rows` to equal the partition's live row count; when the
+partition changes under a built slice, the slice is rejected.
+
+`mod.rs:4650`'s own comment states the consequence: *"`moved` is the partition
+genuinely changing under a verifiable slice, **which no amount of rebuilding
+fixes on a churning day**."* Build throughput is the fix for `no_witness`, which
+is zero here. Nothing in the rollup lane can fix `moved`.
+
+## Why this couples the backlog to query latency
+
+A partition's live row count moves for two reasons, and BOTH are visible:
+
+- **`grew` (95.4%)** — ingest landing in the partition.
+- **`shrank` (4.6%)** — rows being REMOVED, which on this system means **dedup**.
+
+The second is the important one. **Maintenance invalidates the coverage that
+queries depend on.** Dedup drops duplicate rows and consolidation rewrites file
+sets, so every partition maintenance touches has its rollup coverage
+invalidated, gets rebuilt, and is invalidated again by the next maintenance
+pass. Working the backlog harder produces *more* coverage churn, not less.
+
+So "the backlog is 1.2 TB **and as a result** queries are slow" is right, but
+not by the mechanism it sounds like — it is not file fragmentation making scans
+heavy, it is maintenance and ingest continuously invalidating the freshness
+proof so the rollup is never trusted.
+
+## The window that misses is TODAY, and that is what names the fix
+
+A sampled miss carries `lo = 1789272000000000`, `hi = 1789293600000000` —
+**06:00 to 12:00 of the current day**. The dashboards ask about the open
+partition, which is exactly the one that cannot stop growing.
+
+This is the case TimescaleDB's **real-time aggregation** exists for: serve the
+materialized aggregate for the settled part of the range and union raw rows for
+the recent tail, rather than refusing because the bucket is not final.
+
+**TimeFusion already has that shape** — `interiors(lo, hi, grain, horizon,
+&covered)` and the comment that "the realtime fringe is ALWAYS on... With it off
+the rollup had to answer the whole window or nothing". The fringe is not the
+problem.
+
+The problem is one level earlier: **the fringe splits `covered`, and `covered`
+is empty**, because the freshness proof rejects the whole slice when the
+partition's row count moved at all. So a slice holding perfectly good 06:00-11:00
+minutes is discarded because rows landed at 11:55.
+
+That is the asymmetry to exploit: for an append-mostly source, **`grew` tells you
+the tail moved, not the interior.** A slice whose partition only GREW is still
+authoritative for buckets that closed before the growth. The horizon machinery
+to express that already exists; what is missing is letting `grew` narrow a
+slice's usable range instead of voiding it.
+
+The caveat that must be settled first, not assumed: late-arriving data lands in
+EARLIER buckets, so "grew ⇒ only the tail changed" is not free. It needs either
+a per-slice max-timestamp witness or the existing dirty-hour tracking to bound
+where the new rows went.
+
+## What to do about it — do NOT ship any of this unvalidated
+
+Routing correctness has a documented history of under-count incidents
+(hybrid under-count, the 08-22 slice-fingerprint build that "routed nothing,
+failing safe as a permanent miss"). Options, cheapest first:
+
+1. **Bound the proof to the part of the window that cannot move.** A closed past
+   day should be provable once and stay proved; only the open tail should have to
+   re-prove. The machinery for "this partition is settled" already exists in the
+   certification lane.
+2. **Make the proof tolerant of known-direction change.** `shrank` under a dedup
+   that provably removed only duplicates does not change any SUM/COUNT the rollup
+   serves *if* the rollup was built from the deduplicated set. Whether that holds
+   needs checking, not assuming.
+3. **Anything that widens what routes must be oracle-compared** against the raw
+   path on real prod shapes before shipping. A rollup that answers faster and
+   slightly wrong is far worse than a raw scan.
+
+## A stale log message found on the way, worth fixing
+
+`rollup_uncovered_project` warns: *"a project in the window contributed NO
+covered range; with coverage intersected across the set **this refuses the whole
+query**"*. The comment immediately above it says the opposite and is the current
+behaviour: *"It no longer REFUSES the query, though: the project is read raw
+across the whole window while the covered projects still route, so one lagging
+tenant costs its own rows a raw scan instead of everyone's."*
+
+The message describes behaviour that was deliberately removed. It fired 45 times
+in 15 minutes, all for `00000000-0000-0000-0000-000000000000`, and it cost this
+investigation a wrong hypothesis — the log said the query was being refused, so
+the sentinel project looked like the culprit until the code was read.
+
+## Prior art: TimescaleDB already solved this, and names the two pieces
+
+TimescaleDB's continuous aggregates carry an **invalidation threshold**, also
+called the **materialization watermark** — a time cutoff behind the hot head of
+the table. Mutations landing *before* it are logged as invalidations, because
+that region has already been summarized. Data *after* it is never summarized in
+the first place.
+
+**Real-time aggregation** then answers a query by combining two sources
+transparently: pre-computed results from the materialization hypertable for the
+historical range, and a live aggregation against the raw hypertable for anything
+newer than the watermark, unioned automatically. (Since 2.13 `materialized_only`
+defaults to true, so this is opt-in — the mode exists precisely because refusing
+on an unsettled bucket is the wrong default for dashboards.)
+
+Mapped onto TimeFusion:
+
+| TimescaleDB | TimeFusion |
+|---|---|
+| invalidation log | `rollup_dirty` / `invalidate_rollup_hours` — **exists** |
+| materialization watermark | `horizon` / buffered cutoff — **exists** |
+| real-time union | `interiors(lo, hi, grain, horizon, &covered)` — **exists** |
+| — | the freshness proof that voids a slice when `source_rows` moves — **ours alone** |
+
+Every piece of the TimescaleDB design is already present. The divergence is the
+last row: TimeFusion additionally requires an exact row-count match per slice,
+and that check is what empties `covered` before the real-time union ever gets to
+run. TimescaleDB does not verify that the source partition is byte-stable; it
+relies on the watermark to say which region is summarizable and the invalidation
+log to say which summarized regions are suspect.
+
+So the change is not to build a new mechanism — it is to stop a
+belt-and-braces proof from vetoing the mechanism already built. That reframing
+is why this is worth doing carefully rather than quickly: the proof was added
+for a reason (`rollup_correctness`, 2026-08-22), and removing its veto without
+understanding which incident it was protecting against would re-open exactly the
+under-count class it was built to close.
+
+Sources: [About continuous aggregates](https://www.tigerdata.com/docs/use-timescale/latest/continuous-aggregates/about-continuous-aggregates),
+[Continuous aggregate refresh, demystified](https://www.tigerdata.com/blog/continuous-aggregate-refresh-demystified),
+[Understand continuous aggregates](https://www.tigerdata.com/docs/learn/continuous-aggregates)

--- a/docs/plans/2026-09-13-why-every-query-misses-the-rollup.md
+++ b/docs/plans/2026-09-13-why-every-query-misses-the-rollup.md
@@ -190,3 +190,57 @@ under-count class it was built to close.
 Sources: [About continuous aggregates](https://www.tigerdata.com/docs/use-timescale/latest/continuous-aggregates/about-continuous-aggregates),
 [Continuous aggregate refresh, demystified](https://www.tigerdata.com/blog/continuous-aggregate-refresh-demystified),
 [Understand continuous aggregates](https://www.tigerdata.com/docs/learn/continuous-aggregates)
+
+## THE FIX IS ~80% BUILT AND DORMANT
+
+`verify_slice_witness` (`rollup.rs:765`) already understands three witness kinds:
+
+| witness | what it proves | status |
+|---|---|---|
+| `Physical(rows)` | total `num_records` across the partition is unchanged | **the only one production uses** |
+| `PhysicalBelow { rows, bound }` | rows below a time bound unchanged — tolerant of growth above it | tests only |
+| `Logical { rows, lo, hi }` | **deduplicated** row count over the exact slice range | tests only |
+
+Both generalisations are implemented and unit-tested (`rollup.rs:4482-4509`), and
+nothing in production stamps or verifies with them. `slice_coverage_agrees` is
+hardcoded to `Physical` — its own doc says so — and passes `logical: None`, so
+the logical path is fed nothing:
+
+```rust
+let source = LiveSource { files: ..., logical: None };
+... verify_slice_witness(witness.map(SliceWitness::Physical), source) ...
+```
+
+**`Physical` is the wrong proof for this system, and the code says why.**
+`SourceFile::rows` is "the add action's `num_records` — PHYSICAL, so it counts
+tombstones and superseded merge-on-read versions", and `slice_coverage_agrees`
+notes "*'Rows only accrue' is false here — dedup rewrites and vacuum shrink
+`num_records` too*". So a dedup that removes only duplicates, or a consolidation
+that rewrites files with identical logical content, changes the witness and
+voids coverage **without changing a single answer the rollup would give**.
+
+That is exactly what the 2,618,297 `moved` refusals are, and why an eight-day-old
+partition fails.
+
+`Logical` is immune to both: it counts the deduplicated rows over the slice's own
+range, which is precisely the quantity the rollup aggregated. It is also
+preferable to `PhysicalBelow`, whose straddle rule makes a packed day
+`Unverifiable` — the reason its own comment calls it "a candidate and not a
+recommendation".
+
+### What remains to do
+
+1. **Stamp** slices with a logical row count at build time instead of (or
+   alongside) the physical tag. The logical-count index already exists; note the
+   2026-09-02 constraint that **its key must equal the dedup key**, or the count
+   it returns answers a different question.
+2. **Feed** `LiveSource::logical` on the verify path — currently `None` at the
+   only call site.
+3. **Oracle-compare** before trusting it: run both witnesses over real prod
+   slices and assert the `Logical` verdict never says Valid where the raw path
+   would disagree. The 08-22 slice-fingerprint attempt "routed nothing, failing
+   safe as a permanent miss"; the opposite failure — routing something it should
+   not — is the under-count class, and is not safe.
+
+This is the single highest-leverage item on the read path: the verifier is built
+and tested, and the work is stamping and plumbing rather than design.


### PR DESCRIPTION
Docs only —  keeps this off the deploy path, so it will not restart prod.

## The finding

100% of rollup routing attempts were missing on `stale_coverage` (hits frozen at 2,690 while misses climbed ~120/50s). The discriminator built for exactly this splits it cleanly:

| sub-reason | count |
|---|---:|
| `rollup_stale_no_witness` | **0** |
| `rollup_stale_no_source_rows` | **0** |
| `rollup_stale_moved` | **2,618,297** (grew 2,499,123 / shrank 119,174) |

Every refusal is `moved` — the partition's row count changing under a built slice, which `mod.rs:4650` says *"no amount of rebuilding fixes on a churning day"*. Build throughput only fixes `no_witness`, which is zero.

**Not a data gap**: the rollup table holds 168,834 rows for the project, current to the minute. Queries are being refused a rollup that exists.

**The coupling**: `shrank` is dedup removing rows. So maintenance invalidates the coverage the read path depends on — working the backlog harder churns it *more*.

## Prior art

The sampled miss window is 06:00–12:00 of the current day, so this is the open partition. **TimescaleDB's real-time aggregation is the answer, and TimeFusion already has every piece** — invalidation log (`rollup_dirty`), watermark (`horizon`), and the union (`interiors`). What it additionally has is an exact row-count proof per slice, and that proof empties `covered` before the union can run. The change is not a new mechanism; it is stopping a belt-and-braces proof from vetoing the one already built.

**InfluxDB 3 bounds compaction by ROWS** (`compactionRowLimit`, ~1M) rather than compressed bytes. That is the transferable lesson for #271: we cap a bin by converting compressed bytes through a *fixed 12x estimate*, while rows are exact and already summed one function away in `refuse_low_value_bin`.

## Not shipped

No code. Routing correctness has a documented under-count history (the 08-22 slice-fingerprint build "routed nothing, failing safe as a permanent miss"), and the proof was added for a reason. Anything that widens what routes must be oracle-compared against the raw path first.

Also notes a stale log message: `rollup_uncovered_project` says *"this refuses the whole query"* while the comment directly above it says the opposite and is current behaviour. It cost this investigation a wrong hypothesis.